### PR TITLE
fix: search by lowercase

### DIFF
--- a/src/app/select-sign-dialog/select-sign-dialog.component.ts
+++ b/src/app/select-sign-dialog/select-sign-dialog.component.ts
@@ -44,7 +44,7 @@ export class SelectSignDialog implements OnInit {
   updateAvailableSigns() {
     this.filteredSigns = this.allSigns.filter(
       (s) =>
-        (!this.filter || this.i18n.getLabelForSign(s).toLowerCase().includes(this.filter)) &&
+        (!this.filter || this.i18n.getLabelForSign(s).toLowerCase().includes(this.filter.toLowerCase())) &&
         (!this.selected || this.selected === s.kat) &&
         !this.hiddenTypes.includes(s.kat ?? ''),
     );


### PR DESCRIPTION
The commit adjusts the search filter in select-sign-dialog.component. Now, the search filter input is made case-insensitive, enhancing the user experience by returning more accurate and exhaustive search results.