### PR TITLE
never do an update of whole operation, only parts of it

### DIFF
--- a/src/app/session/login/login.component.ts
+++ b/src/app/session/login/login.component.ts
@@ -35,9 +35,7 @@ export class LoginComponent {
   ) {}
 
   async ngOnInit() {
-    const { error, result } = await this._api.get<IZsMapOrganization[]>(
-      '/api/organizations?fields[0]=name&populate[users][fields][0]=username&populate[users][fields][1]=email&populate[logo]=*&pagination[limit]=-1&sort[0]=name',
-    );
+    const { error, result } = await this._api.get<IZsMapOrganization[]>('/api/organizations/forlogin');
     if (error || !result) return;
     const orgs: IZso[] = [];
     for (const org of result) {

--- a/src/app/session/operations/operation.interfaces.ts
+++ b/src/app/session/operations/operation.interfaces.ts
@@ -18,8 +18,6 @@ export interface IZsMapOrganization {
   defaultLocale: string;
   url: string;
   logo: IZsStrapiAsset;
-  mapXCoord: number;
-  mapYCoord: number;
   operations: IZsMapOperation[];
   users: IZsMapUser[];
 }

--- a/src/app/session/operations/operation.service.ts
+++ b/src/app/session/operations/operation.service.ts
@@ -64,9 +64,7 @@ export class OperationService {
   }
 
   public async reload(): Promise<void> {
-    const { error, result: operations } = await this._api.get<IZsMapOperation[]>(
-      `/api/operations?filters[organization][id][$eq]=${this._session.getOrganizationId()}&filters[status][$eq]=active`,
-    );
+    const { error, result: operations } = await this._api.get<IZsMapOperation[]>('/api/operations?status=active');
     if (error || !operations) return;
     this.operations.next(operations);
   }

--- a/src/app/session/revoke-share-dialog/revoke-share-dialog.component.ts
+++ b/src/app/session/revoke-share-dialog/revoke-share-dialog.component.ts
@@ -23,7 +23,7 @@ export class RevokeShareDialogComponent {
 
   async ngOnInit() {
     const { error, result } = await this._api.get<IZsAccess[]>(
-      `/api/accesses?&pagination[limit]=-1&sort[0]=type&operationId=${this.session.getOperationId()}`,
+      `/api/accesses?pagination[limit]=-1&sort[0]=type&operationId=${this.session.getOperationId()}`,
     );
     if (error || !result) return;
     this.shareLinks = result;

--- a/src/app/session/session.service.ts
+++ b/src/app/session/session.service.ts
@@ -96,6 +96,13 @@ export class SessionService {
     return this._session.value?.organization?.id;
   }
 
+  public getOrganizationLongLat(): [number, number] {
+    if (this._session.value?.organization?.mapLongitude && this._session.value?.organization?.mapLatitude) {
+      return [this._session.value?.organization?.mapLongitude, this._session.value?.organization?.mapLatitude];
+    }
+    return [0, 0];
+  }
+
   public getLabel(): string | undefined {
     return this._session.value?.label;
   }

--- a/src/app/session/session.service.ts
+++ b/src/app/session/session.service.ts
@@ -189,12 +189,7 @@ export class SessionService {
       return;
     }
 
-    const { error, result: meResult } = await this._api.get<{ organization: IZsMapOrganization }>(
-      '/api/users/me?populate[0]=organization.logo',
-      {
-        token: jwt,
-      },
-    );
+    const { error, result: meResult } = await this._api.get<{ organization: IZsMapOrganization }>('/api/users/me', { token: jwt });
     if (error || !meResult) {
       await this.logout();
       return;

--- a/src/app/sidebar/sidebar-history/sidebar-history.component.ts
+++ b/src/app/sidebar/sidebar-history/sidebar-history.component.ts
@@ -49,7 +49,7 @@ export class SidebarHistoryComponent implements AfterViewInit {
   loadData(page: number) {
     const operationId = this.sessionService.getOperationId();
     return this.apiService.get$<Snapshots>(
-      `${this.apiPath}?fields[0]=createdAt&filters[operation][id][$eq]=${operationId}&sort[0]=createdAt:desc&pagination[page]=${page}&pagination[pageSize]=20`,
+      `${this.apiPath}?fields[0]=createdAt&operationId=${operationId}&sort[0]=createdAt:desc&pagination[page]=${page}&pagination[pageSize]=20`,
     );
   }
 

--- a/src/app/sidebar/sidebar-menu/sidebar-menu.component.ts
+++ b/src/app/sidebar/sidebar-menu/sidebar-menu.component.ts
@@ -58,7 +58,7 @@ export class SidebarMenuComponent implements OnDestroy {
     const operation = this.session.getOperation();
     if (operation) {
       operation.eventStates = incidents;
-      await this._operation.saveOperation(operation);
+      await this._operation.updateMeta(operation);
     }
   }
 


### PR DESCRIPTION
Deactivate the "update" endpoint and add "archive" and "meta" instead.
This allow more granular access control settings, and also prevent timing issues on concurrent updates (for e.g mapstate).

Also deactivate the "find" endpoint and use added "overview" instead, to lower the data transfared from server to client.

This branch is based on
https://github.com/zskarte/zskarte-client/pull/393
and need refactoring if that one are not planed to be merged.

For the new endpoints it also need the merge from server:
https://github.com/zskarte/zskarte-server/pull/70