### PR TITLE
chore: Condense imports from Angular common module

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -49,8 +49,7 @@ import { EditCoordinatesComponent } from './edit-coordinates/edit-coordinates.co
 import { SidebarFiltersComponent } from './sidebar/sidebar-filters/sidebar-filters.component';
 import { SessionService } from './session/session.service';
 
-import { registerLocaleData } from '@angular/common';
-import { DatePipe } from '@angular/common';
+import { registerLocaleData, DatePipe } from '@angular/common';
 import localeCH from '@angular/common/locales/de-CH';
 import { LoginComponent } from './session/login/login.component';
 import { MapComponent } from './map/map.component';


### PR DESCRIPTION
The 'registerLocaleData' and 'DatePipe' are both imported from '@angular/common' now. This change will keep the import statements cleaner and easier to read. It can also help improve the organization of the code, making it more maintainable.