### PR TITLE
fix(docker build): while npm ci in docker the patches were missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 ADD ./package.json /app/package.json
 ADD ./package-lock.json /app/package-lock.json
 ADD ./packages/server/package.json /app/packages/server/package.json
+ADD ./patches/* /app/patches/
 RUN npm ci 
 
 # Copy all files


### PR DESCRIPTION
This fixes the docker build error since #614