### PR TITLE
Change Line From Text Elements, Refactor DrawStyle.StyleFunction

### DIFF
--- a/src/app/selected-feature/selected-feature.component.ts
+++ b/src/app/selected-feature/selected-feature.component.ts
@@ -228,7 +228,6 @@ export class SelectedFeatureComponent implements OnDestroy {
       // Update the signature in the UI separately from the state, to provide a smooth update of all properties
       el.getOlFeature().get('sig')[field] = value;
       el.getOlFeature().changed();
-
       el.updateElementState((draft) => {
         draft[field as T] = value;
       });


### PR DESCRIPTION
Combine textStyleFunction and imageStyleFunction into one Function to reduce redundance code.
Fix: Lines from Textelements now get their correct style