### PR TITLE
text is always below symbol, even at extreme resolution values

### DIFF
--- a/src/app/drawlayer/draw-style.ts
+++ b/src/app/drawlayer/draw-style.ts
@@ -756,7 +756,7 @@ export class DrawStyle {
                 )[1];
                 return new Point([
                   coordinates[0],
-                  coordinates[1] - 35 / iconTextScale,
+                  coordinates[1] - (35 / iconTextScale * Math.max(resolution/3, 1))
                 ]);
               },
               zIndex: zIndex,

--- a/src/app/drawlayer/draw-style.ts
+++ b/src/app/drawlayer/draw-style.ts
@@ -756,7 +756,8 @@ export class DrawStyle {
                 )[1];
                 return new Point([
                   coordinates[0],
-                  coordinates[1] - (35 / iconTextScale * Math.max(resolution/3, 1))
+                  coordinates[1] -
+                    (35 / iconTextScale) * Math.max(resolution / 3, 1),
                 ]);
               },
               zIndex: zIndex,

--- a/src/app/selected-feature/selected-feature.component.html
+++ b/src/app/selected-feature/selected-feature.component.html
@@ -156,7 +156,7 @@
             (ngModelChange)="redraw()"
             *ngIf="
               editMode &&
-              (selectedSignature.type == 'Point' || selectedSignature.src)
+              (selectedSignature.type === 'Point' || selectedSignature.src)
             "
             >{{ i18n.get('labelShow') }}</mat-checkbox
           >

--- a/src/app/selected-feature/selected-feature.component.html
+++ b/src/app/selected-feature/selected-feature.component.html
@@ -154,7 +154,7 @@
           <mat-checkbox
             [(ngModel)]="selectedSignature.labelShow"
             (ngModelChange)="redraw()"
-            *ngIf="editMode"
+            *ngIf="editMode && (selectedSignature.type == 'Point' || selectedSignature.src)"
             >{{ i18n.get('labelShow') }}</mat-checkbox
           >
           <div class="label-light">

--- a/src/app/selected-feature/selected-feature.component.html
+++ b/src/app/selected-feature/selected-feature.component.html
@@ -154,7 +154,10 @@
           <mat-checkbox
             [(ngModel)]="selectedSignature.labelShow"
             (ngModelChange)="redraw()"
-            *ngIf="editMode && (selectedSignature.type == 'Point' || selectedSignature.src)"
+            *ngIf="
+              editMode &&
+              (selectedSignature.type == 'Point' || selectedSignature.src)
+            "
             >{{ i18n.get('labelShow') }}</mat-checkbox
           >
           <div class="label-light">


### PR DESCRIPTION
Drawing label at center of mass of polygon or freely drawn line is computationally expensive and not really necessary. 

Code changes: 

- guarantees text being always below symbol, even at extreme resolution values.
- show name is not displayed if symbol not present

cnt. in #269