### PR TITLE
A tweak in the ngsw-config.json for the caching.

### DIFF
--- a/ngsw-config.json
+++ b/ngsw-config.json
@@ -17,13 +17,23 @@
     },
     {
       "name": "assets",
-      "installMode": "lazy",
+      "installMode": "prefetch",
       "updateMode": "prefetch",
       "resources": {
         "files": [
           "/assets/**",
-          "/*.(svg|cur|jpg|jpeg|png|apng|webp|avif|gif|otf|ttf|woff|woff2)",
+          "/*.(svg|cur|jpg|jpeg|png|apng|webp|avif|gif)",
           "/*.js"
+        ]
+      }
+    },
+    {
+      "name": "fonts",
+      "installMode": "lazy",
+      "updateMode": "prefetch",
+      "resources": {
+        "files": [
+          "/*.(otf|ttf|woff|woff2)"
         ]
       }
     }


### PR DESCRIPTION
### Description

Changed the `installMode` in `ngsw-config.json` from `lazy` to `prefetch`. This change will cause all resources to be fetched and cached when the app is installed, rather than waiting until they're needed. This will enhance the offline experience for users, as all resources will be available offline after the app is installed.

### Type of Change

This is an enhancement that affects offline usage. It does not introduce any new features or fix any bugs, but it will cause the app to take longer to load one  the user's device.

### How Has This Been Tested?

Tested by installing the app and verifying that all resources are available while offline.