### PR TITLE
feat(unarchive): allow to view archived operations and unarchiv them

### DIFF
--- a/packages/app/src/app/incident-select/incident-select.component.html
+++ b/packages/app/src/app/incident-select/incident-select.component.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="outline">
+<mat-form-field appearance="outline" subscriptSizing="dynamic">
   <mat-label>{{ i18n.get('eventState') }}</mat-label>
   <mat-select [formControl]="incidents" multiple>
     <mat-select-trigger>

--- a/packages/app/src/app/incident-select/incident-select.component.ts
+++ b/packages/app/src/app/incident-select/incident-select.component.ts
@@ -30,6 +30,14 @@ export class IncidentSelectComponent {
   get values(): number[] {
     return this.incidents.value?.map((o) => o) || [];
   }
+  @Input()
+  set disabled(value: boolean) {
+    if (value) {
+      this.incidents.disable();
+    } else {
+      this.incidents.enable();
+    }
+  }
   readonly valuesChange = output<number[]>();
   incidents = new FormControl<number[]>([]);
   incidentList = new BehaviorSubject<{ id: number | undefined; icon: string | undefined; name: string | undefined }[]>([]);
@@ -48,6 +56,9 @@ export class IncidentSelectComponent {
     this.incidents.valueChanges.pipe(takeUntilDestroyed()).subscribe((values) => {
       this.valuesChange.emit(values?.map((o) => o) || []);
     });
+    if (this.disabled) {
+      this.incidents.disable();
+    }
   }
 
   getIncident(id: number | undefined) {

--- a/packages/app/src/app/session/operations/operation.service.ts
+++ b/packages/app/src/app/session/operations/operation.service.ts
@@ -9,7 +9,7 @@ import { BehaviorSubject } from 'rxjs';
 import { IpcService } from '../../ipc/ipc.service';
 import { MatDialog } from '@angular/material/dialog';
 import { db } from '../../db/db';
-import { IZsMapOperation, IZSMapOperationMapLayers, IZsMapState, ZsMapLayerStateType } from '@zskarte/types';
+import { IZsMapOperation, ZsOperationStatus, IZSMapOperationMapLayers, IZsMapState, ZsMapLayerStateType } from '@zskarte/types';
 
 @Injectable({
   providedIn: 'root',
@@ -27,7 +27,7 @@ export class OperationService {
     this._session = sessionService;
   }
 
-  public async deleteOperation(operation: IZsMapOperation): Promise<void> {
+  public async archiveOperation(operation: IZsMapOperation): Promise<void> {
     if (!operation || !operation?.id) {
       return;
     }
@@ -38,7 +38,21 @@ export class OperationService {
     } else {
       await this._api.put(`/api/operations/${operation.id}/archive`, null);
     }
-    await this.reload();
+    await this.reload('active');
+  }
+
+  public async unarchiveOperation(operation: IZsMapOperation): Promise<void> {
+    if (!operation || !operation?.id) {
+      return;
+    }
+
+    operation.status = 'active';
+    if (operation?.id < 0) {
+      await OperationService.persistLocalOpertaion(operation);
+    } else {
+      await this._api.put(`/api/operations/${operation.id}/unarchive`, null);
+    }
+    await this.reload('archived');
   }
 
   public async saveOperation(operation: IZsMapOperation): Promise<void> {
@@ -47,7 +61,7 @@ export class OperationService {
     } else {
       await this.insertOperation(operation);
     }
-    await this.reload();
+    await this.reload('active');
     this.operationToEdit.next(undefined);
   }
 
@@ -92,30 +106,28 @@ export class OperationService {
     await db.localOperation.put(operation);
   }
 
-  private static getLocalOperations() {
-    return db.localOperation.where('status').equals('active').toArray();
+  private static getLocalOperations(status: ZsOperationStatus) {
+    return db.localOperation.where('status').equals(status).toArray();
   }
 
-  public async loadLocal(): Promise<void> {
-    const localOperations = await OperationService.getLocalOperations();
+  public async loadLocal(status: ZsOperationStatus): Promise<void> {
+    const localOperations = await OperationService.getLocalOperations(status);
     if (!localOperations) return;
     this.operations.next(localOperations);
   }
 
-  public async reload(): Promise<void> {
+  public async reload(status: ZsOperationStatus): Promise<void> {
     let operations: IZsMapOperation[] = [];
-    const localOperations = await OperationService.getLocalOperations();
+    const localOperations = await OperationService.getLocalOperations(status);
     if (localOperations) {
       operations = localOperations;
     }
     if (!this._session.isWorkLocal()) {
-      const { error, result: savedOperations } = await this._api.get<IZsMapOperation[]>('/api/operations/overview?status=active');
-      if (!error && savedOperations) {
+      const { error, result: savedOperations } = await this._api.get<IZsMapOperation[]>(`/api/operations/overview?status=${status}`);
+      if (!error && savedOperations != undefined) {
         operations = [...operations, ...savedOperations];
       }
-      if (operations.length > 0) {
-        this.operations.next(operations);
-      }
+      this.operations.next(operations);
     } else {
       this.operations.next(operations);
     }

--- a/packages/app/src/app/session/operations/operation.service.ts
+++ b/packages/app/src/app/session/operations/operation.service.ts
@@ -9,7 +9,13 @@ import { BehaviorSubject } from 'rxjs';
 import { IpcService } from '../../ipc/ipc.service';
 import { MatDialog } from '@angular/material/dialog';
 import { db } from '../../db/db';
-import { IZsMapOperation, ZsOperationStatus, IZSMapOperationMapLayers, IZsMapState, ZsMapLayerStateType } from '@zskarte/types';
+import {
+  IZsMapOperation,
+  ZsOperationStatus,
+  IZSMapOperationMapLayers,
+  IZsMapState,
+  ZsMapLayerStateType,
+} from '@zskarte/types';
 
 @Injectable({
   providedIn: 'root',
@@ -78,7 +84,9 @@ export class OperationService {
       operation.id = minId - 1;
       await db.localOperation.add(operation);
     } else {
-      await this._api.post('/api/operations', { data: { ...operation, organization: this._session.getOrganizationId() } });
+      await this._api.post('/api/operations', {
+        data: { ...operation, organization: this._session.getOrganizationId() },
+      });
     }
   }
 
@@ -123,8 +131,10 @@ export class OperationService {
       operations = localOperations;
     }
     if (!this._session.isWorkLocal()) {
-      const { error, result: savedOperations } = await this._api.get<IZsMapOperation[]>(`/api/operations/overview?status=${status}`);
-      if (!error && savedOperations != undefined) {
+      const { error, result: savedOperations } = await this._api.get<IZsMapOperation[]>(
+        `/api/operations/overview?status=${status}`,
+      );
+      if (!error && savedOperations !== undefined) {
         operations = [...operations, ...savedOperations];
       }
       this.operations.next(operations);

--- a/packages/app/src/app/session/operations/operations.component.html
+++ b/packages/app/src/app/session/operations/operations.component.html
@@ -33,6 +33,15 @@
         <mat-card-actions class="operations-actions">
           <button mat-flat-button color="primary" (click)="operationService.createOperation()">{{ i18n.get('newScenario') }}</button>
           <button mat-flat-button (click)="operationService.importOperation()">{{ i18n.get('importScenario') }}</button>
+          @if (showOpStatus == 'active') {
+            <button mat-icon-button (click)="showArchivedScenarios()" [attr.aria-label]="i18n.get('showArchivedScenarios')" [title]="i18n.get('showArchivedScenarios')">
+              <mat-icon>archive</mat-icon>
+            </button>
+          } @else {
+            <button mat-icon-button (click)="showActiveScenarios()" [attr.aria-label]="i18n.get('showActiveScenarios')" [title]="i18n.get('showActiveScenarios')">
+              <mat-icon>unarchive</mat-icon>
+            </button>
+          }
         </mat-card-actions>
         <mat-divider></mat-divider>
       </mat-card-header>
@@ -40,7 +49,7 @@
         @for (o of operationService.operations | async; track o) {
           <mat-action-list>
             <div class="operation-list-item">
-              <mat-list-item role="button" (click)="selectOperation(o)">
+              <mat-list-item role="button" [lines]="0 + (o.description ? 1 : 0) + (showOpStatus != 'active' ? 1 : 0)" (click)="selectOperation(o)">
                 <div matListItemMeta class="operation-list-item-meta">
                   @if ((o.id ?? 0) < 0) {
                     <mat-icon title="{{ i18n.get('localOperation') }}">cloud_done</mat-icon>
@@ -50,23 +59,35 @@
                 @if (o.description) {
                   <div matListItemLine>{{ o.description }}</div>
                 }
+                @if (showOpStatus != 'active') {
+                  <div matListItemLine>{{ i18n.get('lastModified') }} {{ o.updatedAt | date:'dd.MM.YYYY HH:mm' }}</div>
+                }
               </mat-list-item>
               <button mat-icon-button [matMenuTriggerFor]="menu" aria-label="More options">
                 <mat-icon>more_vert</mat-icon>
               </button>
               <mat-menu #menu="matMenu">
-                <button mat-menu-item (click)="operationService.operationToEdit.next(o)">
-                  <mat-icon aria-hidden="false">edit_note</mat-icon>
-                  Ereignis umbenennen
-                </button>
+                @if (o.status == 'active') {
+                  <button mat-menu-item (click)="operationService.operationToEdit.next(o)">
+                    <mat-icon aria-hidden="false">edit_note</mat-icon>
+                    Ereignis umbenennen
+                  </button>
+                }
                 <button mat-menu-item (click)="operationService.exportOperation(o.id)">
                   <mat-icon aria-hidden="false" [attr.aria-label]="i18n.get('exportOperation')">save</mat-icon>
                   {{ i18n.get('exportOperation') }}
                 </button>
-                <button mat-menu-item (click)="operationService.deleteOperation(o)">
-                  <mat-icon aria-hidden="false" [attr.aria-label]="i18n.get('deleteOperation')">delete</mat-icon>
-                  {{ i18n.get('deleteOperation') }}
-                </button>
+                @if (o.status == 'active') {
+                  <button mat-menu-item (click)="operationService.archiveOperation(o)">
+                    <mat-icon aria-hidden="false" [attr.aria-label]="i18n.get('archiveOperation')">archive</mat-icon>
+                    {{ i18n.get('archiveOperation') }}
+                  </button>
+                } @else {
+                  <button mat-menu-item (click)="operationService.unarchiveOperation(o)">
+                    <mat-icon aria-hidden="false" [attr.aria-label]="i18n.get('unarchiveOperation')">unarchive</mat-icon>
+                    {{ i18n.get('unarchiveOperation') }}
+                  </button>
+                }
               </mat-menu>
             </div>
           </mat-action-list>

--- a/packages/app/src/app/session/operations/operations.component.ts
+++ b/packages/app/src/app/session/operations/operations.component.ts
@@ -1,14 +1,14 @@
 import { Component, OnDestroy, inject } from '@angular/core';
 import { Subject, firstValueFrom, takeUntil } from 'rxjs';
 import { SessionService } from '../session.service';
-import { IZsMapOperation } from '@zskarte/types';
+import { IZsMapOperation, ZsOperationStatus } from '@zskarte/types';
 import { I18NService } from '../../state/i18n.service';
 import { OperationService } from './operation.service';
 import { ActivatedRoute } from '@angular/router';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatCardModule } from '@angular/material/card';
 import { MatDividerModule } from '@angular/material/divider';
-import { AsyncPipe } from '@angular/common';
+import { AsyncPipe, DatePipe } from '@angular/common';
 import { MatActionList, MatListItem } from '@angular/material/list';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
@@ -26,6 +26,7 @@ import { MatInputModule } from '@angular/material/input';
     MatCardModule,
     MatDividerModule,
     AsyncPipe,
+    DatePipe,
     MatActionList,
     MatIconModule,
     MatMenuModule,
@@ -43,17 +44,18 @@ export class OperationsComponent implements OnDestroy {
   private route = inject(ActivatedRoute);
 
   private _ngUnsubscribe = new Subject<void>();
+  public showOpStatus: ZsOperationStatus = 'active';
 
   constructor() {
     const route = this.route;
 
-    this.operationService.loadLocal();
+    this.operationService.loadLocal(this.showOpStatus);
     this._session
       .observeOrganizationId()
       .pipe(takeUntil(this._ngUnsubscribe))
       .subscribe(async (organizationId) => {
         if (organizationId) {
-          await this.operationService.reload();
+          await this.operationService.reload(this.showOpStatus);
         }
       });
     //select operationId if set as parameter and have access to
@@ -87,5 +89,15 @@ export class OperationsComponent implements OnDestroy {
 
   public async logout(): Promise<void> {
     await this._session.logout();
+  }
+
+  public async showActiveScenarios(): Promise<void> {
+    this.showOpStatus = 'active';
+    await this.operationService.reload(this.showOpStatus);
+  }
+
+  public async showArchivedScenarios(): Promise<void> {
+    this.showOpStatus = 'archived';
+    await this.operationService.reload(this.showOpStatus);
   }
 }

--- a/packages/app/src/app/session/session.service.ts
+++ b/packages/app/src/app/session/session.service.ts
@@ -555,6 +555,18 @@ export class SessionService {
     return !(this._session.value?.permission === PermissionType.READ);
   }
 
+  public observeIsArchived(): Observable<boolean> {
+    return this._session.pipe(
+      map((session) => {
+        return session?.operation?.status === 'archived';
+      }),
+    );
+  }
+
+  public isArchived(): boolean {
+    return this._session.value?.operation?.status === 'archived';
+  }
+
   public getDefaultMapCenter(): number[] {
     if (coordinatesProjection && mercatorProjection) {
       if (this._session.value?.defaultLatitude && this._session.value?.defaultLongitude) {

--- a/packages/app/src/app/sidebar/sidebar-menu/sidebar-menu.component.html
+++ b/packages/app/src/app/sidebar/sidebar-menu/sidebar-menu.component.html
@@ -1,5 +1,8 @@
-<app-incident-select [values]="(incidents | async) || []" (valuesChange)="updateIncidents($event)"></app-incident-select>
+<app-incident-select [values]="(incidents | async) || []" (valuesChange)="updateIncidents($event)" [disabled]="!hasWritePermission || isArchived"></app-incident-select>
 
+@if (isArchived) {
+  <p class="archived">{{ i18n.get('viewArchivedOperation') }}</p>
+}
 <mat-divider></mat-divider>
 
 <button mat-menu-item (click)="toggleHistory()" title="ALT+H">

--- a/packages/app/src/app/sidebar/sidebar-menu/sidebar-menu.component.scss
+++ b/packages/app/src/app/sidebar/sidebar-menu/sidebar-menu.component.scss
@@ -1,0 +1,5 @@
+.archived {
+  color: red;
+  padding-left: 20px;
+  padding-top: 5px;
+}

--- a/packages/app/src/app/sidebar/sidebar-menu/sidebar-menu.component.ts
+++ b/packages/app/src/app/sidebar/sidebar-menu/sidebar-menu.component.ts
@@ -56,16 +56,22 @@ export class SidebarMenuComponent {
   locales: Locale[] = LOCALES;
   protocolEntries: ProtocolEntry[] = [];
   public incidents = new BehaviorSubject<number[]>([]);
+  public hasWritePermission = false;
+  public isArchived = true;
 
   constructor() {
     this.incidents.next(this.session.getOperationEventStates() || []);
+    this.hasWritePermission = this.session.hasWritePermission();
+    this.isArchived = this.session.isArchived();
   }
 
   async updateIncidents(incidents: number[]): Promise<void> {
     const operation = this.session.getOperation();
     if (operation) {
-      operation.eventStates = incidents;
-      await this._operation.updateMeta(operation);
+      if (operation.eventStates.toString() !== incidents.toString()) {
+        operation.eventStates = incidents;
+        await this._operation.updateMeta(operation);
+      }
     }
   }
 

--- a/packages/app/src/app/state/i18n.service.ts
+++ b/packages/app/src/app/state/i18n.service.ts
@@ -189,10 +189,30 @@ export class I18NService {
       en: 'Export event',
       fr: 'Exporter événement',
     },
-    deleteOperation: {
-      de: 'Ereignis löschen',
-      en: 'Delete event',
-      fr: 'Effacer événement',
+    archiveOperation: {
+      de: 'Ereignis Archivieren',
+      en: 'Archive event',
+      fr: 'Archiver événement',
+    },
+    unarchiveOperation: {
+      de: 'Ereignis wiederherstellen',
+      en: 'Unarchive event',
+      fr: 'Désarchiver événement',
+    },
+    lastModified: {
+      de: 'Zuletzt geändert:',
+      en: 'Last modified:',
+      fr: 'Dernière modification:',
+    },
+    showArchivedScenarios: {
+      de: 'Archivierte Ereignise anzeigen',
+      en: 'View archived events',
+      fr: 'Afficher les événements archivés',
+    },
+    showActiveScenarios: {
+      de: 'Aktive Ereignise anzeigen',
+      en: 'Show active events',
+      fr: 'Afficher les événements actifs',
     },
     downloadMapCSV: {
       de: 'Als CSV exportieren',
@@ -363,6 +383,11 @@ export class I18NService {
       de: 'Aktuelle Zeichnung',
       fr: 'Dessin actuel',
       en: 'Current drawing',
+    },
+    viewArchivedOperation: {
+      de: 'Dies ist ein archiviertes Ereignis',
+      fr: 'This is an archived event',
+      en: 'Ceci est un événement archivé',
     },
     history: {
       de: 'History- / Lese-Modus',
@@ -1926,7 +1951,7 @@ export class I18NService {
       fr: 'Utilisez des couches de carte avec une fonctionnalité de recherche hors ligne.',
     },
     howtoFindSearchCapability: {
-      de: 'Kartenebene(n) mit Offline-Suchfunktion zeigen in der Liste der „Verfügbaren Ebenen“ ein Lupensymbol an und gehören zur Ebenenquelle „Freigegebene Ebenen“.',
+      de: 'Kartenebene(n) mit Offline-Suchfunktion zeigen in der Liste der „Verfügbaren Ebenen“ ein Lupensymbol an und gehören zur Ebenen Quelle „Geteilte Ebenen“.',
       en: 'Map layer(s) with offline search capability show a Magnifying glass symbol on the list of "Available layers" and they are of "Shared layers" Layer Source.',
       fr: 'Les couches de carte avec capacité de recherche hors ligne affichent un symbole de loupe sur la liste des "Couches cartographiques disponibles" et elles appartiennent à la source de couche "Couches partagées".',
     },

--- a/packages/app/src/app/state/state.service.ts
+++ b/packages/app/src/app/state/state.service.ts
@@ -990,7 +990,7 @@ export class ZsMapStateService {
   }
 
   public updateMapState(fn: (draft: IZsMapState) => void, preventPatches = false) {
-    if (!preventPatches && !this._session.hasWritePermission()) {
+    if (!preventPatches && !this._session.hasWritePermission() && this._session.isArchived()) {
       return;
     }
     const newState = produce<IZsMapState>(this._map.value || {}, fn, (patches, inversePatches) => {
@@ -1150,11 +1150,12 @@ export class ZsMapStateService {
   }
 
   observeIsReadOnly(): Observable<boolean> {
-    return merge(this.observeIsHistoryMode(), this._session.observeHasWritePermission()).pipe(
+    return merge(this.observeIsHistoryMode(), this._session.observeHasWritePermission(), this._session.observeIsArchived()).pipe(
       map(() => {
         const isHistoryMode = this.isHistoryMode();
         const hasWritePermission = this._session.hasWritePermission();
-        return !hasWritePermission || isHistoryMode;
+        const isArchived = this._session.isArchived();
+        return !hasWritePermission || isArchived || isHistoryMode;
       }),
     );
   }

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -42,13 +42,17 @@ npm run dev
 
 Different containerized services to use in the development process like postgresql and pgadmn
 
-### Linux prerequisites
+### Linux/WSL prerequisites
 
 ```bash
 # Create the data/postgresql folder
 mkdir -p data/postgresql
 # Add the UID 1001 (non-root user of postgresql) as the folder owner
 chown -R 1001:1001 data/postgresql
+# Create the data/pgadmin folder
+mkdir -p data/pgadmin
+# Add the UID 5050 (non-root user of pgadmin) as the folder owner
+chown -R 5050:5050 data/pgadmin
 ```
 
 ### Docker-Compose
@@ -104,28 +108,6 @@ A postgresql database management tool
 4. Create database (right click on Servers -> Server -> Databases)
    - Create -> Database
      - Name: zskarte
-
-#### Persist database connections
-
-```bash
-# Execute inside pgadmin docker container
-docker exec -it pgadmin sh
-# Dump Actual connections into servers.json file to
-/venv/bin/python setup.py dump-servers --user info@zskarte.ch servers.json
-```
-
-##### Troubleshooting
-
-Your should have created empty file servers.json before starting the container (with docker compose) or docker would create an folder, that does not fit the needs.
-If this happen use
-
-```bash
-/venv/bin/python setup.py dump-servers --user info@zskarte.ch servers.json/file
-```
-
-to save the configuration instead.
-Than stop the compose, move the file out of the folder, delete the folder and rename file to server.json.
-Now remove the old pgadmin-zskarte (`docker rm pgadmin-zskarte`) and start the compose again.
 
 #### Seed data & set up authorization
 

--- a/packages/server/src/api/operation/controllers/operation.ts
+++ b/packages/server/src/api/operation/controllers/operation.ts
@@ -50,7 +50,8 @@ export default factories.createCoreController('api::operation.operation', ({ str
     return { success: true };
   },
   async overview(ctx) {
-    ctx.query.fields = ['name', 'description', 'status', 'eventStates'];
+    ctx.query.fields = ['name', 'description', 'status', 'eventStates', 'updatedAt'];
+    ctx.query.sort = 'updatedAt:DESC';
     return await this.find(ctx, undefined);
   },
   async archive(ctx) {
@@ -58,6 +59,16 @@ export default factories.createCoreController('api::operation.operation', ({ str
     await strapi.entityService.update('api::operation.operation', id, {
       data: {
         status: OperationStates.ARCHIVED,
+      },
+    });
+    ctx.status = 200;
+    return { success: true };
+  },
+  async unarchive(ctx) {
+    const { id } = ctx.params;
+    await strapi.entityService.update('api::operation.operation', id, {
+      data: {
+        status: OperationStates.ACTIVE,
       },
     });
     ctx.status = 200;

--- a/packages/server/src/api/operation/routes/01-partial.ts
+++ b/packages/server/src/api/operation/routes/01-partial.ts
@@ -22,6 +22,14 @@ export default {
     },
     {
       method: 'PUT',
+      path: '/operations/:id/unarchive',
+      handler: 'operation.unarchive',
+      config: {
+        middlewares: [CreateAccessControlMiddlewareConfig({ type: 'api::operation.operation', check: AccessControlTypes.BY_ID })],
+      },
+    },
+    {
+      method: 'PUT',
       path: '/operations/:id/meta',
       handler: 'operation.updateMeta',
       config: {

--- a/packages/server/src/state/operation.ts
+++ b/packages/server/src/state/operation.ts
@@ -49,8 +49,15 @@ const lifecycleOperation = async (lifecycleHook: StrapiLifecycleHook, operation:
     if (operation.status === OperationStates.ARCHIVED) {
       delete operationCaches[operation.id];
       return;
+    } else if (!(operation.id in operationCaches)) {
+      //maybe an "unarchive" operation
+      const mapState = operation.mapState || {};
+      operationCaches[operation.id] = { operation, connections: [], users: [], mapState, mapStateChanged: false };
+      if (!operation.organization) return;
+      operationCaches[operation.id].users.push(...operation.organization.users);
+    } else {
+      operationCaches[operation.id].operation = operation;
     }
-    operationCaches[operation.id].operation = operation;
   }
   if (lifecycleHook === StrapiLifecycleHooks.AFTER_DELETE) {
     delete operationCaches[operation.id];

--- a/packages/types/operation/interfaces.ts
+++ b/packages/types/operation/interfaces.ts
@@ -6,13 +6,16 @@ export interface IZSMapOperationMapLayers {
   layerConfigs: MapLayer[];
 }
 
+export type ZsOperationStatus = 'active' | 'archived';
+
 export interface IZsMapOperation {
   id?: number;
   name: string;
   description: string;
+  updatedAt?: string;
   mapState: IZsMapState;
   eventStates: number[];
-  status: "active" | "archived";
+  status: ZsOperationStatus;
   mapLayers?: IZSMapOperationMapLayers;
 }
 


### PR DESCRIPTION
replaces: https://github.com/zskarte/zskarte/pull/470
This update allow to switch between active and archived operation in the overview.
As there is no delete it renames that option to archive.
It allows to open archived operation as read only.

It allow to unarchive an operation to continue work on it.
**I'm unsure if this is an good / right idea or:**
- it should only be allowed to unarchive for a specific amount of time
- allow to copy operation(and snapshshots) to a new instance so the old is not manipulated.

