### PR TITLE
feat(zoom): add option to zoom to scale with screensize

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -67,6 +67,7 @@ import { RevokeShareDialogComponent } from './session/revoke-share-dialog/revoke
 import { SidebarHistoryComponent } from './sidebar/sidebar-history/sidebar-history.component';
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { FloatingUIComponent } from './floating-ui/floating-ui.component';
+import { ScaleSelectionComponent } from './scale-selection/scale-selection.component';
 import { CoordinatesComponent } from './coordinates/coordinates.component';
 import { SidebarMenuComponent } from './sidebar/sidebar-menu/sidebar-menu.component';
 import { DrawDialogComponent } from './draw-dialog/draw-dialog.component';
@@ -119,6 +120,7 @@ export function appFactory(session: SessionService, sync: SyncService, state: Zs
     ShareDialogComponent,
     TextDividerComponent,
     FloatingUIComponent,
+    ScaleSelectionComponent,
     CoordinatesComponent,
     SidebarMenuComponent,
     DrawDialogComponent,

--- a/src/app/floating-ui/floating-ui.component.html
+++ b/src/app/floating-ui/floating-ui.component.html
@@ -115,6 +115,10 @@
             <mat-icon>zoom_in</mat-icon>
           </button>
           <mat-divider class="divider"></mat-divider>
+          <button mat-icon-button class="toggle-button" (click)="zoomToScale()" [attr.aria-label]="i18n.get('zoomToScale')">
+            <mat-icon>linear_scale</mat-icon>
+          </button>
+          <mat-divider class="divider"></mat-divider>
           <button mat-icon-button class="toggle-button" (click)="zoomOut()" [attr.aria-label]="i18n.get('zoomOut')">
             <mat-icon>zoom_out</mat-icon>
           </button>

--- a/src/app/floating-ui/floating-ui.component.ts
+++ b/src/app/floating-ui/floating-ui.component.ts
@@ -11,6 +11,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { HelpComponent } from '../help/help.component';
 import { SidebarContext } from '../sidebar/sidebar.interfaces';
 import { SidebarService } from '../sidebar/sidebar.service';
+import { ScaleSelectionComponent } from '../scale-selection/scale-selection.component';
 
 @Component({
   selector: 'app-floating-ui',
@@ -83,6 +84,21 @@ export class FloatingUIComponent {
 
   zoomIn() {
     this._state.updateMapZoom(1);
+  }
+
+  zoomToScale() {
+    const projectionDialog = this._dialog.open(ScaleSelectionComponent, {
+      width: '500px',
+      data: {
+        scale: undefined,
+        dpi: this._state.getDPI(),
+      },
+    });
+    projectionDialog.afterClosed().subscribe((result) => {
+      if (result) {
+        this._state.setMapZoomScale(result.scale, result.dpi);
+      }
+    });
   }
 
   zoomOut() {

--- a/src/app/map-renderer/map-renderer.component.ts
+++ b/src/app/map-renderer/map-renderer.component.ts
@@ -63,6 +63,7 @@ export class MapRendererComponent implements AfterViewInit {
   private _ngUnsubscribe = new Subject<void>();
   private _map!: OlMap;
   private _view!: OlView;
+  private _scaleLine!: ScaleLine;
   private _geolocation!: OlGeolocation;
   private _modify!: Modify;
   private _mapLayer: Layer = new OlTileLayer({
@@ -397,18 +398,18 @@ export class MapRendererComponent implements AfterViewInit {
       zoom: DEFAULT_ZOOM, // will be overwritten once session is loaded via display state
     });
 
+    this._scaleLine = new ScaleLine({
+      units: 'metric',
+      bar: true,
+      steps: 4,
+      text: true,
+      minWidth: 140,
+    });
+
     this._map = new OlMap({
       target: this.mapElement.nativeElement,
       view: this._view,
-      controls: [
-        new ScaleLine({
-          units: 'metric',
-          bar: true,
-          steps: 4,
-          text: true,
-          minWidth: 140,
-        }),
-      ],
+      controls: [this._scaleLine],
       interactions: defaults({
         doubleClickZoom: false,
         pinchRotate: true,
@@ -544,6 +545,13 @@ export class MapRendererComponent implements AfterViewInit {
           }
           this._view.setZoom(zoom);
         }
+      });
+
+    this._state
+      .observeDPI()
+      .pipe(takeUntil(this._ngUnsubscribe))
+      .subscribe((dpi) => {
+        this._scaleLine.setDpi(dpi);
       });
 
     this._map.addLayer(this._mapLayer);

--- a/src/app/scale-selection/scale-selection.component.html
+++ b/src/app/scale-selection/scale-selection.component.html
@@ -1,0 +1,30 @@
+<div mat-dialog-content class="scaleSelection">
+  <mat-form-field class="full-width" appearance="outline">
+    <mat-label>{{ i18n.get('scaleToUse') }}</mat-label>
+    <input matInput type="text" [(ngModel)]="scale" name="scale" cdkFocusInitial/>
+  </mat-form-field>
+  <mat-form-field class="full-width" appearance="outline">
+    <mat-label>screenDimension (in ")</mat-label>
+    <input matInput type="text" [(ngModel)]="screenDimension" name="screenDimension" (change)="updateDpi()"/>
+  </mat-form-field>
+  <mat-form-field class="full-width" appearance="outline">
+    <mat-label>screenWidth (in px)</mat-label>
+    <input matInput type="text" [(ngModel)]="screenWidth" name="screenWidth" disabled/>
+  </mat-form-field>
+  <mat-form-field class="full-width" appearance="outline">
+    <mat-label>screenHeight (in px)</mat-label>
+    <input matInput type="text" [(ngModel)]="screenHeight" name="screenHeight" disabled/>
+  </mat-form-field>
+  <mat-form-field class="full-width" appearance="outline">
+    <mat-label>devicePixelRatio</mat-label>
+    <input matInput type="text" [(ngModel)]="devicePixelRatio" name="devicePixelRatio" disabled/>
+  </mat-form-field>
+  <mat-form-field class="full-width" appearance="outline">
+    <mat-label>DPI</mat-label>
+    <input matInput type="text" [(ngModel)]="dpi" name="dpi" disabled/>
+  </mat-form-field>
+</div>
+<div mat-dialog-actions align="end">
+  <button mat-raised-button (click)="cancel()">{{ i18n.get('cancel') }}</button>
+  <button mat-raised-button (click)="ok()" color="primary">{{ i18n.get('ok') }}</button>
+</div>

--- a/src/app/scale-selection/scale-selection.component.scss
+++ b/src/app/scale-selection/scale-selection.component.scss
@@ -1,0 +1,14 @@
+.scaleSelection {
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: 10px;
+}
+
+.mat-mdc-dialog-content.scaleSelection {
+  padding: 8px;
+}
+
+.scaleSelection > mat-form-field {
+  width: 200px;
+  flex-grow: 1;
+}

--- a/src/app/scale-selection/scale-selection.component.spec.ts
+++ b/src/app/scale-selection/scale-selection.component.spec.ts
@@ -1,0 +1,32 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+import { ScaleSelectionComponent } from './scale-selection.component';
+
+describe('ScaleSelectionComponent', () => {
+  let component: ScaleSelectionComponent;
+  let fixture: ComponentFixture<ScaleSelectionComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ScaleSelectionComponent],
+      providers: [
+        {
+          provide: MatDialogRef,
+          useValue: jasmine.createSpyObj('MatDialogRef', ['close']),
+        },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    });
+
+    fixture = TestBed.createComponent(ScaleSelectionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/scale-selection/scale-selection.component.ts
+++ b/src/app/scale-selection/scale-selection.component.ts
@@ -1,0 +1,65 @@
+import { Component, Inject, HostListener } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { I18NService } from '../state/i18n.service';
+import { DEFAULT_DPI } from '../session/default-map-values';
+
+export type ScaleType = { scale?: number; dpi?: number };
+
+@Component({
+  selector: 'app-scale-selection',
+  templateUrl: './scale-selection.component.html',
+  styleUrl: './scale-selection.component.scss',
+})
+export class ScaleSelectionComponent {
+  scale?: number;
+  dpi: number;
+  screenDimension: number;
+  devicePixelRatio: number;
+  screenWidth: number;
+  screenHeight: number;
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: ScaleType,
+    public i18n: I18NService,
+    public dialogRef: MatDialogRef<ScaleSelectionComponent, ScaleType | undefined>,
+  ) {
+    this.scale = data.scale;
+    if (data.dpi && data.dpi !== DEFAULT_DPI) {
+      this.dpi = data.dpi;
+      this.screenDimension = ScaleSelectionComponent.calcScreenDimension(this.dpi);
+    } else {
+      this.screenDimension = 16;
+      this.dpi = ScaleSelectionComponent.calcDpi(this.screenDimension);
+    }
+    this.devicePixelRatio = window.devicePixelRatio;
+    this.screenWidth = screen.width * window.devicePixelRatio;
+    this.screenHeight = screen.height * window.devicePixelRatio;
+  }
+
+  updateDpi() {
+    this.dpi = ScaleSelectionComponent.calcDpi(this.screenDimension);
+  }
+
+  static calcDpi(screenDimension: number) {
+    //as on the web the window.devicePixelRatio is not used for size calculation don't use it for calc
+    return Math.round(Math.sqrt(Math.pow(screen.width, 2) + Math.pow(screen.height, 2)) / screenDimension);
+  }
+
+  static calcScreenDimension(dpi: number) {
+    //as on the web the window.devicePixelRatio is not used for size calculation don't use it for calc
+    return Math.round(Math.sqrt(Math.pow(screen.width, 2) + Math.pow(screen.height, 2)) / dpi);
+  }
+
+  cancel() {
+    this.dialogRef.close(undefined);
+  }
+
+  ok(): void {
+    this.dialogRef.close({ scale: this.scale, dpi: this.dpi });
+  }
+
+  @HostListener('window:keyup.Enter', ['$event'])
+  onDialogClick(): void {
+    this.ok();
+  }
+}

--- a/src/app/session/default-map-values.ts
+++ b/src/app/session/default-map-values.ts
@@ -1,3 +1,9 @@
 export const DEFAULT_COORDINATES = [828675.7379587183, 5933353.2073429795];
 
 export const DEFAULT_ZOOM = 16;
+
+export const DEFAULT_DPI = 25.4 / 0.28; // from 'ol/control/ScaleLine';
+
+export const ZOOM_0_RESOLUTION = 156543.03390625;
+
+export const LOG2_ZOOM_0_RESOLUTION = Math.log2(ZOOM_0_RESOLUTION);

--- a/src/app/state/i18n.service.ts
+++ b/src/app/state/i18n.service.ts
@@ -863,6 +863,16 @@ export class I18NService {
       en: 'Zoom in',
       fr: 'Zoom in',
     },
+    zoomToScale: {
+      de: 'massstabsgetreu vergrössern',
+      en: 'zoom to scale',
+      fr: "zoomer à l'échelle",
+    },
+    scaleToUse: {
+      de: 'Massstab (1:xxx)',
+      en: 'scale (1:xxx)',
+      fr: 'échelle (1:xxx)',
+    },
     filters: {
       de: 'Filter',
       en: 'Filters',

--- a/src/app/state/interfaces.ts
+++ b/src/app/state/interfaces.ts
@@ -43,6 +43,7 @@ export interface IZsMapDisplayState {
   mapOpacity: number;
   mapCenter: number[];
   mapZoom: number;
+  dpi?: number;
   showMyLocation: boolean;
   activeLayer: string | undefined;
   layerVisibility: Record<string, boolean>;


### PR DESCRIPTION
this fixes: https://github.com/zskarte/zskarte-client/issues/49
<img width="68" alt="floating-ui component_new-scale-button" src="https://github.com/zskarte/zskarte-client/assets/1330346/6d6e105a-e068-4ee7-937e-449debfb1b6f">

HINT: on mercator projection the scale changes based on latitudes.
Therefore the setted scale changes if scoll around on the map.

To make the scale really matches and is not only an value show on the virtual ruler,
the user have to define the pysical size of there screen in Inches so the real DPI/PPI can be calculated.
<img width="382" alt="scale-selection component_define-scale-and-screensize" src="https://github.com/zskarte/zskarte-client/assets/1330346/4c01a03d-058d-4a09-ae5b-53f2c057d3c2">

