### PR TITLE
feat: Update map source URLs

### DIFF
--- a/src/app/core/geoadmin.service.ts
+++ b/src/app/core/geoadmin.service.ts
@@ -93,7 +93,7 @@ export class GeoadminService {
     return new OlTileLayer({
       source: new OlTileWMTS({
         projection: swissProjection,
-        url: 'https://wmts10.geo.admin.ch/1.0.0/{Layer}/default/' + timestamp + '/2056/{TileMatrix}/{TileCol}/{TileRow}.' + extension,
+        url: 'https://wmts.geo.admin.ch/1.0.0/{Layer}/default/' + timestamp + '/2056/{TileMatrix}/{TileCol}/{TileRow}.' + extension,
         tileGrid: new OlTileGridWMTS({
           origin: [swissProjection.getExtent()[0], swissProjection.getExtent()[3]],
           resolutions: swissProjection.resolutions,

--- a/src/app/core/geoadmin.service.ts
+++ b/src/app/core/geoadmin.service.ts
@@ -93,7 +93,7 @@ export class GeoadminService {
     return new OlTileLayer({
       source: new OlTileWMTS({
         projection: swissProjection,
-        url: 'https://wmts.geo.admin.ch/1.0.0/{Layer}/default/' + timestamp + '/2056/{TileMatrix}/{TileCol}/{TileRow}.' + extension,
+        url: `https://wmts.geo.admin.ch/1.0.0/{Layer}/default/${timestamp}/2056/{TileMatrix}/{TileCol}/{TileRow}.${extension}`,
         tileGrid: new OlTileGridWMTS({
           origin: [swissProjection.getExtent()[0], swissProjection.getExtent()[3]],
           resolutions: swissProjection.resolutions,

--- a/src/app/map-renderer/signs.ts
+++ b/src/app/map-renderer/signs.ts
@@ -1037,12 +1037,6 @@ export class Signs {
       de: 'Teilzerstörung',
       en: 'Teilzerstörung',
       fr: 'Destruction partielle',
-      fillStyle: {
-        name: 'cross',
-        size: 2,
-        spacing: 8,
-      },
-      fillOpacity: 0.8,
     },
     {
       id: 108,

--- a/src/app/map-renderer/signs.ts
+++ b/src/app/map-renderer/signs.ts
@@ -1037,6 +1037,12 @@ export class Signs {
       de: 'Teilzerstörung',
       en: 'Teilzerstörung',
       fr: 'Destruction partielle',
+      fillStyle: {
+        name: 'cross',
+        size: 2,
+        spacing: 8,
+      },
+      fillOpacity: 0.8,
     },
     {
       id: 108,

--- a/src/app/state/map-sources.ts
+++ b/src/app/state/map-sources.ts
@@ -22,21 +22,21 @@ export class ZsMapSources {
         return ZsMapSources.getOlTileLayer(
           new OlTileXYZ({
             attributions: ['<a target="new" href="https://www.swisstopo.admin.ch/internet/swisstopo/en/home.html">swisstopo</a>'],
-            url: 'https://wmts10.geo.admin.ch/1.0.0/ch.swisstopo.swissimage/default/current/3857/{z}/{x}/{y}.jpeg',
+            url: 'https://wmts.geo.admin.ch/1.0.0/ch.swisstopo.swissimage/default/current/3857/{z}/{x}/{y}.jpeg',
           }),
         );
       case ZsMapStateSource.GEO_ADMIN_PIXEL:
         return ZsMapSources.getOlTileLayer(
           new OlTileXYZ({
             attributions: ['<a target="new" href="https://www.swisstopo.admin.ch/internet/swisstopo/en/home.html">swisstopo</a>'],
-            url: 'https://wmts10.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/current/3857/{z}/{x}/{y}.jpeg',
+            url: 'https://wmts.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/current/3857/{z}/{x}/{y}.jpeg',
           }),
         );
       case ZsMapStateSource.GEO_ADMIN_PIXEL_BW:
         return ZsMapSources.getOlTileLayer(
           new OlTileXYZ({
             attributions: ['<a target="new" href="https://www.swisstopo.admin.ch/internet/swisstopo/en/home.html">swisstopo</a>'],
-            url: 'https://wmts10.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-grau/default/current/3857/{z}/{x}/{y}.jpeg',
+            url: 'https://wmts.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-grau/default/current/3857/{z}/{x}/{y}.jpeg',
           }),
         );
       case ZsMapStateSource.LOCAL: {


### PR DESCRIPTION
The URLs for swisstopo map sources in the map-sources.ts file have been updated. The changes include the source URLs for swissimage, pixelkarte-farbe, and pixelkarte-grau. The previous URLs were deprecated and have been replaced with the correct ones.