### PR TITLE
feat(reconnect): reconnect if connection lost 60sec,reconnect idle 15min

### DIFF
--- a/packages/app/src/app/sync/sync.service.ts
+++ b/packages/app/src/app/sync/sync.service.ts
@@ -28,8 +28,8 @@ interface Connection {
   currentLocation?: { long: number; lat: number };
 }
 
-const RECONNECT_ACTIVE_CONNECTION_TIME = 9_000;
-const TRY_RECONNECT_NO_CONNECTION_TIME = 6_000;
+const RECONNECT_ACTIVE_CONNECTION_TIME = 900_000;
+const TRY_RECONNECT_NO_CONNECTION_TIME = 60_000;
 
 @Injectable({
   providedIn: 'root',

--- a/packages/app/src/app/sync/sync.service.ts
+++ b/packages/app/src/app/sync/sync.service.ts
@@ -28,6 +28,9 @@ interface Connection {
   currentLocation?: { long: number; lat: number };
 }
 
+const RECONNECT_ACTIVE_CONNECTION_TIME = 9_000;
+const TRY_RECONNECT_NO_CONNECTION_TIME = 6_000;
+
 @Injectable({
   providedIn: 'root',
 })
@@ -42,15 +45,25 @@ export class SyncService {
   private _connections = new BehaviorSubject<Connection[]>([]);
 
   constructor() {
-    // Reload the map every 60s if nothing changed
-    const noChanges$ = this.observeConnections()
-      .pipe(
-        filter(con => con.length > 0),
-        switchMap(() => this._state.observeMapState()),
-        debounceTime(60_000)
-      )
+    // Reload the websocket every 15min if nothing changed
+    // each _reconnect try(respectively _disconnect) will set _connections again to [] and emit again
+    const noChanges$ = this.observeConnections().pipe(
+      filter((con) => con.length > 0),
+      switchMap(() => this._state.observeMapState()),
+      debounceTime(RECONNECT_ACTIVE_CONNECTION_TIME),
+    );
+    const lostConnection$ = this.observeConnections().pipe(
+      debounceTime(TRY_RECONNECT_NO_CONNECTION_TIME),
+      filter((con) => con.length === 0 && this._session.isOnline()),
+    );
 
-    merge(this._session.observeOperationId(), this._session.observeIsOnline(), this._session.observeLabel(), noChanges$)
+    merge(
+      this._session.observeOperationId(),
+      this._session.observeIsOnline(),
+      this._session.observeLabel(),
+      noChanges$,
+      lostConnection$,
+    )
       .pipe(debounceTime(250))
       .subscribe(async () => {
         const operationId = this._session.getOperationId();


### PR DESCRIPTION
With #549 there was added an reconnect of the websocket connection all 60sec if nothing changes.
I don't see the goal behind a so often reconnect and change that to 15min.
It was done be request from #243 but there also stand reconnect after x minute, and perhaps with the next check this could be postponed longer than every 15 min.

But I see the need to try to reconnect if the session is lost (connections empty) while have internet and add those retry to connect all 60 sec.

Attention: the current solution still only do an (re-)connect of the websocket connection, dies does NOT reload the map view / mapState as such a logic is currently not part of the sync logic.
With #652 the journal view will trigger a reload after it sends the local changes(if any) on the connect of the SyncService.