### PR TITLE
feat(#97): select feature after draw

### DIFF
--- a/src/app/map-renderer/elements/base/base-draw-element.ts
+++ b/src/app/map-renderer/elements/base/base-draw-element.ts
@@ -1,5 +1,5 @@
 import { Feature } from 'ol';
-import { Observable, Subject } from 'rxjs';
+import { Observable } from 'rxjs';
 import { IZsMapBaseDrawElementState, ZsMapDrawElementState, ZsMapElementToDraw } from '../../../state/interfaces';
 import { ZsMapStateService } from '../../../state/state.service';
 import { ZsMapBaseElement } from './base-element';
@@ -21,6 +21,7 @@ export abstract class ZsMapBaseDrawElement<T extends ZsMapDrawElementState = ZsM
   constructor(protected override _id: string, protected override _state: ZsMapStateService) {
     super(_id, _state);
     this._olFeature.set(ZsMapOLFeatureProps.IS_DRAW_ELEMENT, true);
+    this._olFeature.set(ZsMapOLFeatureProps.DRAW_ELEMENT_ID, _id);
     this._element = this._state.observeMapState().pipe(
       map((o) => {
         // TODO typings

--- a/src/app/map-renderer/elements/freehand-draw.element.ts
+++ b/src/app/map-renderer/elements/freehand-draw.element.ts
@@ -8,7 +8,7 @@ import {
 import { ZsMapStateService } from '../../state/state.service';
 import { ZsMapBaseDrawElement } from './base/base-draw-element';
 import { LineString } from 'ol/geom';
-import Geometry, { Type } from 'ol/geom/Geometry';
+import { Type } from 'ol/geom/Geometry';
 import { ZsMapOLFeatureProps } from './base/ol-feature-props';
 import VectorSource from 'ol/source/Vector';
 import { Draw } from 'ol/interaction';
@@ -19,7 +19,6 @@ export class ZsMapFreehandDrawElement extends ZsMapBaseDrawElement<ZsMapFreehand
   constructor(protected override _id: string, protected override _state: ZsMapStateService) {
     super(_id, _state);
     this._olFeature.set(ZsMapOLFeatureProps.DRAW_ELEMENT_TYPE, ZsMapDrawElementStateType.LINE);
-    this._olFeature.set(ZsMapOLFeatureProps.DRAW_ELEMENT_ID, this._id);
     this.observeCoordinates()
       .pipe(takeUntil(this._unsubscribe))
       .subscribe((coordinates) => {
@@ -45,11 +44,12 @@ export class ZsMapFreehandDrawElement extends ZsMapBaseDrawElement<ZsMapFreehand
     return 'LineString';
   }
   protected static override _parseFeature(feature: Feature<LineString>, state: ZsMapStateService, element: ZsMapElementToDraw): void {
-    state.addDrawElement({
+    const drawElement = state.addDrawElement({
       type: ZsMapDrawElementStateType.LINE,
       coordinates: feature.getGeometry()?.getCoordinates() || [],
       layer: element.layer,
     });
+    state.setSelectedFeature(drawElement?.id);
   }
 
   public static override getOlDrawHandler(state: ZsMapStateService, element: ZsMapElementToDraw): Draw {

--- a/src/app/map-renderer/elements/line-draw-element.ts
+++ b/src/app/map-renderer/elements/line-draw-element.ts
@@ -10,7 +10,6 @@ import { ZsMapBaseDrawElement } from './base/base-draw-element';
 import { LineString } from 'ol/geom';
 import { Type } from 'ol/geom/Geometry';
 import { ZsMapOLFeatureProps } from './base/ol-feature-props';
-import { areCoordinatesEqual } from '../../helper/coordinates';
 import { takeUntil } from 'rxjs';
 
 export class ZsMapLineDrawElement extends ZsMapBaseDrawElement<ZsMapTextDrawElementState> {
@@ -18,7 +17,6 @@ export class ZsMapLineDrawElement extends ZsMapBaseDrawElement<ZsMapTextDrawElem
   constructor(protected override _id: string, protected override _state: ZsMapStateService) {
     super(_id, _state);
     this._olFeature.set(ZsMapOLFeatureProps.DRAW_ELEMENT_TYPE, ZsMapDrawElementStateType.LINE);
-    this._olFeature.set(ZsMapOLFeatureProps.DRAW_ELEMENT_ID, this._id);
     this.observeCoordinates()
       .pipe(takeUntil(this._unsubscribe))
       .subscribe((coordinates) => {
@@ -43,10 +41,11 @@ export class ZsMapLineDrawElement extends ZsMapBaseDrawElement<ZsMapTextDrawElem
     return 'LineString';
   }
   protected static override _parseFeature(feature: Feature<LineString>, state: ZsMapStateService, element: ZsMapElementToDraw): void {
-    state.addDrawElement({
+    const drawElement = state.addDrawElement({
       type: ZsMapDrawElementStateType.LINE,
       coordinates: feature.getGeometry()?.getCoordinates() || [],
       layer: element.layer,
     });
+    state.setSelectedFeature(drawElement?.id);
   }
 }

--- a/src/app/map-renderer/elements/polygon-draw-element.ts
+++ b/src/app/map-renderer/elements/polygon-draw-element.ts
@@ -10,7 +10,6 @@ import { ZsMapBaseDrawElement } from './base/base-draw-element';
 import { Polygon } from 'ol/geom';
 import { Type } from 'ol/geom/Geometry';
 import { ZsMapOLFeatureProps } from './base/ol-feature-props';
-import { areCoordinatesEqual } from '../../helper/coordinates';
 import { takeUntil } from 'rxjs';
 
 export class ZsMapPolygonDrawElement extends ZsMapBaseDrawElement<ZsMapTextDrawElementState> {
@@ -18,7 +17,6 @@ export class ZsMapPolygonDrawElement extends ZsMapBaseDrawElement<ZsMapTextDrawE
   constructor(protected override _id: string, protected override _state: ZsMapStateService) {
     super(_id, _state);
     this._olFeature.set(ZsMapOLFeatureProps.DRAW_ELEMENT_TYPE, ZsMapDrawElementStateType.POLYGON);
-    this._olFeature.set(ZsMapOLFeatureProps.DRAW_ELEMENT_ID, this._id);
     this.observeCoordinates()
       .pipe(takeUntil(this._unsubscribe))
       .subscribe((coordinates) => {
@@ -46,11 +44,12 @@ export class ZsMapPolygonDrawElement extends ZsMapBaseDrawElement<ZsMapTextDrawE
     return 'Polygon';
   }
   protected static override _parseFeature(feature: Feature<Polygon>, state: ZsMapStateService, element: ZsMapElementToDraw): void {
-    state.addDrawElement({
+    const drawElement = state.addDrawElement({
       type: ZsMapDrawElementStateType.POLYGON,
       // TODO types
       coordinates: (feature.getGeometry()?.getCoordinates() as any) || [],
       layer: element.layer,
     });
+    state.setSelectedFeature(drawElement?.id);
   }
 }

--- a/src/app/map-renderer/elements/symbol-draw-element.ts
+++ b/src/app/map-renderer/elements/symbol-draw-element.ts
@@ -5,7 +5,6 @@ import { ZsMapBaseDrawElement } from './base/base-draw-element';
 import { LineString, Point, Polygon, SimpleGeometry } from 'ol/geom';
 import { ZsMapOLFeatureProps } from './base/ol-feature-props';
 import { Type } from 'ol/geom/Geometry';
-import { areCoordinatesEqual } from '../../helper/coordinates';
 import { StyleLike } from 'ol/style/Style';
 import { Signs } from '../signs';
 import { takeUntil } from 'rxjs';
@@ -16,7 +15,6 @@ export class ZsMapSymbolDrawElement extends ZsMapBaseDrawElement<ZsMapSymbolDraw
   constructor(protected override _id: string, protected override _state: ZsMapStateService) {
     super(_id, _state);
     this._olFeature.set(ZsMapOLFeatureProps.DRAW_ELEMENT_TYPE, ZsMapDrawElementStateType.SYMBOL);
-    this._olFeature.set(ZsMapOLFeatureProps.DRAW_ELEMENT_ID, this._id);
     this.observeCoordinates()
       .pipe(takeUntil(this._unsubscribe))
       .subscribe((coordinates) => {
@@ -55,11 +53,12 @@ export class ZsMapSymbolDrawElement extends ZsMapBaseDrawElement<ZsMapSymbolDraw
   }
 
   protected static override _parseFeature(feature: Feature<Point>, state: ZsMapStateService, element: ZsMapElementToDraw): void {
-    state.addDrawElement({
+    const drawElement = state.addDrawElement({
       type: ZsMapDrawElementStateType.SYMBOL,
       coordinates: feature.getGeometry()?.getCoordinates() || [],
       layer: element.layer,
       symbolId: element.symbolId,
     });
+    state.setSelectedFeature(drawElement?.id);
   }
 }

--- a/src/app/map-renderer/elements/text-draw-element.ts
+++ b/src/app/map-renderer/elements/text-draw-element.ts
@@ -5,7 +5,6 @@ import { ZsMapBaseDrawElement } from './base/base-draw-element';
 import { LineString, SimpleGeometry } from 'ol/geom';
 import { Type } from 'ol/geom/Geometry';
 import { ZsMapOLFeatureProps } from './base/ol-feature-props';
-import { areCoordinatesEqual } from 'src/app/helper/coordinates';
 import { takeUntil } from 'rxjs';
 
 export class ZsMapTextDrawElement extends ZsMapBaseDrawElement<ZsMapTextDrawElementState> {
@@ -13,7 +12,6 @@ export class ZsMapTextDrawElement extends ZsMapBaseDrawElement<ZsMapTextDrawElem
   constructor(protected override _id: string, protected override _state: ZsMapStateService) {
     super(_id, _state);
     this._olFeature.set(ZsMapOLFeatureProps.DRAW_ELEMENT_TYPE, ZsMapDrawElementStateType.TEXT);
-    this._olFeature.set(ZsMapOLFeatureProps.DRAW_ELEMENT_ID, this._id);
     this.observeCoordinates()
       .pipe(takeUntil(this._unsubscribe))
       .subscribe((coordinates) => {
@@ -39,11 +37,12 @@ export class ZsMapTextDrawElement extends ZsMapBaseDrawElement<ZsMapTextDrawElem
     return 'LineString';
   }
   protected static override _parseFeature(feature: Feature<LineString>, state: ZsMapStateService, element: ZsMapElementToDraw): void {
-    state.addDrawElement({
+    const drawElement = state.addDrawElement({
       type: ZsMapDrawElementStateType.TEXT,
       layer: element.layer,
       text: element.text,
       coordinates: feature.getGeometry()?.getCoordinates(),
     });
+    state.setSelectedFeature(drawElement?.id);
   }
 }

--- a/src/app/map-renderer/map-renderer.component.ts
+++ b/src/app/map-renderer/map-renderer.component.ts
@@ -4,7 +4,7 @@ import OlMap from 'ol/Map';
 import OlView from 'ol/View';
 import OlTileLayer from 'ol/layer/Tile';
 import OlTileWMTS from 'ol/source/WMTS';
-import { BehaviorSubject, firstValueFrom, last, lastValueFrom, map, Observable, Subject, takeUntil } from 'rxjs';
+import { BehaviorSubject, combineLatest, firstValueFrom, map, Observable, Subject, takeUntil } from 'rxjs';
 import { ZsMapBaseDrawElement } from './elements/base/base-draw-element';
 import { areArraysEqual } from '../helper/array';
 import { DrawElementHelper } from '../helper/draw-element-helper';
@@ -17,7 +17,7 @@ import { SidebarContext } from '../state/interfaces';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import { Collection, Feature, Overlay } from 'ol';
-import { Geometry, LineString, Point, Polygon, SimpleGeometry } from 'ol/geom';
+import { LineString, Point, Polygon, SimpleGeometry } from 'ol/geom';
 import { Icon, Style } from 'ol/style';
 import { GeoadminService } from '../core/geoadmin.service';
 import { DrawStyle } from './draw-style';
@@ -89,7 +89,18 @@ export class MapRendererComponent implements AfterViewInit {
     private geoAdminService: GeoadminService,
     private dialog: MatDialog,
   ) {
-    this.selectedFeature = _state.observeSelectedFeature().pipe(takeUntil(this._ngUnsubscribe));
+    this.selectedFeature = combineLatest([
+      this._state.observeDrawElements(),
+      _state.observeSelectedFeature().pipe(takeUntil(this._ngUnsubscribe)),
+    ]).pipe(
+      map(([elements, featureId]) => {
+        if (!featureId) {
+          return null;
+        }
+        const element = elements.find((e) => e.getId() === featureId);
+        return element?.getOlFeature() as Feature<SimpleGeometry>;
+      }),
+    );
     this.sidebarContext = this._state.observeSidebarContext();
     this.selectedFeatureCoordinates = this.selectedFeature.pipe(
       map((feature) => {
@@ -124,10 +135,7 @@ export class MapRendererComponent implements AfterViewInit {
       this._modifyCache.clear();
       this.toggleEditButtons(false);
       for (const feature of event.selected) {
-        if (!feature.get('sig').protected) {
-          this._modifyCache.push(feature);
-        }
-        this._state.setSelectedFeature(feature as Feature<SimpleGeometry>);
+        this._state.setSelectedFeature(feature.get(ZsMapOLFeatureProps.DRAW_ELEMENT_ID));
       }
 
       if (event.selected.length === 0) {
@@ -161,6 +169,13 @@ export class MapRendererComponent implements AfterViewInit {
       this.rotateButton?.setPosition(e.mapBrowserEvent.coordinate);
       this.toggleEditButtons(true);
       this._currentSketch = undefined;
+    });
+
+    // select on ol-Map layer
+    this.selectedFeature.subscribe((feature) => {
+      if (feature && !feature.get('sig').protected && !this._modifyCache.getArray().includes(feature)) {
+        this._modifyCache.push(feature);
+      }
     });
 
     // TODO
@@ -563,13 +578,13 @@ export class MapRendererComponent implements AfterViewInit {
   async toggleEditButtons(show: boolean) {
     let allowRotation = false;
     if (show && this._lastModificationPointCoordinates) {
-      const selectedFeature = await firstValueFrom(this.selectedFeature);
+      const feature = await firstValueFrom(this.selectedFeature);
 
       const [pointX, pointY] = this._lastModificationPointCoordinates;
-      const [iconX, iconY] = getFirstCoordinate(selectedFeature);
+      const [iconX, iconY] = getFirstCoordinate(feature);
 
       // only show rotateButton if the feature has an icon and the selected point is where the icon is placed
-      allowRotation = selectedFeature?.get('sig')?.src && pointX === iconX && pointY === iconY;
+      allowRotation = feature?.get('sig')?.src && pointX === iconX && pointY === iconY;
     }
 
     this.toggleButton(show, this.removeButton?.getElement());
@@ -606,7 +621,7 @@ export class MapRendererComponent implements AfterViewInit {
     const feature = await firstValueFrom(this.selectedFeature);
     if (feature) {
       // trigger selectedFeature to enable projection rotation while a feature is selected
-      this._state.setSelectedFeature(feature);
+      this._state.setSelectedFeature(feature.get(ZsMapOLFeatureProps.DRAW_ELEMENT_ID));
     }
   }
 

--- a/src/app/selected-feature/selected-feature.component.ts
+++ b/src/app/selected-feature/selected-feature.component.ts
@@ -56,13 +56,13 @@ export class SelectedFeatureComponent implements OnDestroy {
   ];
 
   constructor(public dialog: MatDialog, public i18n: I18NService, public zsMapStateService: ZsMapStateService) {
-    this.selectedFeature = this.zsMapStateService.observeSelectedFeature().pipe(takeUntil(this._ngUnsubscribe));
-    this.selectedDrawElement = this.selectedFeature.pipe(
-      map((feature) => {
-        const id = feature?.get(ZsMapOLFeatureProps.DRAW_ELEMENT_ID);
-        return this._drawElementCache[id]?.elementState;
-      }),
+    this.selectedFeature = this.zsMapStateService.observeSelectedFeature().pipe(
+      map((featureId) => this._drawElementCache[featureId ?? '']?.getOlFeature() as Feature<SimpleGeometry>),
+      takeUntil(this._ngUnsubscribe),
     );
+    this.selectedDrawElement = this.zsMapStateService
+      .observeSelectedFeature()
+      .pipe(map((featureId) => this._drawElementCache[featureId ?? '']?.elementState));
     this.selectedSignature = this.selectedFeature.pipe(
       map((feature) => {
         const sig = feature?.get('sig');
@@ -239,7 +239,7 @@ export class SelectedFeatureComponent implements OnDestroy {
     dialogRef.afterClosed().subscribe((result: Sign) => {
       if (result) {
         this.updateProperty(drawElement, 'symbolId', result.id);
-        this.zsMapStateService.setSelectedFeature(selectedFeature);
+        this.zsMapStateService.setSelectedFeature(selectedFeature.get(ZsMapOLFeatureProps.DRAW_ELEMENT_ID));
       }
     });
   }

--- a/src/app/state/state.service.ts
+++ b/src/app/state/state.service.ts
@@ -28,10 +28,8 @@ import { DrawingDialogComponent } from '../drawing-dialog/drawing-dialog.compone
 import { defineDefaultValuesForSignature, Sign } from '../core/entity/sign';
 import { TextDialogComponent } from '../text-dialog/text-dialog.component';
 import { Signs } from '../map-renderer/signs';
-import Feature from 'ol/Feature';
 import { SyncService } from '../sync/sync.service';
 import { SessionService } from '../session/session.service';
-import { SimpleGeometry } from 'ol/geom';
 
 @Injectable({
   providedIn: 'root',
@@ -48,7 +46,7 @@ export class ZsMapStateService {
   private _layerCache: Record<string, ZsMapBaseLayer> = {};
   private _drawElementCache: Record<string, ZsMapBaseDrawElement> = {};
   private _elementToDraw = new BehaviorSubject<ZsMapElementToDraw | undefined>(undefined);
-  private _selectedFeature = new BehaviorSubject<Feature<SimpleGeometry> | null>(null);
+  private _selectedFeature = new BehaviorSubject<string | undefined>(undefined);
   private _recentlyUsedElement = new BehaviorSubject<ZsMapDrawElementState[]>([]);
 
   private _mergeMode = new BehaviorSubject<boolean>(false);
@@ -217,12 +215,12 @@ export class ZsMapStateService {
     });
   }
 
-  public setSelectedFeature(feature: Feature<SimpleGeometry>) {
-    this._selectedFeature.next(feature);
+  public setSelectedFeature(featureId: string | undefined) {
+    this._selectedFeature.next(featureId);
   }
 
   public resetSelectedFeature() {
-    this._selectedFeature.next(null);
+    this._selectedFeature.next(undefined);
   }
 
   public setMapZoom(zoom: number) {
@@ -392,7 +390,7 @@ export class ZsMapStateService {
     );
   }
 
-  public observeSelectedFeature(): Observable<Feature<SimpleGeometry> | null> {
+  public observeSelectedFeature(): Observable<string | undefined> {
     return this._selectedFeature.asObservable();
   }
 
@@ -447,12 +445,12 @@ export class ZsMapStateService {
     return this._map.value.layers?.find((layer) => layer.id === this._display.value.activeLayer);
   }
 
-  public addDrawElement(element: ZsMapDrawElementState): void {
+  public addDrawElement(element: ZsMapDrawElementState): ZsMapDrawElementState | null {
     const activeLayerState = this.getActiveLayerState();
     if (activeLayerState?.type === ZsMapLayerStateType.DRAW) {
       const sign = Signs.getSignById(element.symbolId) ?? ({} as Sign);
       defineDefaultValuesForSignature(sign);
-      const drawElement = {
+      const drawElement: ZsMapDrawElementState = {
         color: sign.color,
         protected: sign.protected,
         iconSize: sign.iconSize,
@@ -464,7 +462,7 @@ export class ZsMapStateService {
         style: sign.style,
         arrow: sign.arrow,
         strokeWidth: sign.strokeWidth,
-        fillStyle: { ...sign.fillStyle },
+        fillStyle: { ...sign.fillStyle, name: sign.fillStyle?.name ?? '' },
         fillOpacity: sign.fillOpacity,
         fontSize: sign.fontSize,
         id: uuidv4(),
@@ -476,11 +474,15 @@ export class ZsMapStateService {
         if (!draft.drawElements) {
           draft.drawElements = [];
         }
-        draft.drawElements.push(drawElement as ZsMapDrawElementState);
+        draft.drawElements.push(drawElement);
       });
 
       this.addRecentlyUsedElement(element);
+
+      return drawElement;
     }
+
+    return null;
   }
 
   private addRecentlyUsedElement(element: ZsMapDrawElementState) {


### PR DESCRIPTION
Select a feature after it was drawn.
The selectedFeature state is now just based on the featureId, so the consumer can decide if they want the ZSDrawElement or the OL Feature

fix #97, fix #98 