### PR TITLE
feat(geoAdmin): allow wms layers, add attribution, sanitize, hide layer redesign

### DIFF
--- a/src/app/core/entity/geoFeature.ts
+++ b/src/app/core/entity/geoFeature.ts
@@ -15,7 +15,12 @@ export interface GeoFeature {
   tooltip: boolean;
   topics: string;
   type: string;
-  // should be OlTileLayer<OlTileWMTS> but TS does not allow it somehow
+  wmsLayers: string;
+  wmsUrl?: string;
+  subLayersIds?: string[];
+  maxResolution?: number;
+  minResolution?: number;
+  hidden: boolean;
   deleted?: boolean;
   zIndex: number;
 }

--- a/src/app/core/geoadmin.service.ts
+++ b/src/app/core/geoadmin.service.ts
@@ -1,26 +1,28 @@
-import { Injectable } from '@angular/core';
+import { Injectable, SecurityContext } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { I18NService } from '../state/i18n.service';
-import { Observable, of, tap } from 'rxjs';
-import { GeoFeatures } from './entity/geoFeature';
+import { Observable, firstValueFrom, map, of, tap } from 'rxjs';
+import { GeoFeature, GeoFeatures } from './entity/geoFeature';
 import OlTileGridWMTS from 'ol/tilegrid/WMTS';
 import OlTileWMTS from 'ol/source/WMTS';
 import { swissProjection } from '../helper/projections';
 import { SessionService } from '../session/session.service';
 import OlTileLayer from 'ol/layer/Tile';
+import TileWMS from 'ol/source/TileWMS';
+import { DomSanitizer } from '@angular/platform-browser';
 
 @Injectable({
   providedIn: 'root',
 })
 export class GeoadminService {
   private _featuresCache: GeoFeatures | undefined;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private _legendCache: any;
+  private _legendCache: { [key: string]: string } = {};
 
   constructor(
     private http: HttpClient,
     public i18n: I18NService,
     private _session: SessionService,
+    private domSanitizer: DomSanitizer,
   ) {}
 
   getFeatures(): Observable<GeoFeatures> {
@@ -30,40 +32,101 @@ export class GeoadminService {
 
     return this.http
       .get<GeoFeatures>(`https://api3.geo.admin.ch/rest/services/api/MapServer/layersConfig?lang=${this._session.getLocale()}`)
-      .pipe(tap((data) => (this._featuresCache = data)));
+      .pipe(
+        tap((data) => {
+          Object.keys(data).forEach((key) => {
+            data[key].opacity = data[key].opacity ?? data[key].background ? 1.0 : 0.75;
+          });
+        }),
+        tap((data) => (this._featuresCache = data)),
+      );
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getLegend(layerId: string): Observable<any> {
-    if (this._legendCache) {
-      return of(this._legendCache);
+  getLegend(layerId: string): Observable<string> {
+    if (layerId in this._legendCache) {
+      return of(this._legendCache[layerId]);
     }
 
     return this.http
       .get(`https://api3.geo.admin.ch/rest/services/api/MapServer/${layerId}/legend?lang=${this._session.getLocale()}`, {
         responseType: 'text',
       })
-      .pipe(tap((data) => (this._legendCache = data)));
+      .pipe(
+        map((data) => this.domSanitizer.sanitize(SecurityContext.HTML, data) ?? ''),
+        tap((data) => (this._legendCache[layerId] = data)),
+      );
   }
 
-  // skipcq: JS-0105
-  createGeoAdminLayer(layerId: string, timestamp: string, extension: string, zIndex: number) {
-    return new OlTileLayer({
-      source: new OlTileWMTS({
-        projection: swissProjection,
-        url: `https://wmts.geo.admin.ch/1.0.0/{Layer}/default/${timestamp}/2056/{TileMatrix}/{TileCol}/{TileRow}.${extension}`,
-        tileGrid: new OlTileGridWMTS({
-          origin: [swissProjection.getExtent()[0], swissProjection.getExtent()[3]],
-          resolutions: swissProjection.resolutions,
-          matrixIds: swissProjection.matrixIds,
-        }),
-        layer: layerId,
-        requestEncoding: 'REST',
-        style: '',
-        matrixSet: '',
-      }),
-      opacity: 0.6,
-      zIndex,
+  async createGeoAdminLayer(baseFeature: GeoFeature) {
+    //console.debug('createGeoAdminLayer:', baseFeature);
+    let features = [baseFeature];
+    if (baseFeature.type === 'aggregate' && baseFeature.subLayersIds) {
+      const allFeatures = await firstValueFrom(this.getFeatures());
+      features = baseFeature.subLayersIds.map((id) => allFeatures[id]);
+    }
+    const layers: OlTileLayer<OlTileWMTS | TileWMS>[] = [];
+    features.forEach((feature) => {
+      let attributionHtml: string | undefined;
+      if (feature.attribution) {
+        const name = this.domSanitizer.sanitize(SecurityContext.HTML, feature.attribution) ?? '';
+        if (feature.attributionUrl) {
+          let url = this.domSanitizer.sanitize(SecurityContext.URL, feature.attributionUrl) ?? '';
+          //prevent escape the href attribute
+          url = url?.replace(/"/g, '&quot;');
+          attributionHtml = `<a target="_blank" href="${url}">${name}</a>`;
+        } else {
+          attributionHtml = name;
+        }
+      }
+      if (feature.type === 'wmts') {
+        //if (feature.timeEnabled) //=> possible different values in timestamps, make selectable?
+        const timestamp = feature?.timestamps ? feature.timestamps[0] : 'current';
+        const extension = feature.format;
+        layers.push(
+          new OlTileLayer({
+            source: new OlTileWMTS({
+              projection: swissProjection,
+              url: `https://wmts.geo.admin.ch/1.0.0/{Layer}/default/${timestamp}/2056/{TileMatrix}/{TileCol}/{TileRow}.${extension}`,
+              tileGrid: new OlTileGridWMTS({
+                origin: [swissProjection.getExtent()[0], swissProjection.getExtent()[3]],
+                resolutions: swissProjection.resolutions,
+                matrixIds: swissProjection.matrixIds,
+              }),
+              layer: feature.serverLayerName,
+              requestEncoding: 'REST',
+              style: '',
+              matrixSet: '',
+              crossOrigin: 'anonymous',
+              attributions: attributionHtml,
+            }),
+            opacity: feature.opacity,
+            minResolution: feature.minResolution ?? undefined,
+            maxResolution: feature.maxResolution ?? undefined,
+            zIndex: feature.zIndex,
+          }),
+        );
+      } else if (feature.type === 'wms') {
+        layers.push(
+          new OlTileLayer({
+            source: new TileWMS({
+              projection: swissProjection,
+              url: feature.wmsUrl,
+              params: { LAYERS: feature.wmsLayers, TILED: true },
+              serverType: 'geoserver', //'mapserver'
+              transition: 0,
+              crossOrigin: 'anonymous',
+              attributions: attributionHtml,
+            }),
+            opacity: feature?.opacity ?? feature.background ? 1.0 : 0.75,
+            minResolution: feature.minResolution ?? undefined,
+            maxResolution: feature.maxResolution ?? undefined,
+            zIndex: feature.zIndex,
+          }),
+        );
+      } else {
+        console.error('unknown feature.type:', feature.type, feature, baseFeature !== feature ? baseFeature : '');
+      }
     });
+    return layers;
   }
 }

--- a/src/app/sidebar/sidebar/sidebar.component.css
+++ b/src/app/sidebar/sidebar/sidebar.component.css
@@ -47,3 +47,8 @@ mat-slider {
 .button-download {
   margin-bottom: 1rem;
 }
+
+.material-icons {
+  /*needed as not match for 'visibility_on'*/
+  width: 24px;
+}

--- a/src/app/sidebar/sidebar/sidebar.component.html
+++ b/src/app/sidebar/sidebar/sidebar.component.html
@@ -60,13 +60,14 @@
             <div class="titleRow">
               <div class="title">{{ item.label }}</div>
               <i (click)="showLegend(item)" class="material-icons">info</i>
-              <i (click)="mapState.toggleFeature(item, index)" class="material-icons">visibility_off</i>
+              <i (click)="mapState.toggleFeature(item, index)" *ngIf="!item.hidden" class="material-icons">visibility_off</i>
+              <i (click)="mapState.toggleFeature(item, index)" *ngIf="item.hidden" class="material-icons">visibility_on</i>
               <i (click)="mapState.removeFeature(index)" class="material-icons">remove_circle_outline</i>
               <i (click)="mapState.sortFeatureUp(index)" *ngIf="!first" class="material-icons">arrow_upward</i>
               <i (click)="mapState.sortFeatureDown(index)" *ngIf="!last" class="material-icons">arrow_downward</i>
             </div>
             <div>
-              <mat-slider [max]="1" [min]="0" [step]="0.1">
+              <mat-slider [max]="1" [min]="0" [step]="0.1" [disabled]="item.hidden">
                 <input matSliderThumb [ngModel]="item.opacity" (ngModelChange)="mapState.setFeatureOpacity(index, $event)" />
               </mat-slider>
             </div>

--- a/src/app/sidebar/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar/sidebar.component.ts
@@ -48,8 +48,9 @@ export class SidebarComponent {
     private http: HttpClient,
   ) {
     const allFeatures$ = geoAdminService.getFeatures().pipe(
-      share(),
       map((features) => Object.values(features)),
+      map((features) => features.filter((f) => !f['parentLayerId'])),
+      share(),
     );
     const availableFeatures$: Observable<GeoFeature[]> = combineLatest([allFeatures$, mapState.observeSelectedFeatures$()]).pipe(
       map(([source, selected]) => {

--- a/src/app/state/state.service.ts
+++ b/src/app/state/state.service.ts
@@ -508,7 +508,7 @@ export class ZsMapStateService {
     this.updateDisplayState((draft) => {
       let maxIndex = Math.max(...(draft.features.map((f) => f.zIndex).filter(Boolean) as number[]));
       maxIndex = Number.isInteger(maxIndex) ? maxIndex + 1 : 0;
-      draft.features.unshift({ ...feature, opacity: 0.75, deleted: false, zIndex: maxIndex });
+      draft.features.unshift({ ...feature, deleted: false, zIndex: maxIndex });
     });
   }
 
@@ -570,8 +570,10 @@ export class ZsMapStateService {
   }
 
   public toggleFeature(item: GeoFeature, index: number) {
-    const opacity = item.opacity > 0 ? 0 : 0.75;
-    this.setFeatureOpacity(index, opacity);
+    const hidden = !item.hidden;
+    this.updateDisplayState((draft) => {
+      draft.features[index].hidden = hidden;
+    });
   }
 
   public getActiveLayerState(): ZsMapLayerState | undefined {


### PR DESCRIPTION
The geoAdmin informations have wmts, wms and aggregate layer types.
This change allow to use all of them.

It also fixes issues with base layer change if an additional layer is added.

To prevent unneeded tile downloads the layers are set to visible = false if "hide" is clicked or opacity = 0

It also add the layer specific attribution defined by the api.
The make sure this informations (and also the layer info popup) are sanitized.

The attribution for the layers are not visible with this change.
But adding the OpenLayers element for that is part of:
https://github.com/zskarte/zskarte-client/pull/404