### PR TITLE
fix(cache/loadorder): signatures are shown after change operation

### DIFF
--- a/packages/app/src/app/map-renderer/map-renderer.component.ts
+++ b/packages/app/src/app/map-renderer/map-renderer.component.ts
@@ -52,6 +52,10 @@ export class MapRendererComponent implements AfterViewInit {
   private _rotating = false;
   private _initialRotation = 0;
 
+  public ngOnDestroy(): void {
+    this.renderer.terminate();
+  }
+
   public ngAfterViewInit(): void {
     this.renderer.initialize({
       mapElement: this.mapElement,


### PR DESCRIPTION
After go back to operation list and open the same or another one the map seams to be empty.
And page refresh would temporary solve the problem.

This changes fixes problem in initialize order to prevent require for page refresh.