### PR TITLE
chore: Add Node.js engine version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "zskarte-v3",
   "version": "3.0.0-alpha.0",
   "main": "dist/electron/index.js",
+  "engines": {
+    "node": ">=20.11.0"
+  },
   "scripts": {
     "ng:serve": "ng serve --port 4300",
     "ng:serve:dev": "ng serve --port 4300 --configuration development",


### PR DESCRIPTION
The package.json file was updated to specify the minimum Node.js version required for the project. This will ensure that all developers working on the project are using a compatible version of Node.js.