### PR TITLE
feat/offline warning to prevent login and dataloss

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -73,6 +73,8 @@ import { DrawDialogComponent } from './draw-dialog/draw-dialog.component';
 import { ServiceWorkerModule } from '@angular/service-worker';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { IncidentSelectComponent } from './incident-select/incident-select.component';
+import { OfflineDialogComponent } from './offline-dialog/offline-dialog.component';
+
 
 registerLocaleData(localeCH);
 
@@ -123,6 +125,7 @@ export function appFactory(session: SessionService, sync: SyncService, state: Zs
     SidebarMenuComponent,
     DrawDialogComponent,
     IncidentSelectComponent,
+    OfflineDialogComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -1,4 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, HostListener } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { OfflineDialogComponent } from '../offline-dialog/offline-dialog.component';
 
 @Component({
   selector: 'app-map',
@@ -6,4 +8,29 @@ import { Component } from '@angular/core';
   styleUrls: ['./map.component.scss'],
 })
 // skipcq: JS-0327
-export class MapComponent {}
+export class MapComponent {
+
+  constructor(private dialog: MatDialog) {
+    localStorage.setItem("TriedReloading", "FALSE")
+  }
+
+
+  @HostListener('window:beforeunload', ['$event'])
+  handleBeforeUnload(event: BeforeUnloadEvent): void {
+
+    if (!navigator.onLine && window.localStorage.getItem("TriedReloading") === "FALSE") {
+      event.preventDefault();
+
+      const dialogRef = this.dialog.open(OfflineDialogComponent);
+
+      dialogRef.afterClosed().subscribe(confirmed => {
+        if (confirmed) {
+          localStorage.setItem("TriedReloading", "TRUE")
+          window.removeEventListener('beforeunload', this.handleBeforeUnload.bind(this));
+          window.location.assign(window.location.href)
+        }
+      });
+    }
+  }
+
+}

--- a/src/app/offline-dialog/offline-dialog.component.html
+++ b/src/app/offline-dialog/offline-dialog.component.html
@@ -1,0 +1,8 @@
+<h1 mat-dialog-title [innerText]="i18n.get('offlineDialogTitle')"></h1>
+<div mat-dialog-content>
+  <p [innerText]="i18n.get('offlineDialogMain')"></p>
+</div>
+<div mat-dialog-actions>
+  <button mat-button (click)="onCancel()" [innerText]="i18n.get('cancel')"></button>
+  <button mat-button (click)="onConfirm()" [innerText]="i18n.get('confirm')"></button>
+</div>

--- a/src/app/offline-dialog/offline-dialog.component.scss
+++ b/src/app/offline-dialog/offline-dialog.component.scss
@@ -1,0 +1,7 @@
+h1 {
+    margin: 0;
+}
+div[mat-dialog-actions] {
+    display: flex;
+    justify-content: flex-end;
+}

--- a/src/app/offline-dialog/offline-dialog.component.spec.ts
+++ b/src/app/offline-dialog/offline-dialog.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OfflineDialogComponent } from './offline-dialog.component';
+
+describe('OfflineDialogComponent', () => {
+  let component: OfflineDialogComponent;
+  let fixture: ComponentFixture<OfflineDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [OfflineDialogComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(OfflineDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/offline-dialog/offline-dialog.component.ts
+++ b/src/app/offline-dialog/offline-dialog.component.ts
@@ -1,0 +1,21 @@
+import { Component } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+import { I18NService } from '../state/i18n.service';
+
+@Component({
+  selector: 'app-offline-dialog',
+  templateUrl: './offline-dialog.component.html',
+  styleUrl: './offline-dialog.component.scss'
+})
+export class OfflineDialogComponent {
+  
+  constructor(public dialogRef: MatDialogRef<OfflineDialogComponent>, public i18n: I18NService, ) {}
+  
+  onCancel(): void {
+    this.dialogRef.close(false);
+  }
+
+  onConfirm(): void {
+    this.dialogRef.close(true);
+  }
+}

--- a/src/app/state/i18n.service.ts
+++ b/src/app/state/i18n.service.ts
@@ -1314,6 +1314,16 @@ export class I18NService {
       en: 'Affected Persons',
       fr: 'Persones affectés',
     },
+    offlineDialogTitle: {
+      de: 'Offline-Warnung',
+      en: "Offline Warning",
+      fr: "Avertissement hors ligne",
+    },
+    offlineDialogMain: {
+      de: 'Sie sind derzeit offline. Wenn Sie die Seite aktualisieren oder verlassen, werden Sie abgemeldet und können sich erst wieder anmelden, wenn Sie eine Internetverbindung haben. Sind Sie sicher, dass Sie fortfahren möchten?',
+      en: "You are currently offline. Refreshing or exiting the page will log you out and you won't be able to log back in until you have an internet connection. Are you sure you want to proceed?",
+      fr: "Vous êtes actuellement hors ligne. Actualiser ou quitter la page vous déconnectera et vous ne pourrez pas vous reconnecter tant que vous ne disposerez pas d'une connexion internet. Êtes-vous sûr de vouloir continuer ?",
+    },
   };
 
   public getLabelForSign(sign: Sign): string {


### PR DESCRIPTION
# Description
Added a Warning when trying to refresh/exit map when the user has no connexion. Otherwise he won't be able to use the map offline since he has to log back in. 

# Type of Change
Feature

# How has it been Tested?
Tested locally on my machine and usage reviewed.