### PR TITLE
Improve local map handling

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "Node.js & TypeScript",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-20",
+  "mounts": ["source=${localWorkspaceFolder}/node_modules,target=/app/node_modules,type=bind"],
+  "postCreateCommand": "yarn install --none-interactive",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+      },
+      "extensions": ["angular.ng-template", "dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+    }
+  },
+  "appPort": [4300],
+  "forwardPorts": [4300]
+}

--- a/ngsw-config.json
+++ b/ngsw-config.json
@@ -11,7 +11,8 @@
           "/index.html",
           "/manifest.webmanifest",
           "/*.css",
-          "/main.*.js"
+          "/main.*.js",
+          "/assets/map-style.json"
         ]
       }
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "ng:serve": "ng serve --port 4300",
-    "ng:serve:dev": "ng serve --port 4300 --configuration development-local",
+    "ng:serve:dev": "ng serve --port 4300 --host 0.0.0.0 --configuration development-local",
     "ng:serve:local": "ng serve --port 4300 --configuration local",
     "ng:serve:e2e": "npm-run-all -p ng:serve:dev wait",
     "ng:serve:prod": "ng serve --port 4300 --configuration production",

--- a/src/app/sidebar/sidebar/sidebar.component.css
+++ b/src/app/sidebar/sidebar/sidebar.component.css
@@ -44,6 +44,26 @@ mat-slider {
   width: 100%;
 }
 
+.layer-slider {
+  margin-left: 0;
+  width: 100%;
+}
+
+.map-progress {
+  margin-top:  1rem;
+  margin-bottom: 2rem;
+  width: 100%;
+}
+
 .button-download {
   margin-bottom: 1rem;
+  margin-right: 1rem;
+}
+
+.button-cancel, .button-upload, .button-remove {
+  margin-bottom: 1rem;
+}
+
+.mapfile-input {
+  display: none;
 }

--- a/src/app/sidebar/sidebar/sidebar.component.html
+++ b/src/app/sidebar/sidebar/sidebar.component.html
@@ -11,7 +11,7 @@
           <div class="title">{{ layer.observeName() | async }}</div>
         </div>
         <div>
-          <mat-slider [max]="1" [min]="0" [step]="0.1" style="width: 100%">
+          <mat-slider [max]="1" [min]="0" [step]="0.1" class="layer-slider" >
             <input matSliderThumb [ngModel]="mapState.observeMapOpacity() | async" (ngModelChange)="mapState.setMapOpacity($event)" />
           </mat-slider>
         </div>
@@ -20,15 +20,18 @@
             <div>
               @switch (mapDownloadStates[layer.key]) {
                 @case ('loading') {
-                  <mat-progress-bar color="primary" mode="indeterminate" />
+                  <button mat-flat-button color="warn" class="button-cancel" (click)="cancelDownloadMap(layer.key)" >{{ i18n.get('cancel') }}</button>
+                  <mat-progress-bar color="primary" class="map-progress" mode="determinate" [value]="mapProgress" />
                 }
                 @case ('downloaded') {
-                  <button mat-flat-button color="warn" color="warn" class="buttonDownload" (click)="removeLocalMap(layer.key)">
-                    Remove
+                  <button mat-flat-button color="warn" class="button-remove" (click)="removeLocalMap(layer.key)">
+                    {{ i18n.get('removeSymbol') }}
                   </button>
                 }
                 @default {
-                  <button mat-flat-button color="primary" class="button-download" (click)="downloadMap(layer.key)">Download</button>
+                  <button mat-flat-button color="primary" class="button-download" (click)="downloadMap(layer.key)">{{ i18n.get('download') }}</button>
+                  <button mat-flat-button color="primary" class="button-upload" (click)="mapUpload.click()">{{ i18n.get('upload') }}</button>
+                  <input type="file" class="mapfile-input" accept=".pmtiles" (change)="uploadMap($event, layer.key)" #mapUpload>
                 }
               }
             </div>

--- a/src/app/sidebar/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar/sidebar.component.ts
@@ -17,9 +17,9 @@ import { HttpClient, HttpEventType, HttpResponse } from '@angular/common/http';
   styleUrls: ['./sidebar.component.css'],
 })
 export class SidebarComponent {
-  mapProgress: number = 0;
-  private fileReader: FileReader = new FileReader();
-  private fileReadAborted: boolean = false;
+  mapProgress = 0;
+  private fileReader = new FileReader();
+  private fileReadAborted = false;
   private subscriptions = new Map<ZsMapStateSource, Subscription>();
 
   mapSources = Object.values(ZsMapStateSource)

--- a/src/app/sidebar/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar/sidebar.component.ts
@@ -1,15 +1,15 @@
-import { Component } from '@angular/core';
+import { Component, ChangeDetectorRef } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MapLegendDisplayComponent } from '../map-legend-display/map-legend-display.component';
 import { ZsMapStateService } from 'src/app/state/state.service';
 import { ZsMapStateSource, zsMapStateSourceToDownloadUrl } from 'src/app/state/interfaces';
 import { GeoadminService } from 'src/app/core/geoadmin.service';
 import { GeoFeature } from '../../core/entity/geoFeature';
-import { combineLatest, lastValueFrom, map, Observable, share, startWith } from 'rxjs';
+import { combineLatest, Subscription, Subscriber, map, Observable, share, startWith } from 'rxjs';
 import { FormControl } from '@angular/forms';
 import { I18NService } from '../../state/i18n.service';
-import { db, LocalMapState } from '../../db/db';
-import { HttpClient } from '@angular/common/http';
+import { db, LocalMapMeta, LocalMapState } from '../../db/db';
+import { HttpClient, HttpEventType, HttpResponse } from '@angular/common/http';
 
 @Component({
   selector: 'app-sidebar',
@@ -17,6 +17,11 @@ import { HttpClient } from '@angular/common/http';
   styleUrls: ['./sidebar.component.css'],
 })
 export class SidebarComponent {
+  mapProgress: number = 0;
+  private fileReader: FileReader = new FileReader();
+  private fileReadAborted: boolean = false;
+  private subscriptions = new Map<ZsMapStateSource, Subscription>();
+
   mapSources = Object.values(ZsMapStateSource)
     .map((key) => ({
       key,
@@ -46,6 +51,7 @@ export class SidebarComponent {
     public i18n: I18NService,
     public dialog: MatDialog,
     private http: HttpClient,
+    private cdRef: ChangeDetectorRef,
   ) {
     const allFeatures$ = geoAdminService.getFeatures().pipe(
       share(),
@@ -114,38 +120,156 @@ export class SidebarComponent {
   async downloadMap(map: ZsMapStateSource) {
     this.mapDownloadStates[map] = 'loading';
     const downloadUrl = zsMapStateSourceToDownloadUrl[map];
-    let localMapMeta = await db.localMapMeta.get(downloadUrl);
-    if (!localMapMeta) {
-      localMapMeta = {
-        url: downloadUrl,
-        map,
-        mapStatus: this.mapDownloadStates[map],
-        objectUrl: undefined,
-        mapStyle: undefined,
-      };
-      await db.localMapMeta.put(localMapMeta);
-    }
-    let localMapBlob = await db.localMapBlobs.get(localMapMeta.url);
+    const localMapMeta = (await db.localMapMeta.get(downloadUrl)) || {
+      url: downloadUrl,
+      map,
+      mapStatus: 'missing',
+      objectUrl: undefined,
+      mapStyle: undefined,
+    };
+
+    await db.localMapMeta.put(localMapMeta);
+
+    const localMapBlob = await db.localMapBlobs.get(localMapMeta.url);
     if (!localMapBlob) {
-      try {
-        const [localMap, mapStyle] = await Promise.all([
-          lastValueFrom(this.http.get(downloadUrl, { responseType: 'blob' })),
-          fetch('/assets/map-style.json').then((res) => res.text()),
-        ]);
-        localMapBlob = {
-          url: localMapMeta.url,
-          data: localMap,
-        };
-        await db.localMapBlobs.add(localMapBlob);
-        localMapMeta.mapStyle = mapStyle;
-        localMapMeta.objectUrl = undefined;
-        localMapMeta.mapStatus = 'downloaded';
-      } catch (e) {
+      const mapRequest = this.http
+        .get(downloadUrl, {
+          responseType: 'blob',
+          reportProgress: true,
+          observe: 'events',
+        })
+        .subscribe({
+          next: async (event) => {
+            if (event.type === HttpEventType.DownloadProgress) {
+              this.mapProgress = Math.round((100 * event.loaded) / (event.total ?? 1));
+              this.cdRef.detectChanges();
+            } else if (event instanceof HttpResponse) {
+              this.subscriptions.get(map)?.unsubscribe();
+              const localMap = event.body as Blob;
+              await this.blobToStorage(map, localMap, localMapMeta);
+            }
+          },
+          error: async () => {
+            this.subscriptions.get(map)?.unsubscribe();
+            localMapMeta.mapStatus = 'missing';
+            this.mapProgress = 0;
+            this.mapDownloadStates[map] = localMapMeta.mapStatus;
+            await db.localMapMeta.put(localMapMeta);
+          },
+        });
+
+      // Store the subscription so it can be cancelled later
+      this.subscriptions.set(map, mapRequest);
+    }
+  }
+
+  async cancelDownloadMap(map: ZsMapStateSource) {
+    this.mapDownloadStates[map] = 'missing';
+    if (this.subscriptions.has(map)) {
+      this.subscriptions.get(map)?.unsubscribe();
+      this.subscriptions.delete(map);
+      this.mapProgress = 0;
+      const downloadUrl = zsMapStateSourceToDownloadUrl[map];
+      const localMapMeta = await db.localMapMeta.get(downloadUrl);
+      if (localMapMeta) {
         localMapMeta.mapStatus = 'missing';
+        await db.localMapMeta.put(localMapMeta);
       }
+    }
+  }
+
+  async uploadMap(event: Event, map: ZsMapStateSource) {
+    if (!event.target) return;
+
+    this.mapDownloadStates[map] = 'loading';
+    const downloadUrl = zsMapStateSourceToDownloadUrl[map];
+    const localMapMeta = (await db.localMapMeta.get(downloadUrl)) || {
+      url: downloadUrl,
+      map,
+      mapStatus: 'missing',
+      objectUrl: undefined,
+      mapStyle: undefined,
+    };
+
+    await db.localMapMeta.put(localMapMeta);
+
+    const file = event.target['files'][0] as Blob;
+    this.subscriptions.get(map)?.unsubscribe();
+
+    const mapRequest = this.readFile(file).subscribe({
+      next: (percentDone) => {
+        this.mapProgress = percentDone;
+        this.cdRef.detectChanges();
+      },
+      complete: async () => {
+        this.subscriptions.get(map)?.unsubscribe();
+        if (this.fileReadAborted) {
+          this.mapProgress = 0;
+          return;
+        }
+        const blob = new Blob([this.fileReader.result as ArrayBuffer]);
+        await this.blobToStorage(map, blob, localMapMeta);
+      },
+      error: async () => {
+        this.subscriptions.get(map)?.unsubscribe();
+        localMapMeta.mapStatus = 'missing';
+        this.mapDownloadStates[map] = localMapMeta.mapStatus;
+        await db.localMapMeta.put(localMapMeta);
+      },
+    });
+    this.subscriptions.set(map, mapRequest);
+  }
+
+  readFile(file: Blob): Observable<number> {
+    return new Observable((subscriber: Subscriber<number>) => {
+      this.fileReader = new FileReader();
+      this.fileReadAborted = false;
+
+      this.fileReader.onprogress = (event) => {
+        if (event.lengthComputable) {
+          const progress = Math.round((event.loaded / event.total) * 100);
+          subscriber.next(progress);
+        }
+      };
+
+      this.fileReader.onloadend = () => {
+        subscriber.complete();
+      };
+
+      this.fileReader.onerror = () => {
+        subscriber.error('Failed to read file.');
+      };
+
+      this.fileReader.readAsArrayBuffer(file);
+
+      // Return cleanup function
+      return () => {
+        if (this.fileReader.readyState === FileReader.LOADING) {
+          this.fileReader.abort();
+          this.fileReadAborted = true;
+        }
+      };
+    });
+  }
+
+  private async blobToStorage(map: ZsMapStateSource, blob: Blob, localMapMeta: LocalMapMeta) {
+    try {
+      const mapStyleResponse = await fetch('/assets/map-style.json');
+      const mapStyle = await mapStyleResponse.json();
+      await db.localMapBlobs.add({
+        url: localMapMeta.url,
+        data: blob,
+      });
+      localMapMeta.mapStatus = 'downloaded';
+      localMapMeta.mapStyle = mapStyle;
+      localMapMeta.objectUrl = undefined;
+    } catch (e) {
+      localMapMeta.mapStatus = 'missing';
+      this.mapProgress = 0;
     }
     this.mapDownloadStates[map] = localMapMeta.mapStatus;
     await db.localMapMeta.put(localMapMeta);
+    this.cdRef.detectChanges();
   }
 
   async removeLocalMap(map: ZsMapStateSource): Promise<void> {
@@ -159,5 +283,7 @@ export class SidebarComponent {
       URL.revokeObjectURL(objectUrl);
     }
     this.mapDownloadStates[map] = 'missing';
+    this.mapProgress = 0;
+    this.cdRef.detectChanges();
   }
 }

--- a/src/app/state/i18n.service.ts
+++ b/src/app/state/i18n.service.ts
@@ -183,6 +183,11 @@ export class I18NService {
       en: 'Download',
       fr: 'Télécharger',
     },
+    upload: {
+      de: 'Hochladen',
+      en: 'Upload',
+      fr: 'Uploader',
+    },
     exportOperation: {
       de: 'Ereignis exportieren',
       en: 'Export event',


### PR DESCRIPTION
Hi,

This PR improves how the `zskarte` handles local map data:
- added an option to upload a local `.pmtiles` file. This allows you to upload the map locally if you suddenly loose connection to the internet and didn't download the local map earlier. 
- added a cancel button to make both download and upload cancellable.
- made the progress bar determinate

In 87c0ec40561a5d07754707f587ff3c0ace7ff925 I've added the `devcontainer.json` which I used so I can work using github codespaces. If you don't want this in your codebase, let me know and I'll remove it.