### PR TITLE
redesign projection handling, add format selection

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -73,6 +73,7 @@ import { DrawDialogComponent } from './draw-dialog/draw-dialog.component';
 import { ServiceWorkerModule } from '@angular/service-worker';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { IncidentSelectComponent } from './incident-select/incident-select.component';
+import { ProjectionSelectionComponent } from './projection-selection/projection-selection.component';
 
 registerLocaleData(localeCH);
 
@@ -123,6 +124,7 @@ export function appFactory(session: SessionService, sync: SyncService, state: Zs
     SidebarMenuComponent,
     DrawDialogComponent,
     IncidentSelectComponent,
+    ProjectionSelectionComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/coordinates/coordinates.component.html
+++ b/src/app/coordinates/coordinates.component.html
@@ -1,5 +1,17 @@
 <div class="coordinates mat-elevation-z3">
-  <span *ngFor="let coordinate of coordinates">
-    {{ coordinate }}
-  </span>
+  <app-projection-selection
+    *ngIf="showOptions"
+    [projectionFormatIndexes]="projectionFormatIndexes"
+    [showNumerical]="false"
+    [multiple]="true"
+    (change)="updateProjection($event)"
+  ></app-projection-selection>
+  <div class="box">
+    <div class="coords">
+      <span *ngFor="let coordinate of coordinates">
+        {{ coordinate }}
+      </span>
+    </div>
+    <span class="menu" (click)="showOptions = !showOptions">{{ showOptions ? '&cross;' : '&#x2637;' }}</span>
+  </div>
 </div>

--- a/src/app/coordinates/coordinates.component.html
+++ b/src/app/coordinates/coordinates.component.html
@@ -4,7 +4,7 @@
     [projectionFormatIndexes]="projectionFormatIndexes"
     [showNumerical]="false"
     [multiple]="true"
-    (change)="updateProjection($event)"
+    (projectionChanged)="updateProjection($event)"
   ></app-projection-selection>
   <div class="box">
     <div class="coords">

--- a/src/app/coordinates/coordinates.component.scss
+++ b/src/app/coordinates/coordinates.component.scss
@@ -1,8 +1,19 @@
 .coordinates {
   background: white;
-  display: flex;
-  flex-direction: column;
   font-size: 0.85rem;
   padding: 0.5rem 1rem;
   border-radius: 1rem;
+}
+.box {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+}
+.coords {
+  display: flex;
+  flex-direction: column;
+}
+.menu {
+  padding-left: 5px;
+  cursor: pointer;
 }

--- a/src/app/coordinates/coordinates.component.ts
+++ b/src/app/coordinates/coordinates.component.ts
@@ -10,7 +10,7 @@ import { first } from 'rxjs/operators';
   styleUrl: './coordinates.component.scss',
 })
 export class CoordinatesComponent {
-  showOptions: boolean = false;
+  showOptions = false;
   projectionFormatIndexes: number[];
   coordinates: string[] = [];
   constructor(private _state: ZsMapStateService) {
@@ -27,10 +27,10 @@ export class CoordinatesComponent {
   }
 
   updateProjection(value: ChangeType) {
-    if (value.projectionFormatIndexes!.length == 0) {
+    if (!value.projectionFormatIndexes || value.projectionFormatIndexes?.length === 0) {
       this.projectionFormatIndexes = [0];
     } else {
-      this.projectionFormatIndexes = value.projectionFormatIndexes!;
+      this.projectionFormatIndexes = value.projectionFormatIndexes;
     }
     this._state.getCoordinates().pipe(first()).subscribe(this.updateCoordinates.bind(this));
     //TODO: save this to session/state?

--- a/src/app/coordinates/coordinates.component.ts
+++ b/src/app/coordinates/coordinates.component.ts
@@ -1,8 +1,8 @@
 import { Component } from '@angular/core';
 import { ZsMapStateService } from '../state/state.service';
-import { Coordinate } from 'ol/coordinate';
-import { availableProjections, mercatorProjection } from '../helper/projections';
-import { transform } from 'ol/proj';
+import { projectionByIndex } from '../helper/projections';
+import { ChangeType } from '../projection-selection/projection-selection.component';
+import { first } from 'rxjs/operators';
 
 @Component({
   selector: 'app-coordinates',
@@ -10,21 +10,29 @@ import { transform } from 'ol/proj';
   styleUrl: './coordinates.component.scss',
 })
 export class CoordinatesComponent {
+  showOptions: boolean = false;
+  projectionFormatIndexes: number[];
   coordinates: string[] = [];
   constructor(private _state: ZsMapStateService) {
-    this._state.getCoordinates().subscribe((coordinates) => {
-      const lv95 = this.coordinatesToString(coordinates, '1.2-2');
-      const gps = this.coordinatesToString(coordinates, '1.5-5');
-      this.coordinates = [lv95, gps];
+    //TODO: load this from session/state?
+    this.projectionFormatIndexes = [0, 1];
+    this._state.getCoordinates().subscribe(this.updateCoordinates.bind(this));
+  }
+
+  updateCoordinates(coordinates) {
+    this.coordinates = this.projectionFormatIndexes.map((i) => {
+      const proj = projectionByIndex(i);
+      return proj.translate(proj.transformTo(coordinates));
     });
   }
 
-  // skipcq:  JS-0105
-  coordinatesToString(coordinates: Coordinate, format: string): string {
-    const projection = availableProjections.find((p) => p.format === format);
-    if (projection?.projection && mercatorProjection && coordinates.every((c) => !isNaN(c))) {
-      return projection.translate(transform(coordinates, mercatorProjection, projection.projection));
+  updateProjection(value: ChangeType) {
+    if (value.projectionFormatIndexes!.length == 0) {
+      this.projectionFormatIndexes = [0];
+    } else {
+      this.projectionFormatIndexes = value.projectionFormatIndexes!;
     }
-    return '';
+    this._state.getCoordinates().pipe(first()).subscribe(this.updateCoordinates.bind(this));
+    //TODO: save this to session/state?
   }
 }

--- a/src/app/edit-coordinates/edit-coordinates.component.css
+++ b/src/app/edit-coordinates/edit-coordinates.component.css
@@ -1,3 +1,7 @@
+.format {
+  padding-bottom: 5px;
+}
+
 textarea {
   width: 100%;
   height: 50vh;
@@ -10,4 +14,35 @@ textarea {
 
 mat-form-field {
   width: 30vw;
+  min-width: 400px;
+}
+
+mat-form-field textarea {
+  min-height: 100px;
+  height: 30vh;
+}
+
+@media screen and (max-width: 650px) and (orientation: portrait), screen and (max-height: 650px) and (orientation: landscape) {
+  mat-form-field {
+    width: 100%;
+    min-width: auto;
+  }
+  mat-form-field textarea {
+    height: 100vh;
+  }
+  .mat-mdc-dialog-content {
+    padding: 0;
+    max-height: 100vh;
+  }
+}
+
+@media screen and (max-width: 650px) and (orientation: portrait) {
+  mat-form-field textarea {
+    max-height: 70vh;
+  }
+}
+@media screen and (max-height: 650px) and (orientation: landscape) {
+  mat-form-field textarea {
+    max-height: 50vh;
+  }
 }

--- a/src/app/edit-coordinates/edit-coordinates.component.html
+++ b/src/app/edit-coordinates/edit-coordinates.component.html
@@ -3,7 +3,7 @@
     <app-projection-selection
       [projectionFormatIndex]="projectionFormatIndex"
       [numerical]="numerical"
-      (change)="updateProjection($event)"
+      (projectionChanged)="updateProjection($event)"
       [disabled]="formatedCoordinatesControl.invalid || formatedCoordinatesControl.pending"
     ></app-projection-selection>
   </div>

--- a/src/app/edit-coordinates/edit-coordinates.component.html
+++ b/src/app/edit-coordinates/edit-coordinates.component.html
@@ -1,13 +1,26 @@
 <div mat-dialog-content>
-  <mat-form-field appearance="outline">
+  <div class="format">
+    <app-projection-selection
+      [projectionFormatIndex]="projectionFormatIndex"
+      [numerical]="numerical"
+      (change)="updateProjection($event)"
+      [disabled]="formatedCoordinatesControl.invalid || formatedCoordinatesControl.pending"
+    ></app-projection-selection>
+  </div>
+  <mat-form-field appearance="outline" subscriptSizing="dynamic">
     <mat-label>{{ i18n.get('defineCoordinates') }}</mat-label>
-    <textarea matInput [(ngModel)]="coordinates"></textarea>
+    <textarea matInput [formControl]="formatedCoordinatesControl"></textarea>
+    <mat-error>{{ error }}</mat-error>
   </mat-form-field>
 </div>
-<div *ngIf="error" class="error">{{ error }}</div>
 <div mat-dialog-actions align="end">
   <button mat-raised-button (click)="cancel()">{{ i18n.get('cancel') }}</button>
-  <button mat-raised-button color="primary" (click)="ok()">
+  <button
+    mat-raised-button
+    color="primary"
+    (click)="ok()"
+    [disabled]="formatedCoordinatesControl.invalid || formatedCoordinatesControl.pending"
+  >
     {{ i18n.get('ok') }}
   </button>
 </div>

--- a/src/app/edit-coordinates/edit-coordinates.component.ts
+++ b/src/app/edit-coordinates/edit-coordinates.component.ts
@@ -2,6 +2,10 @@ import { Component, Inject } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { Coordinate } from 'ol/coordinate';
 import { I18NService } from '../state/i18n.service';
+import { convertTo, convertFrom } from '../helper/projections';
+import { FormControl, AbstractControl, ValidationErrors } from '@angular/forms';
+import { of, delay, switchMap, Observable } from 'rxjs';
+import { ChangeType } from '../projection-selection/projection-selection.component';
 
 @Component({
   selector: 'app-edit-coordinates',
@@ -9,17 +13,91 @@ import { I18NService } from '../state/i18n.service';
   styleUrls: ['./edit-coordinates.component.css'],
 })
 export class EditCoordinatesComponent {
-  coordinates: string;
+  projectionFormatIndex: number = 0;
+  lastProjectionFormatIndex: number = 0;
+  numerical: boolean = true;
+  lastNumerical: boolean = true;
+  coordinates: Coordinate;
   geometry: string;
   error = '';
+  formatedCoordinatesControl: FormControl;
 
   constructor(
-    @Inject(MAT_DIALOG_DATA) public data: { geometry: string; coordinates: string },
+    @Inject(MAT_DIALOG_DATA) public data: { geometry: string; coordinates: Coordinate },
     public i18n: I18NService,
     public dialogRef: MatDialogRef<EditCoordinatesComponent>,
   ) {
     this.geometry = data.geometry;
     this.coordinates = data.coordinates;
+    this.formatedCoordinatesControl = new FormControl(null, undefined, [this.inputValidator.bind(this)]);
+    this.updateFormatedCoordinates();
+  }
+
+  inputValidator(control: AbstractControl): Observable<ValidationErrors | null> {
+    return of(control.value).pipe(
+      delay(500),
+      switchMap((value) => {
+        const result = this.validateAndUpdate(this.transformInput(value)) ? null : { invalidInput: { value: this.error } };
+        return of(result);
+      }),
+    );
+  }
+
+  updateFormatedCoordinates() {
+    const converted = convertTo(this.coordinates, this.projectionFormatIndex, this.numerical);
+    const formatedCoordinates = JSON.stringify(converted, null, '\t');
+    this.lastProjectionFormatIndex = this.projectionFormatIndex;
+    this.lastNumerical = this.numerical;
+    this.formatedCoordinatesControl.setValue(formatedCoordinates);
+  }
+
+  updateProjection(value: ChangeType) {
+    if (this.formatedCoordinatesControl.valid || this.formatedCoordinatesControl.pending) {
+      this.projectionFormatIndex = value.projectionFormatIndex!;
+      this.numerical = value.numerical!;
+      this.updateFormatedCoordinates();
+    } else {
+      this.projectionFormatIndex = this.lastProjectionFormatIndex;
+      this.numerical = this.lastNumerical;
+    }
+  }
+
+  transformInput(value: string) {
+    try {
+      const parsedCoordinates = JSON.parse(value);
+      return convertFrom(parsedCoordinates, this.projectionFormatIndex, this.numerical);
+    } catch (e) {
+      this.error = 'Invalid JSON payload';
+      return undefined;
+    }
+  }
+
+  validateAndUpdate(input: Coordinate | undefined) {
+    if (input) {
+      let valid: boolean;
+      switch (this.geometry) {
+        case 'Point':
+          valid = this.isValidPointCoordinate(input);
+          break;
+        case 'LineString':
+          valid = this.isValidLine(input);
+          break;
+        case 'Polygon':
+        case 'MultiPolygon':
+          valid = this.isValidPolygon(input);
+          break;
+        default:
+          valid = true;
+      }
+      if (valid) {
+        this.error = '';
+        this.coordinates = input;
+        return true;
+      } else {
+        this.error = 'Invalid coordinates';
+      }
+    }
+    return false;
   }
 
   cancel() {
@@ -27,32 +105,8 @@ export class EditCoordinatesComponent {
   }
 
   ok(): void {
-    try {
-      const parsedCoordinates = JSON.parse(this.coordinates);
-      if (parsedCoordinates) {
-        let valid: boolean;
-        switch (this.geometry) {
-          case 'Point':
-            valid = this.isValidPointCoordinate(parsedCoordinates);
-            break;
-          case 'LineString':
-            valid = this.isValidLine(parsedCoordinates);
-            break;
-          case 'Polygon':
-          case 'MultiPolygon':
-            valid = this.isValidPolygon(parsedCoordinates);
-            break;
-          default:
-            valid = true;
-        }
-        if (valid) {
-          this.dialogRef.close(parsedCoordinates);
-        } else {
-          this.error = 'Invalid coordinates';
-        }
-      }
-    } catch (e) {
-      this.error = 'Invalid JSON payload';
+    if (this.formatedCoordinatesControl.valid && !this.formatedCoordinatesControl.pending) {
+      this.dialogRef.close(this.coordinates);
     }
   }
 

--- a/src/app/edit-coordinates/edit-coordinates.component.ts
+++ b/src/app/edit-coordinates/edit-coordinates.component.ts
@@ -13,10 +13,10 @@ import { ChangeType } from '../projection-selection/projection-selection.compone
   styleUrls: ['./edit-coordinates.component.css'],
 })
 export class EditCoordinatesComponent {
-  projectionFormatIndex: number = 0;
-  lastProjectionFormatIndex: number = 0;
-  numerical: boolean = true;
-  lastNumerical: boolean = true;
+  projectionFormatIndex = 0;
+  lastProjectionFormatIndex = 0;
+  numerical = true;
+  lastNumerical = true;
   coordinates: Coordinate;
   geometry: string;
   error = '';
@@ -53,8 +53,8 @@ export class EditCoordinatesComponent {
 
   updateProjection(value: ChangeType) {
     if (this.formatedCoordinatesControl.valid || this.formatedCoordinatesControl.pending) {
-      this.projectionFormatIndex = value.projectionFormatIndex!;
-      this.numerical = value.numerical!;
+      this.projectionFormatIndex = value.projectionFormatIndex ?? this.lastProjectionFormatIndex;
+      this.numerical = value.numerical ?? this.lastNumerical;
       this.updateFormatedCoordinates();
     } else {
       this.projectionFormatIndex = this.lastProjectionFormatIndex;

--- a/src/app/helper/projections.ts
+++ b/src/app/helper/projections.ts
@@ -1,7 +1,8 @@
-import { get } from 'ol/proj';
+import { get, transform } from 'ol/proj';
 import proj4 from 'proj4';
 import { register } from 'ol/proj/proj4';
 import Projection from 'ol/proj/Projection';
+import { Coordinate } from 'ol/coordinate';
 
 proj4.defs(
   'EPSG:2056',
@@ -13,18 +14,75 @@ export const coordinatesProjection = getCoordinatesProjection();
 export const mercatorProjection = getMercatorProjection();
 export const swissProjection = getSwissProjection();
 
-type ZsKarteProjection = {
-  format: string;
+type CoordinateTypes<T> = T | Array<T> | Array<Array<T>>;
+
+interface IOverloadedCoordinateFunction<T, U> {
+  (coordinates: T): U;
+  (coordinates: Array<T>): Array<U>;
+  (coordinates: Array<Array<T>>): Array<Array<U>>;
+}
+
+export type ZsKarteProjection = {
+  name: string;
   projection: Projection | null;
-  translate: (coords: number[]) => string;
+  parse: (coords: string) => Coordinate | undefined;
+  translate: (coords: Coordinate, prefix?: boolean) => string;
+  transformTo: IOverloadedCoordinateFunction<Coordinate, Coordinate>;
+  transformFrom: IOverloadedCoordinateFunction<Coordinate, Coordinate>;
+  asString: IOverloadedCoordinateFunction<Coordinate, string>;
+  fromString: IOverloadedCoordinateFunction<string, Coordinate>;
+};
+
+const callUnpacked = <U>(coordinates: CoordinateTypes<Coordinate>, func: (c: Coordinate) => U) => {
+  if (Array.isArray(coordinates) && coordinates.length === 2 && !Array.isArray(coordinates[0])) {
+    return func(coordinates as Coordinate);
+  }
+  return coordinates.map((c) => callUnpacked(c, func));
+};
+const callUnpackedString = (coordinates: CoordinateTypes<string>, func: (c: string) => Coordinate | undefined) => {
+  if (typeof coordinates === 'string') {
+    return func(coordinates);
+  }
+  return coordinates.map((c: CoordinateTypes<string>) => callUnpackedString(c, func));
+};
+
+const addTransformationFunctions = (
+  proj: Omit<ZsKarteProjection, 'transformTo' | 'transformFrom' | 'asString' | 'fromString'>,
+): ZsKarteProjection => {
+  if (!proj.projection || !mercatorProjection) {
+    throw Error(`projection for ${proj.name} or mercatorProjection is missing!`);
+  }
+
+  return {
+    ...proj,
+    transformTo(coordinates: CoordinateTypes<Coordinate>) {
+      return callUnpacked(coordinates, (c: Coordinate) => transform(c, mercatorProjection, this.projection!));
+    },
+    transformFrom(coordinates: CoordinateTypes<Coordinate>) {
+      return callUnpacked(coordinates, (c: Coordinate) => transform(c, this.projection!, mercatorProjection));
+    },
+    asString(coordinates: CoordinateTypes<Coordinate>) {
+      return callUnpacked(coordinates, (c: Coordinate) => this.translate(transform(c, mercatorProjection, this.projection!), false));
+    },
+    fromString(coordinates: CoordinateTypes<string>) {
+      return callUnpackedString(coordinates, (c: string) => {
+        const v = this.parse(c);
+        if (v) {
+          return transform(v, this.projection!, mercatorProjection);
+        } else {
+          return undefined;
+        }
+      });
+    },
+  };
 };
 
 export const availableProjections: Array<ZsKarteProjection> = [
-  {
-    format: '1.2-2',
+  addTransformationFunctions({
+    name: 'LV95',
     projection: swissProjection,
     // see: https://www.swisstopo.admin.ch/de/wissen-fakten/geodaesie-vermessung/bezugsrahmen/lokal/lv95.html > E / N
-    translate(coords?: number[]): string {
+    translate(coords?: Coordinate, prefix: boolean = true): string {
       const numberFormatOptions = {
         minimumFractionDigits: 2,
         maximumFractionDigits: 2,
@@ -32,20 +90,106 @@ export const availableProjections: Array<ZsKarteProjection> = [
       if (!coords || coords.length !== 2) return '';
       const longitude = coords[0].toLocaleString('de-CH', numberFormatOptions);
       const latitude = coords[1].toLocaleString('de-CH', numberFormatOptions);
-      return `LV95 E${longitude} / N${latitude}`;
+      return `${prefix ? 'LV95 ' : ''}E${longitude} / N${latitude}`;
     },
-  },
-  {
-    format: '1.5-5',
+    parse(coords: string): Coordinate | undefined {
+      try {
+        const values = coords.match(/E([0-9'’]+(?:\.\d+)) ?\/ ?N([0-9'’]+(?:\.\d+))/);
+        values?.shift(); //skip fullmatch
+        console.log(values);
+        return values?.map((v) => parseFloat(v.replace(/['’]/g, '')));
+      } catch (ex) {
+        return undefined;
+      }
+    },
+  }),
+  addTransformationFunctions({
+    name: 'GPS',
     projection: coordinatesProjection,
     // see: https://de.wikipedia.org/wiki/Geographische_Koordinaten > LAT(N) should be 1st and LONG(E) 2nd
-    translate(coords: number[]) {
+    translate(coords: Coordinate, prefix: boolean = true): string {
       if (!coords || coords.length !== 2) return 'GPS';
-      const latitude = coords[1].toFixed(5);
-      const longitude = coords[0].toFixed(5);
-      return `GPS N${latitude}°, E${longitude}°`;
+      const latitude = coords[1].toFixed(6);
+      const longitude = coords[0].toFixed(6);
+      return `${prefix ? 'GPS ' : ''}N${latitude}°, E${longitude}°`;
     },
-  },
+    parse(coords: string): Coordinate | undefined {
+      try {
+        const values = coords.match(/N(\d+(?:\.\d+))°?, ?E(\d+(?:\.\d+))°?/);
+        values?.shift(); //skip fullmatch
+        const numbers = values?.map(parseFloat);
+        console.log(values, [numbers![1], numbers![0]]);
+        return [numbers![1], numbers![0]];
+      } catch (ex) {
+        return undefined;
+      }
+    },
+  }),
+  addTransformationFunctions({
+    name: 'GPS°\'"',
+    projection: coordinatesProjection,
+    // see: https://de.wikipedia.org/wiki/Geographische_Koordinaten > LAT(N) should be 1st and LONG(E) 2nd
+    translate(coords: Coordinate, prefix: boolean = true): string {
+      if (!coords || coords.length !== 2) return 'GPS';
+      const latitudeGrad = Math.floor(coords[1]);
+      const latitudeMin = Math.floor((coords[1] - latitudeGrad) * 60);
+      const latitudeSec = (((coords[1] - latitudeGrad) * 60 - latitudeMin) * 60).toFixed(3);
+      const longitudeGrad = Math.floor(coords[0]);
+      const longitudeMin = Math.floor((coords[0] - longitudeGrad) * 60);
+      const longitudeSec = (((coords[0] - longitudeGrad) * 60 - longitudeMin) * 60).toFixed(3);
+      return `${prefix ? 'GPS ' : ''}N${latitudeGrad}° ${latitudeMin}' ${latitudeSec}", E${longitudeGrad}° ${longitudeMin}' ${longitudeSec}"`;
+    },
+    parse(coords: string): Coordinate | undefined {
+      try {
+        const values = coords.match(/N(\d+)° ?(?:(\d+)')? ?(?:(\d+(?:\.\d+)?)"?)? ?, ?E(\d+)° ?(?:(\d+)')? ?(?:(\d+(?:\.\d+)?)"?)?/);
+        values?.shift(); //skip fullmatch
+        const numbers = values!.map(parseFloat);
+        let latitude = 0;
+        if (numbers[2]) {
+          latitude += numbers[2];
+        }
+        latitude /= 60;
+        if (numbers[1]) {
+          latitude += numbers[1];
+        }
+        latitude /= 60;
+        latitude += numbers[0];
+        let longitude = 0;
+        if (numbers[5]) {
+          longitude += numbers[5];
+        }
+        longitude /= 60;
+        if (numbers[4]) {
+          longitude += numbers[4];
+        }
+        longitude /= 60;
+        longitude += numbers[3];
+        console.log(values, numbers, [longitude, latitude]);
+        return [longitude, latitude];
+      } catch (ex) {
+        return undefined;
+      }
+    },
+  }),
+  addTransformationFunctions({
+    name: 'Mercator',
+    projection: mercatorProjection,
+    translate(coords: Coordinate, prefix: boolean = true): string {
+      if (!coords || coords.length !== 2) return 'Mercator';
+      const longitude = coords[0].toFixed(8);
+      const latitude = coords[1].toFixed(8);
+      return `${prefix ? 'Mercator ' : ''}${longitude} / ${latitude}`;
+    },
+    parse(coords: string): Coordinate | undefined {
+      try {
+        const values = coords.match(/(\d+(?:\.\d+)) ?\/ ?(\d+(?:\.\d+))/);
+        values?.shift(); //skip fullmatch
+        return values?.map(parseFloat);
+      } catch (ex) {
+        return undefined;
+      }
+    },
+  }),
 ];
 
 function getCoordinatesProjection() {
@@ -74,3 +218,34 @@ function getSwissProjection() {
   }
   return projection;
 }
+
+export const projectionByIndex = (projectionIndex: number) => {
+  return availableProjections[projectionIndex];
+};
+export const projectionByName = (formatName: string) => {
+  return availableProjections.find((p) => p.name === formatName);
+};
+
+interface IOverloadedConvertFunction<T, U> {
+  (coordinates: T, projectionFormatIndex: number, numerical?: boolean): U;
+  (coordinates: Array<T>, projectionFormatIndex: number, numerical?: boolean): Array<U>;
+  (coordinates: Array<Array<T>>, projectionFormatIndex: number, numerical?: boolean): Array<Array<U>>;
+}
+
+export const convertTo: IOverloadedConvertFunction<Coordinate, Coordinate | string> = <U>(
+  coordinates,
+  projectionFormatIndex: number,
+  numerical: boolean = true,
+): U => {
+  const proj = projectionByIndex(projectionFormatIndex);
+  return numerical ? (proj.transformTo(coordinates) as U) : (proj.asString(coordinates) as U);
+};
+
+export const convertFrom: IOverloadedConvertFunction<Coordinate | string, Coordinate> = <U>(
+  coordinates,
+  projectionFormatIndex: number,
+  numerical: boolean = true,
+): U => {
+  const proj = projectionByIndex(projectionFormatIndex);
+  return numerical ? (proj.transformFrom(coordinates) as U) : (proj.fromString(coordinates) as U);
+};

--- a/src/app/helper/protocolEntry.ts
+++ b/src/app/helper/protocolEntry.ts
@@ -1,25 +1,30 @@
 import { DatePipe } from '@angular/common';
 import { ZsMapBaseDrawElement } from '../map-renderer/elements/base/base-draw-element';
+import { ZsMapTextDrawElementState } from '../state/interfaces';
 import { I18NService } from '../state/i18n.service';
 import capitalizeFirstLetter from './capitalizeFirstLetter';
 import { getCenter } from 'ol/extent';
-import { availableProjections } from './projections';
 import saveAs from 'file-saver';
 import { Workbook } from 'exceljs';
+import { convertTo } from '../helper/projections';
+import { SimpleGeometry } from 'ol/geom';
 
 export function mapProtocolEntry(
   elements: ZsMapBaseDrawElement[],
   datePipe: DatePipe,
   i18n: I18NService,
   currentLocale: string,
+  projectionFormatIndex: number,
+  numerical: boolean,
 ): ProtocolEntry[] {
   return elements.map((element) => {
     const olFeature = element.getOlFeature();
     const sig = olFeature.get('sig');
     const sk: string = sig.kat ? 'sign' + capitalizeFirstLetter(sig.kat) : 'csvGroupArea';
-    const geometry = element.getOlFeature().getGeometry();
+    const geometry = element.getOlFeature().getGeometry() as SimpleGeometry;
+    const location = JSON.stringify(convertTo(geometry.getCoordinates() || [], projectionFormatIndex, numerical));
     const extent = geometry?.getExtent();
-    const centroid = availableProjections[0].translate(extent ? getCenter(extent) : []);
+    const centroid = convertTo(extent ? getCenter(extent) : [], projectionFormatIndex, numerical);
     return {
       id: element.getId(),
       date: datePipe.transform(element.elementState?.createdAt, 'dd.MM.yyyy HH:mm'),
@@ -28,16 +33,14 @@ export function mapProtocolEntry(
         currentLocale === 'fr' ? sig.fr
         : currentLocale === 'en' ? sig.en
         : sig.de,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      location: JSON.stringify((geometry as any).getCoordinates() || []),
+      location,
       centroid,
       size: sig.size,
 
       // if the element is of type text,
       // the name attribute does not exist.
       // However, the "name" is stored inside the "text" attribute
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      label: element.elementState?.name || (element.elementState as any)?.text,
+      label: element.elementState?.name || (element.elementState as ZsMapTextDrawElementState)?.text,
       description: element.elementState?.description,
     } as ProtocolEntry;
   });

--- a/src/app/helper/protocolEntry.ts
+++ b/src/app/helper/protocolEntry.ts
@@ -6,7 +6,7 @@ import capitalizeFirstLetter from './capitalizeFirstLetter';
 import { getCenter } from 'ol/extent';
 import saveAs from 'file-saver';
 import { Workbook } from 'exceljs';
-import { convertTo } from '../helper/projections';
+import { convertTo } from './projections';
 import { SimpleGeometry } from 'ol/geom';
 
 export function mapProtocolEntry(

--- a/src/app/projection-selection/projection-selection.component.html
+++ b/src/app/projection-selection/projection-selection.component.html
@@ -1,0 +1,20 @@
+<div class="projectionSelection">
+  <mat-radio-group *ngIf="!multiple" [(ngModel)]="projectionFormatIndex" (change)="updateFormat($event.value)" [disabled]="disabled">
+    <div>{{ i18n.get('selectFormat') }}:</div>
+    <mat-radio-button *ngFor="let projection of availableProjections; index as i" [value]="i">{{ projection.name }}</mat-radio-button>
+  </mat-radio-group>
+  <div *ngIf="multiple">
+    <div>{{ i18n.get('selectFormat') }}:</div>
+    <mat-checkbox
+      *ngFor="let projection of availableProjections; index as i"
+      [checked]="projectionFormatIndexes.includes(i)"
+      (change)="updateFormats(i, $event.checked)"
+      [disabled]="disabled"
+      >{{ projection.name }}</mat-checkbox
+    >
+  </div>
+  <span *ngIf="showNumerical" class="separator">|</span>
+  <mat-checkbox *ngIf="showNumerical" [checked]="numerical" (change)="updateNumerical($event.checked)" [disabled]="disabled">{{
+    i18n.get('numerical')
+  }}</mat-checkbox>
+</div>

--- a/src/app/projection-selection/projection-selection.component.scss
+++ b/src/app/projection-selection/projection-selection.component.scss
@@ -1,0 +1,4 @@
+.separator {
+  margin-left: 10px;
+  margin-right: 5px;
+}

--- a/src/app/projection-selection/projection-selection.component.spec.ts
+++ b/src/app/projection-selection/projection-selection.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProjectionSelectionComponent } from './projection-selection.component';
+
+describe('ProjectionSelectionComponent', () => {
+  let component: ProjectionSelectionComponent;
+  let fixture: ComponentFixture<ProjectionSelectionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProjectionSelectionComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProjectionSelectionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/projection-selection/projection-selection.component.ts
+++ b/src/app/projection-selection/projection-selection.component.ts
@@ -1,0 +1,61 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import type { ZsKarteProjection } from '../helper/projections';
+import { availableProjections } from '../helper/projections';
+import { I18NService } from '../state/i18n.service';
+
+export type ChangeType = { projectionFormatIndex?: number; projectionFormatIndexes?: number[]; numerical?: boolean };
+
+@Component({
+  selector: 'app-projection-selection',
+  templateUrl: './projection-selection.component.html',
+  styleUrl: './projection-selection.component.scss',
+})
+export class ProjectionSelectionComponent {
+  @Input() projectionFormatIndex: number = 0;
+  @Input() projectionFormatIndexes: number[] = [0];
+  @Input() numerical: boolean = true;
+  @Output() change = new EventEmitter<ChangeType>();
+
+  @Input() multiple: boolean = false;
+  @Input() showNumerical: boolean = true;
+  @Input() disabled: boolean = false;
+
+  availableProjections: Array<ZsKarteProjection> = availableProjections;
+
+  constructor(public i18n: I18NService) {}
+
+  updateFormat(value: number) {
+    this.projectionFormatIndex = value;
+    this.emitChange();
+  }
+
+  updateFormats(formatIndex: number, value: boolean) {
+    if (value && !this.projectionFormatIndexes.includes(formatIndex)) {
+      this.projectionFormatIndexes.push(formatIndex);
+    } else if (!value && this.projectionFormatIndexes.includes(formatIndex)) {
+      const index = this.projectionFormatIndexes.indexOf(formatIndex);
+      if (index !== -1) {
+        this.projectionFormatIndexes.splice(index, 1);
+      }
+    }
+    this.emitChange();
+  }
+
+  updateNumerical(value: boolean) {
+    this.numerical = value;
+    this.emitChange();
+  }
+
+  emitChange() {
+    const state: ChangeType = {};
+    if (this.showNumerical) {
+      state.numerical = this.numerical;
+    }
+    if (this.multiple) {
+      state.projectionFormatIndexes = this.projectionFormatIndexes;
+    } else {
+      state.projectionFormatIndex = this.projectionFormatIndex;
+    }
+    this.change.emit(state);
+  }
+}

--- a/src/app/projection-selection/projection-selection.component.ts
+++ b/src/app/projection-selection/projection-selection.component.ts
@@ -11,14 +11,14 @@ export type ChangeType = { projectionFormatIndex?: number; projectionFormatIndex
   styleUrl: './projection-selection.component.scss',
 })
 export class ProjectionSelectionComponent {
-  @Input() projectionFormatIndex: number = 0;
+  @Input() projectionFormatIndex = 0;
   @Input() projectionFormatIndexes: number[] = [0];
-  @Input() numerical: boolean = true;
-  @Output() change = new EventEmitter<ChangeType>();
+  @Input() numerical = true;
+  @Output() readonly projectionChanged = new EventEmitter<ChangeType>();
 
-  @Input() multiple: boolean = false;
-  @Input() showNumerical: boolean = true;
-  @Input() disabled: boolean = false;
+  @Input() multiple = false;
+  @Input() showNumerical = true;
+  @Input() disabled = false;
 
   availableProjections: Array<ZsKarteProjection> = availableProjections;
 
@@ -56,6 +56,6 @@ export class ProjectionSelectionComponent {
     } else {
       state.projectionFormatIndex = this.projectionFormatIndex;
     }
-    this.change.emit(state);
+    this.projectionChanged.emit(state);
   }
 }

--- a/src/app/protocol-table/protocol-table.component.html
+++ b/src/app/protocol-table/protocol-table.component.html
@@ -12,7 +12,7 @@
     <app-projection-selection
       [projectionFormatIndex]="projectionFormatIndex"
       [numerical]="numerical"
-      (change)="updateProjection($event)"
+      (projectionChanged)="updateProjection($event)"
     ></app-projection-selection>
   </div>
   <table mat-table [dataSource]="protocolTableDataSource" class="mat-elevation-z8 protocol-table" matSort>

--- a/src/app/protocol-table/protocol-table.component.html
+++ b/src/app/protocol-table/protocol-table.component.html
@@ -1,5 +1,5 @@
 <div class="table-container">
-  <div>
+  <div class="header">
     <mat-form-field appearance="outline">
       <input
         matInput
@@ -9,6 +9,11 @@
         [placeholder]="i18n.get('csvSearchFor')"
       />
     </mat-form-field>
+    <app-projection-selection
+      [projectionFormatIndex]="projectionFormatIndex"
+      [numerical]="numerical"
+      (change)="updateProjection($event)"
+    ></app-projection-selection>
   </div>
   <table mat-table [dataSource]="protocolTableDataSource" class="mat-elevation-z8 protocol-table" matSort>
     <ng-container matColumnDef="id">

--- a/src/app/protocol-table/protocol-table.component.scss
+++ b/src/app/protocol-table/protocol-table.component.scss
@@ -7,6 +7,12 @@
   position: sticky;
   top: 0;
 }
+.header {
+  display: flex;
+}
+app-projection-selection {
+  margin-left: 20px;
+}
 
 .protocol-table {
   width: 100%;

--- a/src/app/protocol-table/protocol-table.component.ts
+++ b/src/app/protocol-table/protocol-table.component.ts
@@ -8,6 +8,8 @@ import { mapProtocolEntry, ProtocolEntry } from '../helper/protocolEntry';
 import { ZsMapBaseDrawElement } from '../map-renderer/elements/base/base-draw-element';
 import { SessionService } from '../session/session.service';
 import { I18NService } from '../state/i18n.service';
+import { ChangeType } from '../projection-selection/projection-selection.component';
+import { first } from 'rxjs/operators';
 
 @Component({
   selector: 'app-protocol-table',
@@ -16,6 +18,9 @@ import { I18NService } from '../state/i18n.service';
 })
 export class ProtocolTableComponent implements OnInit, OnDestroy, AfterViewInit {
   private _ngUnsubscribe = new Subject<void>();
+  projectionFormatIndex: number = 0;
+  numerical: boolean = false;
+
   constructor(
     public zsMapStateService: ZsMapStateService,
     public i18n: I18NService,
@@ -26,13 +31,7 @@ export class ProtocolTableComponent implements OnInit, OnDestroy, AfterViewInit 
   @ViewChild(MatSort) sort?: MatSort;
 
   ngOnInit(): void {
-    this.zsMapStateService
-      .observeDrawElements()
-      .pipe(takeUntil(this._ngUnsubscribe))
-      .subscribe((elements: ZsMapBaseDrawElement[]) => {
-        this.data = mapProtocolEntry(elements, this.datePipe, this.i18n, this.session.getLocale());
-        this.protocolTableDataSource.data = this.data;
-      });
+    this.zsMapStateService.observeDrawElements().pipe(takeUntil(this._ngUnsubscribe)).subscribe(this.updateTable.bind(this));
   }
 
   ngAfterViewInit() {
@@ -41,9 +40,20 @@ export class ProtocolTableComponent implements OnInit, OnDestroy, AfterViewInit 
     }
   }
 
+  updateTable(elements: ZsMapBaseDrawElement[]) {
+    this.data = mapProtocolEntry(elements, this.datePipe, this.i18n, this.session.getLocale(), this.projectionFormatIndex, this.numerical);
+    this.protocolTableDataSource.data = this.data;
+  }
+
   ngOnDestroy(): void {
     this._ngUnsubscribe.next();
     this._ngUnsubscribe.complete();
+  }
+
+  updateProjection(value: ChangeType) {
+    this.projectionFormatIndex = value.projectionFormatIndex!;
+    this.numerical = value.numerical!;
+    this.zsMapStateService.observeDrawElements().pipe(first()).subscribe(this.updateTable.bind(this));
   }
 
   public data: ProtocolEntry[] = [];

--- a/src/app/protocol-table/protocol-table.component.ts
+++ b/src/app/protocol-table/protocol-table.component.ts
@@ -18,8 +18,8 @@ import { first } from 'rxjs/operators';
 })
 export class ProtocolTableComponent implements OnInit, OnDestroy, AfterViewInit {
   private _ngUnsubscribe = new Subject<void>();
-  projectionFormatIndex: number = 0;
-  numerical: boolean = false;
+  projectionFormatIndex = 0;
+  numerical = false;
 
   constructor(
     public zsMapStateService: ZsMapStateService,
@@ -51,8 +51,8 @@ export class ProtocolTableComponent implements OnInit, OnDestroy, AfterViewInit 
   }
 
   updateProjection(value: ChangeType) {
-    this.projectionFormatIndex = value.projectionFormatIndex!;
-    this.numerical = value.numerical!;
+    this.projectionFormatIndex = value.projectionFormatIndex ?? this.projectionFormatIndex;
+    this.numerical = value.numerical ?? this.numerical;
     this.zsMapStateService.observeDrawElements().pipe(first()).subscribe(this.updateTable.bind(this));
   }
 

--- a/src/app/selected-feature/selected-feature.component.ts
+++ b/src/app/selected-feature/selected-feature.component.ts
@@ -216,8 +216,9 @@ export class SelectedFeatureComponent implements OnDestroy {
       const editDialog = this.dialog.open(EditCoordinatesComponent, {
         data: {
           geometry: selectedElement.getOlFeature().getGeometry()?.getType(),
-          coordinates: JSON.stringify(selectedElement.elementState?.coordinates),
+          coordinates: selectedElement.elementState?.coordinates,
         },
+        maxWidth: '100vw',
       });
       editDialog.afterClosed().subscribe((result) => {
         if (result) {

--- a/src/app/sidebar/sidebar-menu/sidebar-menu.component.html
+++ b/src/app/sidebar/sidebar-menu/sidebar-menu.component.html
@@ -64,6 +64,19 @@
     {{ i18n.get('protocolSaveAsExcel') }}
   </button>
 </mat-menu>
+<ng-template #projectionSelectionTemplate let-data>
+  <div mat-dialog-content>
+    <app-projection-selection
+      [projectionFormatIndex]="data.projectionFormatIndex"
+      [numerical]="data.numerical"
+      (change)="data.numerical = $event.numerical; data.projectionFormatIndex = $event.projectionFormatIndex"
+    ></app-projection-selection>
+  </div>
+  <div mat-dialog-actions align="end">
+    <button mat-raised-button [mat-dialog-close]="null">{{ i18n.get('cancel') }}</button>
+    <button mat-raised-button color="primary" [mat-dialog-close]="data" cdkFocusInitial>{{ i18n.get('ok') }}</button>
+  </div>
+</ng-template>
 
 <mat-menu #shareOptions="matMenu">
   <button mat-menu-item (click)="generateShareLink(false, false)">

--- a/src/app/sidebar/sidebar-menu/sidebar-menu.component.html
+++ b/src/app/sidebar/sidebar-menu/sidebar-menu.component.html
@@ -69,7 +69,7 @@
     <app-projection-selection
       [projectionFormatIndex]="data.projectionFormatIndex"
       [numerical]="data.numerical"
-      (change)="data.numerical = $event.numerical; data.projectionFormatIndex = $event.projectionFormatIndex"
+      (projectionChanged)="data.numerical = $event.numerical ?? data.numerical; data.projectionFormatIndex = $event.projectionFormatIndex ?? data.projectionFormatIndex"
     ></app-projection-selection>
   </div>
   <div mat-dialog-actions align="end">

--- a/src/app/sidebar/sidebar-menu/sidebar-menu.component.ts
+++ b/src/app/sidebar/sidebar-menu/sidebar-menu.component.ts
@@ -1,10 +1,9 @@
-import { ChangeDetectorRef, Component, OnDestroy, ViewChild } from '@angular/core';
+import { ChangeDetectorRef, Component, ViewChild, TemplateRef } from '@angular/core';
 import { I18NService, Locale, LOCALES } from '../../state/i18n.service';
 import { MatDialog } from '@angular/material/dialog';
 import { HelpComponent } from '../../help/help.component';
 import { ZsMapStateService } from '../../state/state.service';
-import { BehaviorSubject, Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { BehaviorSubject } from 'rxjs';
 import { SessionService } from '../../session/session.service';
 import { MatMenuTrigger } from '@angular/material/menu';
 import { ZsMapBaseDrawElement } from '../../map-renderer/elements/base/base-draw-element';
@@ -15,19 +14,21 @@ import { ShareDialogComponent } from '../../session/share-dialog/share-dialog.co
 import { AccessTokenType, PermissionType } from '../../session/session.interfaces';
 import { RevokeShareDialogComponent } from '../../session/revoke-share-dialog/revoke-share-dialog.component';
 import { OperationService } from '../../session/operations/operation.service';
+import { first } from 'rxjs/operators';
+import { ChangeType } from '../../projection-selection/projection-selection.component';
 
 @Component({
   selector: 'app-sidebar-menu',
   templateUrl: './sidebar-menu.component.html',
   styleUrl: './sidebar-menu.component.scss',
 })
-export class SidebarMenuComponent implements OnDestroy {
+export class SidebarMenuComponent {
   @ViewChild(MatMenuTrigger) menu!: MatMenuTrigger;
+  @ViewChild('projectionSelectionTemplate') projectionSelectionTemplate!: TemplateRef<unknown>;
 
   locales: Locale[] = LOCALES;
   protocolEntries: ProtocolEntry[] = [];
   public incidents = new BehaviorSubject<number[]>([]);
-  private _ngUnsubscribe = new Subject<void>();
 
   constructor(
     public i18n: I18NService,
@@ -39,18 +40,6 @@ export class SidebarMenuComponent implements OnDestroy {
     private _dialog: MatDialog,
     private _operation: OperationService,
   ) {
-    this.zsMapStateService
-      .observeDrawElements()
-      .pipe(takeUntil(this._ngUnsubscribe))
-      .subscribe((elements: ZsMapBaseDrawElement[]) => {
-        this.protocolEntries = mapProtocolEntry(
-          elements,
-          this.datePipe,
-          this.i18n,
-          this.session.getLocale() === undefined ? 'de' : this.session.getLocale(),
-        );
-      });
-
     this.incidents.next(this.session.getOperationEventStates() || []);
   }
 
@@ -60,11 +49,6 @@ export class SidebarMenuComponent implements OnDestroy {
       operation.eventStates = incidents;
       await this._operation.saveOperation(operation);
     }
-  }
-
-  ngOnDestroy(): void {
-    this._ngUnsubscribe.next();
-    this._ngUnsubscribe.complete();
   }
 
   toggleHistory(): void {
@@ -80,7 +64,31 @@ export class SidebarMenuComponent implements OnDestroy {
   }
 
   protocolExcelExport(): void {
-    exportProtocolExcel(this.protocolEntries, this.i18n);
+    const projectionDialog = this.dialog.open(this.projectionSelectionTemplate, {
+      width: '450px',
+      data: {
+        projectionFormatIndex: 0,
+        numerical: true,
+      } as ChangeType,
+    });
+    projectionDialog.afterClosed().subscribe((result: ChangeType | undefined) => {
+      if (result) {
+        this.zsMapStateService
+          .observeDrawElements()
+          .pipe(first())
+          .subscribe((elements: ZsMapBaseDrawElement[]) => {
+            this.protocolEntries = mapProtocolEntry(
+              elements,
+              this.datePipe,
+              this.i18n,
+              this.session.getLocale() === undefined ? 'de' : this.session.getLocale(),
+              result.projectionFormatIndex ?? 0,
+              result.numerical ?? true,
+            );
+            exportProtocolExcel(this.protocolEntries, this.i18n);
+          });
+      }
+    });
   }
 
   print(): void {

--- a/src/app/state/i18n.service.ts
+++ b/src/app/state/i18n.service.ts
@@ -648,6 +648,16 @@ export class I18NService {
       fr: 'Voulez-vous vraiment supprimer ce symbole ?',
       en: 'Do you really want to delete this symbol?',
     },
+    selectFormat: {
+      de: 'Format wählen',
+      en: 'Select format',
+      fr: 'Sélectionnez le format',
+    },
+    numerical: {
+      de: 'numerisch',
+      en: 'numerical',
+      fr: 'numérique',
+    },
     defineCoordinates: {
       de: 'Koordinaten definieren',
       en: 'Define coordinates',


### PR DESCRIPTION
This pull request contains a redesign of the projection / coordinate format systems with added functions.
It fixes https://github.com/zskarte/zskarte-client/issues/57

It adds a Coord format selection to:
- edit-coordinates.component
- coordinates.component
- protocol-table.component
- sidebar-menu.component // #projectionSelectionTemplate for export protocol format

and allow to show/edit the values as number or text representation in corresponding format.

I added format selection to coordinates.component behind the small symbol at right.
<img width="488" alt="coordinates component-options" src="https://github.com/zskarte/zskarte-client/assets/1330346/26cf26e2-00a4-4866-bb06-fe0e978cccd7">
This my be difficult to click on touchscreen, so perhaps it have to be moved to somewhere else / increase in size / other option to open.
_I don't know how/where this setting should be persisted in your concept so I leave an TODO for that._

In edit-coordinates.component the values can now be entered as numbers or formatted strings.
Also the json is pretty printed for display (but can be changed with prettyf or course).
<img width="641" alt="edit-coordinates component-JSON-prettify" src="https://github.com/zskarte/zskarte-client/assets/1330346/8687cf54-2c10-43dc-b23f-cff44ad98370">

The new GPS°'" format have an slightly problem if used in edit-coordinates.component as if the json conversion have to escape the ".
<img width="638" alt="edit-coordinates component-GPS-JSON-problem" src="https://github.com/zskarte/zskarte-client/assets/1330346/29673dcc-ed7c-4115-9e2b-16a5cf8395c6">
But on parsing the values back for save, it's allowed to remove the " symbol on the coordinates completely, for simplify it an bit.

In map-renderer.component.ts the functions
```
  this.selectedFeatureCoordinates = this.selectedFeature.pipe(
    map((feature) => {
      const coords = this.getFeatureCoordinates(feature);
      return projectionByIndex(this.selectedProjectionIndex).translate(coords);
    }),
  );
  this.mouseProjection = this._state.getCoordinates().pipe(
    takeUntil(this._ngUnsubscribe),
    map((coords) => {
      const transform = this.transformToCurrentProjection(coords) ?? [];
      return projectionByIndex(this.selectedProjectionIndex).translate(transform);
    }),
  );
	
  getFeatureCoordinates(feature: Feature | null | undefined): Coordinate {
    const center = getCenter(feature?.getGeometry()?.getExtent() ?? []);
    return this.transformToCurrentProjection(center) ?? [];
  }

  transformToCurrentProjection(coordinates: Coordinate) {
    return projectionByIndex(this.selectedProjectionIndex).transformTo(coordinates);
  }
```
are never used, I adjusted them anyway.
Also the "selectedProjectionIndex" have not any effect, as it cannot be set/changed and is not used by coordinates.component
I suggest to delete this functions and the selectedProjectionIndex if not planed to be used again.


PS: is there an option to do the DeepSource checks locally? "yarn lint" have not shown any issues.