### PR TITLE
chore: Update GitHub Actions in pr.yml

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,10 +15,15 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Cache Node Modules
         uses: actions/cache@v3


### PR DESCRIPTION
The commit updates the checkout and setup-node actions to versions 4 in the pr.yml file. It also adds an 'Enable Corepack' step to the workflow. The node-version is now explicitly stated in the setup-node step.