### PR TITLE
feat: Add fillStyle and fillOpacity to map signs

### DIFF
--- a/src/app/map-renderer/signs.ts
+++ b/src/app/map-renderer/signs.ts
@@ -1037,6 +1037,12 @@ export class Signs {
       de: 'Teilzerstörung',
       en: 'Teilzerstörung',
       fr: 'Destruction partielle',
+      fillStyle: {
+        name: 'cross',
+        size: 2,
+        spacing: 8,
+      },
+      fillOpacity: 0.8,
     },
     {
       id: 108,


### PR DESCRIPTION
A new fillStyle and fillOpacity have been added to the map signs. This improves visual clarity and defines how signs are filled and what their opacity looks like. FillStyle includes settings like the pattern name, its size and spacing.