### PR TITLE
readme clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ Please note, that this application integrates several different map provider ser
 
 ### Development server
 
-Run `yarn start` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
+Run `yarn install` to install dependencies.
+
+Run `yarn start` for a dev server. The Angular server will announce itself, usually at `http://localhost:4200/`.
+
+The app will automatically reload if you change any of the source files.
 
 To use your own local backend (https://github.com/zskarte/zskarte-server) run `yarn start:local`.
 


### PR DESCRIPTION
# Description
Clarified the installation process, implied that the angular live server will not always run on the same port.

# Type of Change
README change

# How Has This Been Tested?
\-
