### PR TITLE
Feat(search): add street search, show result geometry, add filter/sort options

### DIFF
--- a/packages/app/src/app/geocoder/geocoder.component.html
+++ b/packages/app/src/app/geocoder/geocoder.component.html
@@ -35,12 +35,12 @@
     cdkConnectedOverlay
     [cdkConnectedOverlayOrigin]="trigger"
     [cdkConnectedOverlayOpen]="settingsVisble"
-    [cdkConnectedOverlayOffsetX]="-15"
-    [cdkConnectedOverlayOffsetY]="5"
+    [cdkConnectedOverlayOffsetX]="+37"
+    [cdkConnectedOverlayOffsetY]="-43"
   >
     <div class="overlay-container allow-overflow">
-      <svg class="overlay-arrow" width="20" height="10" xmlns="http://www.w3.org/2000/svg">
-        <polygon points="10,0 0,10 20,10" class="arrow-shape" />
+      <svg class="overlay-arrow-left" width="10" height="20" xmlns="http://www.w3.org/2000/svg">
+        <polygon points="0,10 10,0 10,20" class="arrow-shape-left" />
       </svg>
 
       <div class="overlay-content">

--- a/packages/app/src/app/geocoder/geocoder.component.html
+++ b/packages/app/src/app/geocoder/geocoder.component.html
@@ -20,7 +20,7 @@
       class="settings"
       cdkOverlayOrigin
       #trigger="cdkOverlayOrigin"
-      (click)="settingsVisble = !settingsVisble"
+      (click)="toggleSettings($event)"
       >settings</mat-icon
     >
     <mat-icon aria-hidden="false" aria-label="Search" matSuffix>search</mat-icon>
@@ -33,6 +33,7 @@
   ></app-search-autocomplete>
   <ng-template
     cdkConnectedOverlay
+    (overlayOutsideClick)="toggleSettings($event)"
     [cdkConnectedOverlayOrigin]="trigger"
     [cdkConnectedOverlayOpen]="settingsVisble"
     [cdkConnectedOverlayOffsetX]="+37"

--- a/packages/app/src/app/geocoder/geocoder.component.html
+++ b/packages/app/src/app/geocoder/geocoder.component.html
@@ -8,6 +8,21 @@
       (ngModelChange)="geoCodeLoad()"
       #searchField
     />
+    <mat-icon
+      matSuffix
+      [ngClass]="{
+        active:
+          searchConfig.filterMapSection ||
+          searchConfig.filterByDistance ||
+          searchConfig.filterByArea ||
+          searchConfig.sortedByDistance,
+      }"
+      class="settings"
+      cdkOverlayOrigin
+      #trigger="cdkOverlayOrigin"
+      (click)="settingsVisble = !settingsVisble"
+      >settings</mat-icon
+    >
     <mat-icon aria-hidden="false" aria-label="Search" matSuffix>search</mat-icon>
   </mat-form-field>
   <app-search-autocomplete
@@ -16,4 +31,60 @@
     (active)="previewCoordinate($event)"
     (selected)="geoCodeSelected($event)"
   ></app-search-autocomplete>
+  <ng-template
+    cdkConnectedOverlay
+    [cdkConnectedOverlayOrigin]="trigger"
+    [cdkConnectedOverlayOpen]="settingsVisble"
+    [cdkConnectedOverlayOffsetX]="-15"
+    [cdkConnectedOverlayOffsetY]="5"
+  >
+    <div class="overlay-container allow-overflow">
+      <svg class="overlay-arrow" width="20" height="10" xmlns="http://www.w3.org/2000/svg">
+        <polygon points="10,0 0,10 20,10" class="arrow-shape" />
+      </svg>
+
+      <div class="overlay-content">
+        <div>
+          <mat-icon class="filter">filter_list</mat-icon>
+          <mat-checkbox [(ngModel)]="searchConfig.filterMapSection" (change)="configChanged()">{{
+            i18n.get('filterMapSection')
+          }}</mat-checkbox>
+        </div>
+        <div>
+          <mat-icon class="filter">filter_list</mat-icon>
+          <mat-checkbox [(ngModel)]="searchConfig.filterByDistance" (change)="configChanged()">{{
+            i18n.get('filterByDistance')
+          }}</mat-checkbox>
+        </div>
+        @if (searchConfig.filterByDistance) {
+          <mat-form-field subscriptSizing="dynamic">
+            <mat-label>{{ i18n.get('maxDistance') }}</mat-label>
+            <input type="number" min="100" matInput [(ngModel)]="searchConfig.maxDistance" (change)="configChanged()" />
+          </mat-form-field>
+        }
+        <div>
+          <mat-icon class="filter">filter_list</mat-icon>
+          <mat-checkbox [(ngModel)]="searchConfig.filterByArea" (change)="configChanged()">{{
+            i18n.get('filterByArea')
+          }}</mat-checkbox>
+        </div>
+        @if (searchConfig.filterByArea) {
+          <div>
+            @if (drawingArea) {
+              <button mat-stroked-button (click)="stopDefineArea()">{{ i18n.get('endDefineArea') }}</button>
+            } @else {
+              <button mat-stroked-button (click)="startDefineArea()">{{ i18n.get('defineArea') }}</button>
+            }
+          </div>
+        }
+        <div>
+          <!--<mat-icon class="filter">filter_center_focus</mat-icon>-->
+          <mat-icon class="filter">sort</mat-icon>
+          <mat-checkbox [(ngModel)]="searchConfig.sortedByDistance" (change)="configChanged()">{{
+            i18n.get('sortedByDistance')
+          }}</mat-checkbox>
+        </div>
+      </div>
+    </div>
+  </ng-template>
 </div>

--- a/packages/app/src/app/geocoder/geocoder.component.html
+++ b/packages/app/src/app/geocoder/geocoder.component.html
@@ -3,49 +3,17 @@
     <input
       matInput
       [placeholder]="i18n.get('findPlace')"
-      [matAutocomplete]="auto"
+      [matAutocomplete]="autocomplete.autocompleteRef"
       [(ngModel)]="inputText"
       (ngModelChange)="geoCodeLoad()"
       #searchField
     />
     <mat-icon aria-hidden="false" aria-label="Search" matSuffix>search</mat-icon>
   </mat-form-field>
-
-  <mat-autocomplete
-    #auto="matAutocomplete"
-    (optionSelected)="geoCodeSelected($event)"
-    (optionActivated)="previewCoordinate($event.option?.value)"
-  >
-    <ng-template let-location="location" #option>
-      <mat-option [value]="location" (mouseenter)="previewCoordinate(location)" (mouseleave)="goToCoordinate(false)">
-        <span [innerHTML]="location.label" [title]="getLabel(location)"></span>
-      </mat-option>
-    </ng-template>
-    @if (foundLocations.length === 1) {
-      @for (location of foundLocations[0].results; track location) {
-        <ng-container [ngTemplateOutlet]="option" [ngTemplateOutletContext]="{ location: location }"></ng-container>
-      }
-    } @else {
-      @for (group of foundLocations; track group) {
-        <mat-optgroup [label]="group.config.label + ' (' + group.results.length + ')'" (mousedown)="expandGroup(group, $event)">
-          <ng-container>
-            @if (group.collapsed === 'peek') {
-              @for (location of group.results | slice: 0 : 3; track location) {
-                <ng-container [ngTemplateOutlet]="option" [ngTemplateOutletContext]="{ location: location }"></ng-container>
-              }
-              @if (group.results.length > 3) {
-                <div class="hasMore">...</div>
-              }
-            } @else if (!group.collapsed) {
-              @for (location of group.results; track location) {
-                <ng-container [ngTemplateOutlet]="option" [ngTemplateOutletContext]="{ location: location }"></ng-container>
-              }
-            } @else {
-              <mat-option class="dummyOption"></mat-option>
-            }
-          </ng-container>
-        </mat-optgroup>
-      }
-    }
-  </mat-autocomplete>
+  <app-search-autocomplete
+    #autocomplete
+    [foundLocations]="foundLocations()"
+    (active)="previewCoordinate($event)"
+    (selected)="geoCodeSelected($event)"
+  ></app-search-autocomplete>
 </div>

--- a/packages/app/src/app/geocoder/geocoder.component.scss
+++ b/packages/app/src/app/geocoder/geocoder.component.scss
@@ -23,13 +23,13 @@ mat-icon.settings.active {
   box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
 }
 
-.overlay-arrow {
+.overlay-arrow-left {
   position: absolute;
-  top: -10px;
-  left: 1rem;
+  top: 1rem;
+  left: -10px;
 }
 
-.arrow-shape {
+.arrow-shape-left {
   fill: white;
   stroke: #ccc;
   stroke-width: 1;

--- a/packages/app/src/app/geocoder/geocoder.component.scss
+++ b/packages/app/src/app/geocoder/geocoder.component.scss
@@ -6,3 +6,43 @@ mat-form-field {
   pointer-events: auto;
   overflow: hidden;
 }
+
+mat-icon.settings {
+  padding: 0;
+}
+mat-icon.settings.active {
+  color: #3f51b5;
+}
+
+.overlay-container {
+  position: relative;
+  background: white;
+  border: 1px solid #ccc;
+  border-radius: 1rem;
+  padding: 10px;
+  box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.overlay-arrow {
+  position: absolute;
+  top: -10px;
+  left: 1rem;
+}
+
+.arrow-shape {
+  fill: white;
+  stroke: #ccc;
+  stroke-width: 1;
+  stroke-dasharray: 15, 20; /* removes bottom line */
+}
+
+.overlay-content {
+  mat-icon {
+    vertical-align: middle;
+  }
+  mat-form-field,
+  button {
+    margin-left: 64px;
+    max-width: calc(100% - 64px);
+  }
+}

--- a/packages/app/src/app/geocoder/geocoder.component.scss
+++ b/packages/app/src/app/geocoder/geocoder.component.scss
@@ -1,7 +1,3 @@
-.mat-option {
-  font-size: 0.7em;
-}
-
 mat-form-field {
   width: 100%;
   --mdc-outlined-text-field-container-shape: 28px !important;
@@ -9,18 +5,4 @@ mat-form-field {
   border-radius: 28px;
   pointer-events: auto;
   overflow: hidden;
-}
-
-mat-optgroup {
-  cursor: pointer;
-}
-
-.hasMore {
-  cursor: pointer;
-  text-align: center;
-}
-
-/* invisible element to prevent autocomplete is closed/hidden if there are only mat-optgroups */
-.dummyOption {
-  display: none;
 }

--- a/packages/app/src/app/geocoder/geocoder.component.ts
+++ b/packages/app/src/app/geocoder/geocoder.component.ts
@@ -140,4 +140,9 @@ export class GeocoderComponent implements OnDestroy {
     this.searchConfig.area = this._searchArea.getSearchAreaExtent();
     this.configChanged();
   }
+
+  toggleSettings(event?: MouseEvent) {
+    event?.stopPropagation();
+    this.settingsVisble = !this.settingsVisble;
+  }
 }

--- a/packages/app/src/app/geocoder/geocoder.component.ts
+++ b/packages/app/src/app/geocoder/geocoder.component.ts
@@ -1,17 +1,19 @@
-import { ChangeDetectorRef, Component, ElementRef, OnDestroy, inject, viewChild } from '@angular/core';
+import { signal, Component, ElementRef, OnDestroy, inject, viewChild } from '@angular/core';
 import { I18NService } from '../state/i18n.service';
 import { ZsMapStateService } from '../state/state.service';
 import { transform } from 'ol/proj';
 import { SessionService } from '../session/session.service';
 import { Subject, takeUntil } from 'rxjs';
-import { MatAutocompleteModule, MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
-import { IZsMapSearchConfig, IZsMapSearchResult } from '@zskarte/types';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { IResultSet, IZsMapSearchResult } from '@zskarte/types';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
 import { coordinateFromString } from '../helper/coordinates-extract';
+import { SearchService } from '../search/search.service';
+import { SearchAutocompleteComponent } from '../search/search-autocomplete/search-autocomplete.component';
 interface IFoundLocation {
   attrs: IFoundLocationAttrs;
 }
@@ -22,34 +24,36 @@ interface IFoundLocationAttrs {
   lat: number;
 }
 
-interface IResultSet {
-  config: IZsMapSearchConfig;
-  results: IZsMapSearchResult[];
-  collapsed: boolean | 'peek';
-}
-
 @Component({
   selector: 'app-geocoder',
   templateUrl: './geocoder.component.html',
   styleUrls: ['./geocoder.component.scss'],
-  imports: [MatFormFieldModule, MatInputModule, MatIconModule, MatAutocompleteModule, CommonModule, FormsModule],
+  imports: [
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    MatAutocompleteModule,
+    CommonModule,
+    FormsModule,
+    SearchAutocompleteComponent,
+  ],
 })
 export class GeocoderComponent implements OnDestroy {
   i18n = inject(I18NService);
   zsMapStateService = inject(ZsMapStateService);
   private _session = inject(SessionService);
-  private ref = inject(ChangeDetectorRef);
+  private _search = inject(SearchService);
 
   readonly el = viewChild.required<ElementRef>('searchField');
   geocoderUrl = 'https://api3.geo.admin.ch/rest/services/api/SearchServer?type=locations&searchText=';
-  foundLocations: IResultSet[] = [];
+  foundLocations = signal<IResultSet[]>([]);
   inputText = '';
+  keepCoord = false;
   selected: IZsMapSearchResult | null = null;
   private _ngUnsubscribe = new Subject<void>();
+  private updateSearchTerm: (searchText: string) => void;
 
   constructor() {
-    const zsMapStateService = this.zsMapStateService;
-
     this._session
       .observeAuthenticated()
       .pipe(takeUntil(this._ngUnsubscribe))
@@ -57,8 +61,29 @@ export class GeocoderComponent implements OnDestroy {
         this.selected = null;
       });
 
-    zsMapStateService.addSearch(this.coordinateSearch.bind(this), this.i18n.get('coordinates'), undefined, 1);
-    zsMapStateService.addSearch(this.geoAdminLocationSearch.bind(this), 'Geo Admin', undefined, 100);
+    this._search.addSearch(this.coordinateSearch.bind(this), this.i18n.get('coordinates'), undefined, 1);
+    this._search.addSearch(this.geoAdminLocationSearch.bind(this), 'Geo Admin', undefined, 100);
+
+    const { searchResults$, updateSearchTerm } = this._search.createSearchInstance();
+    this.updateSearchTerm = updateSearchTerm;
+
+    searchResults$.subscribe((newResultSets) => {
+      if (newResultSets === null) {
+        //request aborted by new search
+        return;
+      }
+
+      this.foundLocations().forEach((s) => s.results.forEach((x) => x.feature?.unset('ZsMapSearchResult')));
+      newResultSets.forEach((s) => s.results.forEach((x) => x.feature?.set('ZsMapSearchResult', true)));
+      if (newResultSets.length > 3) {
+        newResultSets.forEach((s) => (s.collapsed = true));
+      }
+      this.foundLocations.set(newResultSets);
+      if (newResultSets.length === 0 && this.inputText.length <= 1 && !this.keepCoord) {
+        this.zsMapStateService.updatePositionFlag({ isVisible: false, coordinates: [0, 0] });
+      }
+      this.keepCoord = false;
+    });
   }
 
   ngOnDestroy(): void {
@@ -97,63 +122,22 @@ export class GeocoderComponent implements OnDestroy {
   }
 
   async geoCodeLoad() {
-    if (this.inputText.length > 1) {
-      const originalInput = this.inputText;
-      const configs = this.zsMapStateService.getSearchConfigs().sort((a, b) => a.resultOrder - b.resultOrder);
-      const newResultSets: IResultSet[] = [];
-      for (const config of configs) {
-        if (this.inputText !== originalInput) {
-          // break handling if input changes
-          return;
-        }
-        try {
-          const results = await config.func(originalInput, config.maxResultCount);
-          if (results.length > 0) {
-            newResultSets.push({ config, results, collapsed: 'peek' });
-          }
-        } catch (error) {
-          console.error(error);
-        }
-      }
-      if (this.inputText === originalInput) {
-        // only continue update if no new search is started
-        this.foundLocations.forEach((s) => s.results.forEach((x) => x.feature?.unset('ZsMapSearchResult')));
-        newResultSets.forEach((s) => s.results.forEach((x) => x.feature?.set('ZsMapSearchResult', true)));
-        if (newResultSets.length > 3) {
-          newResultSets.forEach((s) => (s.collapsed = true));
-        }
-        this.foundLocations = newResultSets;
-      }
-    } else {
-      this.foundLocations.forEach((s) => s.results.forEach((x) => x.feature?.unset('ZsMapSearchResult')));
-      this.foundLocations = [];
-      this.zsMapStateService.updatePositionFlag({ isVisible: false, coordinates: [0, 0] });
-    }
-    // need to do this explicit, it seams to have problem with this async approach
-    this.ref.detectChanges();
+    this.updateSearchTerm(this.inputText);
   }
 
-  // skipcq: JS-0105
-  expandGroup(group: IResultSet, $event: MouseEvent) {
-    if (!($event.target as Element).closest('mat-option')) {
-      group.collapsed = !group.collapsed;
-      $event.preventDefault();
-    }
-  }
-
-  // skipcq: JS-0105
-  getLabel(selected: IZsMapSearchResult): string {
-    return selected ? selected.label.replace(/<[^>]*>/g, '') : '';
-  }
-
-  geoCodeSelected(event: MatAutocompleteSelectedEvent) {
-    this.selected = event.option.value;
+  geoCodeSelected(value: IZsMapSearchResult) {
+    this.selected = value;
     this.goToCoordinate(true);
+    this.keepCoord = true;
     this.inputText = '';
   }
 
-  previewCoordinate(element: IZsMapSearchResult) {
-    this.doGoToCoordinate(element, false);
+  previewCoordinate(element: IZsMapSearchResult | null) {
+    if (element === null) {
+      this.goToCoordinate(false);
+    } else {
+      this.doGoToCoordinate(element, false);
+    }
   }
 
   private doGoToCoordinate(element: IZsMapSearchResult | null, center: boolean) {

--- a/packages/app/src/app/geocoder/geocoder.component.ts
+++ b/packages/app/src/app/geocoder/geocoder.component.ts
@@ -3,7 +3,7 @@ import { I18NService } from '../state/i18n.service';
 import { ZsMapStateService } from '../state/state.service';
 import { SessionService } from '../session/session.service';
 import { Subject, takeUntil } from 'rxjs';
-import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { MatAutocompleteModule, MatAutocompleteTrigger } from '@angular/material/autocomplete';
 import { IResultSet, IZsGlobalSearchConfig, IZsMapSearchResult } from '@zskarte/types';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { CommonModule } from '@angular/common';
@@ -42,6 +42,7 @@ export class GeocoderComponent implements OnDestroy {
   private _searchArea = inject(MapSearchAreaService);
 
   readonly el = viewChild.required<ElementRef>('searchField');
+  readonly autocompleteTrigger = viewChild.required(MatAutocompleteTrigger);
   foundLocations = signal<IResultSet[]>([]);
   inputText = '';
   keepCoord = false;
@@ -90,6 +91,7 @@ export class GeocoderComponent implements OnDestroy {
         this._search.highlightResult(null, false);
       }
       this.keepCoord = false;
+      this.autocompleteTrigger().openPanel();
     });
   }
 
@@ -112,6 +114,7 @@ export class GeocoderComponent implements OnDestroy {
 
   previewCoordinate(element: IZsMapSearchResult | null) {
     if (element === null) {
+      this.selected = null;
       this.goToCoordinate(false);
     } else {
       this._search.highlightResult(element, false);
@@ -124,7 +127,6 @@ export class GeocoderComponent implements OnDestroy {
 
   configChanged() {
     this._state.setSearchConfig({ ...this.searchConfig });
-    this.updateSearchConfig(this.searchConfig);
   }
 
   startDefineArea() {

--- a/packages/app/src/app/map-layer/geojson/geojson.service.ts
+++ b/packages/app/src/app/map-layer/geojson/geojson.service.ts
@@ -310,7 +310,7 @@ export class GeoJSONService {
       if (labels[label]) {
         continue;
       }
-      let dist: number | null = null;
+      let dist: number | undefined = undefined;
       if (searchConfig.sortedByDistance) {
         dist = squaredDistance(refCoord, coords);
       }
@@ -354,7 +354,7 @@ export class GeoJSONService {
       );
     }
     if (searchConfig.sortedByDistance) {
-      result.sort((a, b) => a.internal.dist - b.internal.dist);
+      result.sort((a, b) => (a.internal?.dist ?? Infinity) - (b.internal?.dist ?? Infinity));
     } else {
       result.sort((a, b) => NumberSortCollator.compare(a.label, b.label));
     }
@@ -420,7 +420,7 @@ export class GeoJSONService {
     } else {
       if (currentGroup.length > 1) {
         if (sortedByDistance) {
-          currentGroup.sort((a, b) => a.internal.dist - b.internal.dist);
+          currentGroup.sort((a, b) => (a.internal?.dist ?? Infinity) - (b.internal?.dist ?? Infinity));
         } else {
           currentGroup.sort((a, b) => NumberSortCollator.compare(a.label, b.label));
         }

--- a/packages/app/src/app/map-layer/geojson/geojson.service.ts
+++ b/packages/app/src/app/map-layer/geojson/geojson.service.ts
@@ -201,7 +201,7 @@ export class GeoJSONService {
     });
   }
 
-  public search(searchText: string, layer: GeoJSONMapLayer, features: Feature<Geometry>[], maxResultCount?: number): IZsMapSearchResult[] {
+  public search(searchText: string, layer: GeoJSONMapLayer, features: Feature<Geometry>[], abortController: AbortController, maxResultCount?: number): IZsMapSearchResult[] {
     if (searchText.length < 3 || !layer.source?.url || !layer.searchRegExPatterns) {
       return [];
     }
@@ -302,6 +302,9 @@ export class GeoJSONService {
         if (resultCount >= maxResultCount) {
           break;
         }
+      }
+      if (abortController.signal.aborted){
+        return [];
       }
     }
     if (layer.searchResultGroupingFilterFields?.length) {

--- a/packages/app/src/app/map-layer/geojson/geojson.service.ts
+++ b/packages/app/src/app/map-layer/geojson/geojson.service.ts
@@ -1,8 +1,8 @@
 import { Injectable, inject } from '@angular/core';
 import { Feature } from 'ol';
-import { Coordinate } from 'ol/coordinate';
+import { Coordinate, squaredDistance } from 'ol/coordinate';
 import { Geometry, LineString, Point } from 'ol/geom';
-import { Extent, containsExtent, getCenter } from 'ol/extent';
+import { Extent, containsCoordinate, containsExtent, getCenter } from 'ol/extent';
 import VectorSource from 'ol/source/Vector';
 import VectorLayer from 'ol/layer/Vector';
 import GeoJSON from 'ol/format/GeoJSON';
@@ -14,7 +14,8 @@ import { transformExtent, transform } from 'ol/proj';
 import { inferSchema, initParser } from 'udsv';
 import { LocalMapLayerMeta } from 'src/app/db/db';
 import { BlobService } from 'src/app/db/blob.service';
-import { GeoJSONMapLayer, CsvMapLayer, IZsMapSearchResult } from '@zskarte/types';
+import { GeoJSONMapLayer, CsvMapLayer, IZsMapSearchResult, IZsGlobalSearchConfig } from '@zskarte/types';
+import { SearchService } from 'src/app/search/search.service';
 
 const NumberSortCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
 @Injectable({
@@ -22,6 +23,7 @@ const NumberSortCollator = new Intl.Collator(undefined, { numeric: true, sensiti
 })
 export class GeoJSONService {
   private _mapLayerService = inject(MapLayerService);
+  private _search = inject(SearchService);
 
   private _searchRegExPatternsCache: Map<string, RegExp[]> = new Map();
 
@@ -41,7 +43,11 @@ export class GeoJSONService {
       .then((response) => response.json())
       .then((geojsonObject) => {
         if (mercatorProjection) {
-          const swissExtentMercatorProjection = transformExtent(swissProjection.getExtent(), swissProjection, mercatorProjection);
+          const swissExtentMercatorProjection = transformExtent(
+            swissProjection.getExtent(),
+            swissProjection,
+            mercatorProjection,
+          );
           const features = (
             new GeoJSON().readFeatures(geojsonObject, {
               //dataProjection: swissProjection,
@@ -83,7 +89,11 @@ export class GeoJSONService {
         const parser = initParser(schema);
         const csvLines = parser.typedObjs(csvContent, (rows, append) => {
           rows = rows.filter((row) => {
-            if (isNaN(row[layer.fieldX]) || isNaN(row[layer.fieldY]) || (row[layer.fieldX] === 0 && row[layer.fieldY] === 0)) {
+            if (
+              isNaN(row[layer.fieldX]) ||
+              isNaN(row[layer.fieldY]) ||
+              (row[layer.fieldX] === 0 && row[layer.fieldY] === 0)
+            ) {
               return false;
             }
             if (regexPatterns?.length) {
@@ -112,7 +122,9 @@ export class GeoJSONService {
               (csvLine) =>
                 new Feature({
                   ...csvLine,
-                  geometry: new Point(transform([csvLine[layer.fieldX], csvLine[layer.fieldY]], layer.dataProjection, destProjection)),
+                  geometry: new Point(
+                    transform([csvLine[layer.fieldX], csvLine[layer.fieldY]], layer.dataProjection, destProjection),
+                  ),
                 }),
             )
             .filter((f) => {
@@ -201,7 +213,14 @@ export class GeoJSONService {
     });
   }
 
-  public search(searchText: string, layer: GeoJSONMapLayer, features: Feature<Geometry>[], abortController: AbortController, maxResultCount?: number): IZsMapSearchResult[] {
+  public search(
+    searchText: string,
+    layer: GeoJSONMapLayer,
+    features: Feature<Geometry>[],
+    abortController: AbortController,
+    searchConfig: IZsGlobalSearchConfig,
+    maxResultCount?: number,
+  ): IZsMapSearchResult[] {
     if (searchText.length < 3 || !layer.source?.url || !layer.searchRegExPatterns) {
       return [];
     }
@@ -221,7 +240,9 @@ export class GeoJSONService {
       this._searchRegExPatternsCache.set(url, regexPatterns);
     }
     searchText = searchText.toLowerCase();
-    const matches = regexPatterns.map((pattern: RegExp) => searchText.match(pattern)).filter((match) => match) as RegExpMatchArray[];
+    const matches = regexPatterns
+      .map((pattern: RegExp) => searchText.match(pattern))
+      .filter((match) => match) as RegExpMatchArray[];
     if (!matches || matches.length === 0) {
       return [];
     }
@@ -232,6 +253,8 @@ export class GeoJSONService {
       ]),
     ];
 
+    const refCoord = this._search.getDistanceReferenceCoordinate(searchConfig);
+    const filterArea = this._search.getSearchFilterArea(searchConfig);
     maxResultCount = maxResultCount ?? 50;
     const labels = {};
     const result: IZsMapSearchResult[] = [];
@@ -279,20 +302,33 @@ export class GeoJSONService {
         }
         coords = getCenter(extent);
       }
+      if (filterArea && !containsCoordinate(filterArea, coords)) {
+        continue;
+      }
       const label = GeoJSONService.renderString(layer.searchResultLabelMask, params);
       //only keep first if same label
       if (labels[label]) {
         continue;
+      }
+      let dist: number | null = null;
+      if (searchConfig.sortedByDistance) {
+        dist = squaredDistance(refCoord, coords);
       }
       labels[label] = true;
       const info: IZsMapSearchResult = {
         label,
         mercatorCoordinates: coords,
         feature,
+        internal: { dist },
       };
       resultCount++;
       if (layer.searchResultGroupingFilterFields?.length) {
-        const innerGroup = GeoJSONService.getInnerGroup(resultGroups, 0, filteredParams, layer.searchResultGroupingFilterFields);
+        const innerGroup = GeoJSONService.getInnerGroup(
+          resultGroups,
+          0,
+          filteredParams,
+          layer.searchResultGroupingFilterFields,
+        );
         innerGroup.push(info);
         if (resultCount >= 5000 || resultGroups['__count__'] >= maxResultCount) {
           break;
@@ -303,14 +339,25 @@ export class GeoJSONService {
           break;
         }
       }
-      if (abortController.signal.aborted){
+      if (abortController.signal.aborted) {
         return [];
       }
     }
     if (layer.searchResultGroupingFilterFields?.length) {
-      GeoJSONService.flatFilterResultGroups(resultGroups, 0, maxResultCount, result, layer.searchResultGroupingFilterFields);
+      GeoJSONService.flatFilterResultGroups(
+        resultGroups,
+        0,
+        maxResultCount,
+        result,
+        layer.searchResultGroupingFilterFields,
+        searchConfig.sortedByDistance,
+      );
     }
-    result.sort((a, b) => NumberSortCollator.compare(a.label, b.label));
+    if (searchConfig.sortedByDistance) {
+      result.sort((a, b) => a.internal.dist - b.internal.dist);
+    } else {
+      result.sort((a, b) => NumberSortCollator.compare(a.label, b.label));
+    }
     return result;
   }
 
@@ -327,7 +374,12 @@ export class GeoJSONService {
       } else {
         currentGroup['__sum__']++;
       }
-      return GeoJSONService.getInnerGroup(currentGroup[val], layer + 1, filteredParams, searchResultGroupingFilterFields);
+      return GeoJSONService.getInnerGroup(
+        currentGroup[val],
+        layer + 1,
+        filteredParams,
+        searchResultGroupingFilterFields,
+      );
     } else {
       if (!currentGroup[val]) {
         currentGroup['__count__']++;
@@ -344,6 +396,7 @@ export class GeoJSONService {
     maxCount: number,
     data: IZsMapSearchResult[],
     searchResultGroupingFilterFields: string[],
+    sortedByDistance: boolean,
   ) {
     if (layer <= searchResultGroupingFilterFields.length - 1) {
       const keys = Object.keys(currentGroup);
@@ -355,11 +408,22 @@ export class GeoJSONService {
         maxCount = Math.max(1, Math.floor(maxCount / currentGroup['__count__']));
       }
       keys.forEach((key) => {
-        GeoJSONService.flatFilterResultGroups(currentGroup[key], layer + 1, maxCount, data, searchResultGroupingFilterFields);
+        GeoJSONService.flatFilterResultGroups(
+          currentGroup[key],
+          layer + 1,
+          maxCount,
+          data,
+          searchResultGroupingFilterFields,
+          sortedByDistance,
+        );
       });
     } else {
       if (currentGroup.length > 1) {
-        currentGroup.sort((a, b) => NumberSortCollator.compare(a.label, b.label));
+        if (sortedByDistance) {
+          currentGroup.sort((a, b) => a.internal.dist - b.internal.dist);
+        } else {
+          currentGroup.sort((a, b) => NumberSortCollator.compare(a.label, b.label));
+        }
       }
       if (maxCount === 1) {
         data.push(currentGroup[0]);

--- a/packages/app/src/app/map-renderer/map-renderer.service.ts
+++ b/packages/app/src/app/map-renderer/map-renderer.service.ts
@@ -36,6 +36,7 @@ import { MapModifyService } from './map-modify.service';
 import { MapOverlayService } from './map-overlay.service';
 import { MapPrintService } from './map-print.service';
 import { MapSelectService } from './map-select.service';
+import { SearchService } from '../search/search.service';
 
 export const LAYER_Z_INDEX_CURRENT_LOCATION = 1000000;
 export const LAYER_Z_INDEX_NAVIGATION_LAYER = 1000001;
@@ -51,6 +52,7 @@ export class MapRendererService {
   private geoAdminService = inject(GeoadminService);
   private wmsService = inject(WmsService);
   private geoJSONService = inject(GeoJSONService);
+  private _search = inject(SearchService);
 
   private _ngUnsubscribe = new Subject<void>();
   private _map!: OlMap;
@@ -503,7 +505,7 @@ export class MapRendererService {
                     ),
                   );
                 };
-                this._state.addSearch(searchFunc, mapLayer.label, (mapLayer as GeoJSONMapLayer).searchMaxResultCount);
+                this._search.addSearch(searchFunc, mapLayer.label, (mapLayer as GeoJSONMapLayer).searchMaxResultCount);
               }
 
               // observe mapLayer changes
@@ -518,7 +520,7 @@ export class MapRendererService {
                 complete: () => {
                   this._map.removeLayer(olLayer);
                   if (searchFunc) {
-                    this._state.removeSearch(searchFunc);
+                    this._search.removeSearch(searchFunc);
                   }
                   this._mapLayerCache.delete(name);
                 },

--- a/packages/app/src/app/map-renderer/map-search-area.service.spec.ts
+++ b/packages/app/src/app/map-renderer/map-search-area.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MapSearchAreaService } from './map-search-area.service';
+
+describe('MapSearchAreaService', () => {
+  let service: MapSearchAreaService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(MapSearchAreaService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/packages/app/src/app/map-renderer/map-search-area.service.ts
+++ b/packages/app/src/app/map-renderer/map-search-area.service.ts
@@ -1,0 +1,133 @@
+import { Injectable } from '@angular/core';
+import { Collection, Feature } from 'ol';
+import { Geometry, Polygon } from 'ol/geom';
+import Draw, { createBox } from 'ol/interaction/Draw';
+import VectorLayer from 'ol/layer/Vector';
+import { fromLonLat } from 'ol/proj';
+import VectorSource from 'ol/source/Vector';
+import { IZsGlobalSearchConfig } from '../../../../types';
+import { ZsMapStateService } from '../state/state.service';
+import { LAYER_Z_INDEX_SEARCH_AREA_LAYER, MapRendererService } from './map-renderer.service';
+import { Fill, Style } from 'ol/style';
+import { ModifyRectangle } from './modify-rectangle.interaction';
+import { boundingExtent } from 'ol/extent';
+import { fromExtent } from 'ol/geom/Polygon';
+
+const worldExtent = [
+  [-180, -90],
+  [180, -90],
+  [180, 90],
+  [-180, 90],
+  [-180, -90],
+];
+
+@Injectable({
+  providedIn: 'root',
+})
+export class MapSearchAreaService {
+  private _renderer!: MapRendererService;
+  private _state!: ZsMapStateService;
+
+  private _worldCoordinates!: number[][];
+  private _searchAreaOverlayFeature!: Feature<Polygon>;
+  private _overlaySource!: VectorSource;
+  private _overlayLayer!: VectorLayer<VectorSource>;
+  private _draw!: Draw;
+  private _modify!: ModifyRectangle;
+
+  initialize({
+    renderer,
+    state,
+  }: {
+    renderer: MapRendererService;
+    state: ZsMapStateService;
+  }) {
+    this._renderer = renderer;
+    this._state = state;
+
+    this._worldCoordinates = worldExtent.map((coord) => fromLonLat(coord));
+    this._searchAreaOverlayFeature = new Feature(new Polygon([this._worldCoordinates]));
+
+    this._overlaySource = new VectorSource({
+      features: [this._searchAreaOverlayFeature as Feature<Geometry>],
+    });
+    this._overlayLayer = new VectorLayer({
+      source: this._overlaySource,
+      style: new Style({
+        fill: new Fill({ color: 'rgba(0, 0, 0, 0.5)' }),
+      }),
+    });
+    this._overlayLayer.setZIndex(LAYER_Z_INDEX_SEARCH_AREA_LAYER);
+    this._overlayLayer.setVisible(false);
+    this._renderer.getMap().addLayer(this._overlayLayer);
+
+    this._state.observeSearchConfig().subscribe((searchconfig: IZsGlobalSearchConfig) => {
+      this._overlayLayer.setVisible(searchconfig.filterByArea);
+      if (searchconfig.area) {
+        const overlayGeometry = this._searchAreaOverlayFeature.getGeometry();
+        if (overlayGeometry) {
+          const extentPoly = fromExtent(searchconfig.area);
+          overlayGeometry.setCoordinates([this._worldCoordinates, extentPoly.getCoordinates()[0]]);
+        }
+      }
+    });
+
+    const updateSearchAreaOverlayFeature = (markedGeometry: Polygon) => {
+      const overlayGeometry = this._searchAreaOverlayFeature.getGeometry();
+      if (overlayGeometry) {
+        overlayGeometry.setCoordinates([this._worldCoordinates, markedGeometry.getCoordinates()[0]]);
+      }
+    };
+
+    this._draw = new Draw({
+      source: this._overlaySource,
+      type: 'Circle',
+      geometryFunction: createBox(),
+    });
+
+    this._draw.on('drawend', (event) => {
+      const feature = event.feature;
+      updateSearchAreaOverlayFeature(feature.getGeometry() as Polygon);
+      setTimeout(() => {
+        this._overlaySource.removeFeature(feature);
+      }, 0);
+    });
+
+    this._modify = new ModifyRectangle({
+      features: new Collection([this._searchAreaOverlayFeature]),
+    });
+  }
+
+  public activateAreaEdit() {
+    //disable normal map manipulation interactions
+    this._renderer.getMapInteractions().forEach((i) => {
+      i.setActive(false);
+    });
+    this._renderer.getMap().addInteraction(this._draw);
+    this._renderer.getMap().addInteraction(this._modify);
+  }
+
+  public deactivateAreaEdit() {
+    this._modify.cancel();
+    this._renderer.getMap().removeInteraction(this._draw);
+    this._renderer.getMap().removeInteraction(this._modify);
+
+    //reenable normal map manipulation interactions
+    this._renderer.getMapInteractions().forEach((i) => {
+      i.setActive(true);
+    });
+  }
+
+  public getSearchAreaOverlayFeature() {
+    return this._searchAreaOverlayFeature;
+  }
+
+  public getSearchAreaExtent() {
+    const geometry = this._searchAreaOverlayFeature.getGeometry();
+    if (geometry && geometry.getCoordinates().length === 2) {
+      //only return the inner rectangle if any
+      return boundingExtent(geometry.getCoordinates()[1]);
+    }
+    return null;
+  }
+}

--- a/packages/app/src/app/map-renderer/modify-rectangle.interaction.ts
+++ b/packages/app/src/app/map-renderer/modify-rectangle.interaction.ts
@@ -1,0 +1,225 @@
+import type { Collection, Feature, MapBrowserEvent } from 'ol';
+import { Polygon } from 'ol/geom';
+import type { Coordinate } from 'ol/coordinate';
+import type { CombinedOnSignature, EventTypes, OnSignature } from 'ol/Observable';
+import type { EventsKey } from 'ol/events';
+import BaseEvent from 'ol/events/Event';
+import type { ModifyEvent, ModifyOnSignature } from 'ol/interaction/Modify';
+import Modify from 'ol/interaction/Modify';
+import type { StyleLike } from 'ol/style/Style';
+import type { FlatStyleLike } from 'ol/style/flat';
+import type VectorSource from 'ol/source/Vector';
+import { boundingExtent } from 'ol/extent';
+import { fromExtent } from 'ol/geom/Polygon';
+
+export type Options = {
+  pixelTolerance?: number;
+  style?: StyleLike | FlatStyleLike;
+  source?: VectorSource;
+  features?: Collection<Feature>;
+};
+
+export type MovePointConf = {
+  modifyX: number[];
+  modifyY: number[];
+  edgeMove: boolean;
+  selectedVertexIndex: number;
+  polyIndex: number;
+};
+
+export class ModifyRectangleEvent extends BaseEvent {
+  modifyFeature: Feature<Polygon>;
+  movePointConf: MovePointConf;
+  mapBrowserEvent: MapBrowserEvent<any>;
+  constructor(
+    type: string,
+    modifyFeature: Feature<Polygon>,
+    movePointConf: MovePointConf,
+    mapBrowserEvent: MapBrowserEvent<any>,
+  ) {
+    super(type);
+
+    this.modifyFeature = modifyFeature;
+    this.movePointConf = movePointConf;
+    this.mapBrowserEvent = mapBrowserEvent;
+  }
+}
+
+export type ModifyRectangleEventTypes = 'modifyrectanglestart' | 'modifyrectangleend';
+
+export type ModifyRectangleOnSignature<Return> = ModifyOnSignature<Return> &
+  OnSignature<ModifyRectangleEventTypes, ModifyRectangleEvent, Return> &
+  CombinedOnSignature<
+    'propertychange' | 'change:active' | EventTypes | 'modifyend' | 'modifystart' | ModifyRectangleEventTypes,
+    Return
+  >;
+
+export class ModifyRectangle extends Modify {
+  private pixelTolerance: number;
+  private movePointConf: MovePointConf | null = null;
+  private modifyFeature: Feature<Polygon> | null = null;
+  private modifyGeometry: Polygon | null = null;
+  private updatePointsBinding: any = null;
+
+  declare on: ModifyRectangleOnSignature<EventsKey>;
+  declare once: ModifyRectangleOnSignature<EventsKey>;
+  declare un: ModifyRectangleOnSignature<EventsKey>;
+
+  constructor(options: Options) {
+    super({ ...options, deleteCondition: () => false, pixelTolerance: options.pixelTolerance ?? 10 });
+    this.pixelTolerance = options.pixelTolerance ?? 10;
+    this.updatePointsBinding = this.updatePoints.bind(this);
+
+    this.on('modifystart', this.startChange);
+  }
+
+  private startChange(event: ModifyEvent) {
+    const features = event.features.getArray();
+    if (features.length === 1) {
+      const geometry = features[0].getGeometry();
+      if (geometry instanceof Polygon) {
+        this.modifyFeature = features[0] as Feature<Polygon>;
+        this.modifyGeometry = geometry;
+        this.findModifiedPoint(event.mapBrowserEvent);
+        if (this.movePointConf === null) {
+          this.getMap()!.once('pointermove', this.findModifiedPoint.bind(this));
+        }
+        this.getMap()!.on('pointermove', this.updatePointsBinding);
+      }
+    }
+  }
+
+  private endChange(event: ModifyEvent) {
+    this.getMap()!.un('pointermove', this.updatePointsBinding);
+    if (this.modifyGeometry && this.movePointConf) {
+      this.adjustPoints(event.mapBrowserEvent.coordinate, this.modifyGeometry, true, this.movePointConf);
+    }
+    this.dispatchEvent({
+      type: 'modifyrectangleend',
+      modifyFeature: this.modifyFeature,
+      movePointConf: this.movePointConf,
+      mapBrowserEvent: event.mapBrowserEvent,
+    } as any);
+    this.movePointConf = null;
+    this.modifyGeometry = null;
+    this.modifyFeature = null;
+  }
+
+  private findModifiedPoint(event: MapBrowserEvent<any>) {
+    if (this.modifyGeometry) {
+      this.movePointConf = this.findIndexToModify(event.coordinate, this.modifyGeometry);
+
+      if (this.movePointConf !== null) {
+        this.dispatchEvent({
+          type: 'modifyrectanglestart',
+          modifyFeature: this.modifyFeature,
+          movePointConf: this.movePointConf,
+          mapBrowserEvent: event,
+        } as ModifyRectangleEvent);
+        this.once('modifyend', this.endChange.bind(this));
+      }
+    }
+  }
+
+  updatePoints(event: MapBrowserEvent<any>) {
+    if (this.modifyGeometry && this.movePointConf) {
+      this.adjustPoints(event.coordinate, this.modifyGeometry, false, this.movePointConf);
+    }
+  }
+
+  findIndexToModify(mapCoord: Coordinate, rectangle: Polygon) {
+    const coordinateTolerance = this.pixelTolerance * this.getMap()?.getView().getResolution()!;
+    const coordinates = rectangle.getCoordinates();
+    let selectedVertexIndex: number | null = null;
+    let polyIndex = 0;
+    for (; polyIndex < coordinates.length; polyIndex++) {
+      for (let index = 0; index < coordinates[polyIndex].length; index++) {
+        const vertex = coordinates[polyIndex][index];
+        if (
+          Math.abs(vertex[0] - mapCoord[0]) < coordinateTolerance &&
+          Math.abs(vertex[1] - mapCoord[1]) < coordinateTolerance
+        ) {
+          selectedVertexIndex = index;
+          break;
+        }
+      }
+      if (selectedVertexIndex !== null) {
+        break;
+      }
+    }
+    if (selectedVertexIndex === null) {
+      if (coordinates[1].length === 6) {
+        //try again next movement:
+        this.getMap()!.once('pointermove', this.findModifiedPoint.bind(this));
+      }
+      return null;
+    }
+
+    if (coordinates[polyIndex].length > 6 || coordinates[polyIndex].length < 5) {
+      //something get wrong, cleanup polygon
+      const extent = boundingExtent(coordinates[polyIndex]);
+      const extentPoly = fromExtent(extent);
+      coordinates[polyIndex] = extentPoly.getCoordinates()[0];
+      rectangle.setCoordinates(coordinates);
+      return null;
+    }
+
+    const modifyX: number[] = [selectedVertexIndex];
+    const modifyY: number[] = [selectedVertexIndex];
+    const prevIndex = selectedVertexIndex === 0 ? coordinates[polyIndex].length - 2 : selectedVertexIndex - 1;
+    const nextIndex = selectedVertexIndex === coordinates[polyIndex].length - 2 ? 0 : selectedVertexIndex + 1;
+
+    const lastIndex = coordinates[polyIndex].length - 1;
+
+    let edgeMove = false;
+    if (coordinates[polyIndex].length === 6) {
+      //new point added => draw edge not corner
+      edgeMove = true;
+      //x or y edge
+      if (Math.abs(coordinates[polyIndex][prevIndex][0] - coordinates[polyIndex][nextIndex][0]) < Number.EPSILON) {
+        modifyX.push(prevIndex);
+        modifyX.push(nextIndex);
+      } else {
+        modifyY.push(prevIndex);
+        modifyY.push(nextIndex);
+      }
+    } else {
+      if (selectedVertexIndex === 0 || selectedVertexIndex === 2) {
+        modifyX.push(prevIndex);
+        modifyY.push(nextIndex);
+      } else {
+        modifyY.push(prevIndex);
+        modifyX.push(nextIndex);
+      }
+    }
+    if (modifyX.includes(0)) {
+      modifyX.push(lastIndex);
+    }
+    if (modifyY.includes(0)) {
+      modifyY.push(lastIndex);
+    }
+    return { modifyX, modifyY, edgeMove, selectedVertexIndex, polyIndex };
+  }
+
+  adjustPoints(mapCoord: Coordinate, rectangle: Polygon, end: boolean, conf: MovePointConf) {
+    const { modifyX, modifyY, edgeMove, selectedVertexIndex, polyIndex } = conf;
+    const coordinates = rectangle.getCoordinates();
+
+    for (const index of modifyX) {
+      coordinates[polyIndex][index][0] = mapCoord[0];
+    }
+    for (const index of modifyY) {
+      coordinates[polyIndex][index][1] = mapCoord[1];
+    }
+
+    if (edgeMove && end) {
+      coordinates[polyIndex].splice(selectedVertexIndex, 1);
+    }
+
+    rectangle.setCoordinates(coordinates);
+  }
+
+  public cancel() {
+    this.getMap()!.un('pointermove', this.updatePointsBinding);
+  }
+}

--- a/packages/app/src/app/search/search-autocomplete/search-autocomplete.component.html
+++ b/packages/app/src/app/search/search-autocomplete/search-autocomplete.component.html
@@ -1,0 +1,46 @@
+<mat-autocomplete
+  #autocompleteRef="matAutocomplete"
+  (optionSelected)="entrySelected($event)"
+  (optionActivated)="entryActivated($event.option?.value)"
+>
+  <ng-template let-location="location" #option>
+    <mat-option [value]="location" (mouseenter)="entryActivated(location)" (mouseleave)="entryDeactivated()">
+      <span [innerHTML]="location.label" [title]="getLabel(location)"></span>
+    </mat-option>
+  </ng-template>
+  @if (foundLocations().length === 1) {
+    @for (location of foundLocations()[0].results; track location.lonLat) {
+      <ng-container [ngTemplateOutlet]="option" [ngTemplateOutletContext]="{ location: location }"></ng-container>
+    }
+  } @else {
+    @for (group of foundLocations(); track group) {
+      <mat-optgroup
+        [label]="group.config.label + ' (' + group.results.length + ')'"
+        (mousedown)="expandGroup(group, $event)"
+      >
+        <ng-container>
+          @if (group.collapsed === 'peek') {
+            @for (location of group.results | slice: 0 : 3; track location.lonLat) {
+              <ng-container
+                [ngTemplateOutlet]="option"
+                [ngTemplateOutletContext]="{ location: location }"
+              ></ng-container>
+            }
+            @if (group.results.length > 3) {
+              <div class="hasMore">...</div>
+            }
+          } @else if (!group.collapsed) {
+            @for (location of group.results; track location.lonLat) {
+              <ng-container
+                [ngTemplateOutlet]="option"
+                [ngTemplateOutletContext]="{ location: location }"
+              ></ng-container>
+            }
+          } @else {
+            <mat-option class="dummyOption"></mat-option>
+          }
+        </ng-container>
+      </mat-optgroup>
+    }
+  }
+</mat-autocomplete>

--- a/packages/app/src/app/search/search-autocomplete/search-autocomplete.component.html
+++ b/packages/app/src/app/search/search-autocomplete/search-autocomplete.component.html
@@ -9,7 +9,7 @@
     </mat-option>
   </ng-template>
   @if (foundLocations().length === 1) {
-    @for (location of foundLocations()[0].results; track location.lonLat) {
+    @for (location of foundLocations()[0].results; track location.lonLat || location.feature) {
       <ng-container [ngTemplateOutlet]="option" [ngTemplateOutletContext]="{ location: location }"></ng-container>
     }
   } @else {

--- a/packages/app/src/app/search/search-autocomplete/search-autocomplete.component.html
+++ b/packages/app/src/app/search/search-autocomplete/search-autocomplete.component.html
@@ -9,7 +9,7 @@
     </mat-option>
   </ng-template>
   @if (foundLocations().length === 1) {
-    @for (location of foundLocations()[0].results; track location.lonLat || location.feature) {
+    @for (location of foundLocations()[0].results; track location.internal?.id || location.lonLat || location.label) {
       <ng-container [ngTemplateOutlet]="option" [ngTemplateOutletContext]="{ location: location }"></ng-container>
     }
   } @else {
@@ -20,7 +20,10 @@
       >
         <ng-container>
           @if (group.collapsed === 'peek') {
-            @for (location of group.results | slice: 0 : 3; track location.lonLat) {
+            @for (
+              location of group.results | slice: 0 : 3;
+              track location.internal?.id || location.lonLat || location.label
+            ) {
               <ng-container
                 [ngTemplateOutlet]="option"
                 [ngTemplateOutletContext]="{ location: location }"
@@ -30,7 +33,7 @@
               <div class="hasMore">...</div>
             }
           } @else if (!group.collapsed) {
-            @for (location of group.results; track location.lonLat) {
+            @for (location of group.results; track location.internal?.id || location.lonLat || location.label) {
               <ng-container
                 [ngTemplateOutlet]="option"
                 [ngTemplateOutletContext]="{ location: location }"

--- a/packages/app/src/app/search/search-autocomplete/search-autocomplete.component.scss
+++ b/packages/app/src/app/search/search-autocomplete/search-autocomplete.component.scss
@@ -1,0 +1,17 @@
+.mat-option {
+  font-size: 0.7em;
+}
+
+mat-optgroup {
+  cursor: pointer;
+}
+
+.hasMore {
+  cursor: pointer;
+  text-align: center;
+}
+
+/* invisible element to prevent autocomplete is closed/hidden if there are only mat-optgroups */
+.dummyOption {
+  display: none;
+}

--- a/packages/app/src/app/search/search-autocomplete/search-autocomplete.component.spec.ts
+++ b/packages/app/src/app/search/search-autocomplete/search-autocomplete.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SearchAutocompleteComponent } from './search-autocomplete.component';
+
+describe('SearchAutocompleteComponent', () => {
+  let component: SearchAutocompleteComponent;
+  let fixture: ComponentFixture<SearchAutocompleteComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SearchAutocompleteComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SearchAutocompleteComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/packages/app/src/app/search/search-autocomplete/search-autocomplete.component.ts
+++ b/packages/app/src/app/search/search-autocomplete/search-autocomplete.component.ts
@@ -1,0 +1,42 @@
+import { Component, ViewChild, input, output } from '@angular/core';
+import { MatAutocompleteModule, MatAutocompleteSelectedEvent, MatAutocomplete } from '@angular/material/autocomplete';
+import { IResultSet, IZsMapSearchResult } from '@zskarte/types';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-search-autocomplete',
+  templateUrl: './search-autocomplete.component.html',
+  styleUrl: './search-autocomplete.component.scss',
+  imports: [MatAutocompleteModule, CommonModule],
+})
+export class SearchAutocompleteComponent {
+  @ViewChild('autocompleteRef', { static: false }) autocompleteRef!: MatAutocomplete;
+  foundLocations = input<IResultSet[]>([]);
+  selected = output<IZsMapSearchResult>();
+  active = output<IZsMapSearchResult | null>();
+
+  // skipcq: JS-0105
+  expandGroup(group: IResultSet, $event: MouseEvent) {
+    if (!($event.target as Element).closest('mat-option')) {
+      group.collapsed = !group.collapsed;
+      $event.preventDefault();
+    }
+  }
+
+  // skipcq: JS-0105
+  getLabel(selected: IZsMapSearchResult): string {
+    return selected ? selected.label.replace(/<[^>]*>/g, '') : '';
+  }
+
+  entrySelected(event: MatAutocompleteSelectedEvent) {
+    this.selected.emit(event.option.value);
+  }
+
+  entryActivated(value: IZsMapSearchResult) {
+    this.active.emit(value);
+  }
+
+  entryDeactivated() {
+    this.active.emit(null);
+  }
+}

--- a/packages/app/src/app/search/search.service.spec.ts
+++ b/packages/app/src/app/search/search.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SearchService } from './search.service';
+
+describe('SearchService', () => {
+  let service: SearchService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SearchService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/packages/app/src/app/search/search.service.ts
+++ b/packages/app/src/app/search/search.service.ts
@@ -1,13 +1,162 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
-import { IResultSet, IZsMapSearchConfig, SearchFunction } from '../../../../types/state/interfaces';
+import {
+  IFoundLocation,
+  IResultSet,
+  IZsMapSearchConfig,
+  IZsMapSearchResult,
+  SearchFunction,
+} from '../../../../types/state/interfaces';
+import { coordinateFromString } from '../helper/coordinates-extract';
+import { I18NService } from '../state/i18n.service';
+import { GeoJSONFeature, default as GeoJSON } from 'ol/format/GeoJSON';
+import { Feature } from 'ol';
+import { Geometry, LineString, MultiLineString } from 'ol/geom';
+import { Extent, containsCoordinate, getCenter } from 'ol/extent';
+import { Coordinate, distance } from 'ol/coordinate';
+import { transform } from 'ol/proj';
+import { ZsMapStateService } from '../state/state.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class SearchService {
+  private _i18n = inject(I18NService);
+  private _state = inject(ZsMapStateService);
+
   private _searchConfigs: IZsMapSearchConfig[] = [];
+  private sortReferencePoint: Coordinate | null = null;
+  private filterArea: Extent | null = null;
+  private _softFilterMaxDist = 20_000;
+
+  geocoderUrl = 'https://api3.geo.admin.ch/rest/services/api/SearchServer?type=locations&searchText=';
+  streetGeometryUrl =
+    'https://api3.geo.admin.ch/rest/services/api/MapServer/find?layer=ch.swisstopo.amtliches-strassenverzeichnis&searchField=stn_label&geometryFormat=geojson&sr=3857&searchText=';
+  streetGeometryByIdUrl =
+    'https://api3.geo.admin.ch/rest/services/api/MapServer/find?layer=ch.swisstopo.amtliches-strassenverzeichnis&searchField=str_esid&geometryFormat=geojson&sr=4326&contains=false&searchText=';
+
+  constructor() {
+    this.addSearch(this.coordinateSearch.bind(this), this._i18n.get('coordinates'), undefined, -1);
+    this.addSearch(this.geoAdminStreetGeometrySearch.bind(this), this._i18n.get('streetSearch'), undefined, 50);
+    this.addSearch(this.geoAdminLocationSearch.bind(this), 'Geo Admin', undefined, 100);
+  }
+
+  public setSortReferencePoint(center: Coordinate) {
+    this.sortReferencePoint = center;
+  }
+
+  private getSortReferencePoint() {
+    return this.sortReferencePoint ?? this._state.getMapCenter();
+  }
+
+  private getFilterArea() {
+    return this.filterArea;
+  }
+
+  private getSoftFilterArea() {
+    return this._state.getMapExtent();
+  }
+
+  private filterByAreaOrDistance(locations: IZsMapSearchResult[]) {
+    const filterArea = this.getFilterArea();
+    if (filterArea) {
+      return locations.filter((l) => l.internal?.center && containsCoordinate(filterArea, l.internal.center));
+    }
+    const softFilterArea = this.getSoftFilterArea();
+    return locations.filter(
+      (l) =>
+        (l.internal?.center && containsCoordinate(softFilterArea, l.internal.center)) ||
+        (l.internal?.dist && l.internal.dist < this._softFilterMaxDist),
+    );
+  }
+
+  async coordinateSearch(text: string) {
+    const coords = coordinateFromString(text);
+    if (coords) {
+      return [{ label: text, lonLat: coords }];
+    }
+    return [];
+  }
+
+  async geoAdminLocationSearch(text: string, abortController: AbortController, maxResultCount?: number) {
+    if (!navigator.onLine) {
+      return [];
+    }
+    let url = this.geocoderUrl + encodeURIComponent(text);
+    if (maxResultCount !== undefined) {
+      url = `${url}&limit=${maxResultCount}`;
+    }
+    const result: { results: IFoundLocation[] } = await fetch(url).then((response) => response.json());
+    if (abortController.signal.aborted) {
+      // if there is already a new search query skip map results as they are not displayed.
+      return [];
+    }
+    const sortCenter = this.getSortReferencePoint();
+    const foundLocations: IZsMapSearchResult[] = [];
+
+    result.results
+      .filter((r) => r?.attrs?.label)
+      .forEach((r) => {
+        const lonLat = [r.attrs.lon, r.attrs.lat];
+        const mercatorCoordinates = transform(lonLat, 'EPSG:4326', 'EPSG:3857');
+        const dist = distance(sortCenter, mercatorCoordinates);
+        foundLocations.push({
+          label: r.attrs.label,
+          lonLat,
+          mercatorCoordinates,
+          internal: { ...r, dist, center: mercatorCoordinates },
+        });
+      });
+    foundLocations.sort((a, b) => a.internal.dist - b.internal.dist);
+    return foundLocations;
+  }
+
+  async geoAdminStreetGeometrySearch(text: string, abortController: AbortController) {
+    if (!navigator.onLine) {
+      return [];
+    }
+    const url = this.streetGeometryUrl + encodeURIComponent(text);
+    const format = new GeoJSON();
+    const result: { results: GeoJSONFeature[] } = await fetch(url).then((response) => response.json());
+    if (abortController.signal.aborted) {
+      // if there is already a new search query skip map results as they are not displayed.
+      return [];
+    }
+    const sortCenter = this.getSortReferencePoint();
+    const foundLocations: IZsMapSearchResult[] = [];
+    result.results
+      .filter((r) => r?.properties?.['stn_label'])
+      .forEach((r) => {
+        const feature = format.readFeature(r) as Feature<Geometry>;
+        let center = getCenter(r.bbox as Extent);
+        const geometry = feature.getGeometry();
+        if (geometry && 'getClosestPoint' in geometry) {
+          center = geometry.getClosestPoint(center);
+        }
+        const dist = distance(sortCenter, center);
+        foundLocations.push({
+          label: `${r.properties?.['stn_label']} (${r.properties?.['zip_label']})`,
+          feature,
+          internal: { dist, center },
+        });
+      });
+    foundLocations.sort((a, b) => a.internal.dist - b.internal.dist);
+    return this.filterByAreaOrDistance(foundLocations);
+  }
+
+  public async geoAdminStreetGeometryById(id: string) {
+    if (!navigator.onLine) {
+      return null;
+    }
+    const url = this.streetGeometryByIdUrl + encodeURIComponent(id);
+    const format = new GeoJSON();
+    const result: { results: GeoJSONFeature[] } = await fetch(url).then((response) => response.json());
+    if (result.results.length > 0) {
+      return format.readFeature(result.results[0]) as Feature<Geometry>;
+    }
+    return null;
+  }
 
   public addSearch(
     searchFunc: SearchFunction,
@@ -60,6 +209,10 @@ export class SearchService {
     };
   }
 
+  async simpleSearch(searchText: string): Promise<IResultSet[]> {
+    return (await this.processConfigs(searchText, new AbortController())) ?? [];
+  }
+
   private async processConfigs(searchText: string, abortController: AbortController): Promise<IResultSet[] | null> {
     if (searchText.length <= 1) {
       return [];
@@ -74,7 +227,7 @@ export class SearchService {
       }
 
       try {
-        const results = await config.func(searchText, config.maxResultCount);
+        const results = await config.func(searchText, abortController, config.maxResultCount);
         if (results.length > 0) {
           resultSets.push({ config, results, collapsed: 'peek' });
         }

--- a/packages/app/src/app/search/search.service.ts
+++ b/packages/app/src/app/search/search.service.ts
@@ -1,0 +1,91 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
+import { IResultSet, IZsMapSearchConfig, SearchFunction } from '../../../../types/state/interfaces';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SearchService {
+  private _searchConfigs: IZsMapSearchConfig[] = [];
+
+  public addSearch(
+    searchFunc: SearchFunction,
+    searchName: string,
+    maxResultCount: number | undefined = undefined,
+    resultOrder: number | undefined = undefined,
+  ) {
+    const configs = this._searchConfigs;
+    const config: IZsMapSearchConfig = {
+      label: searchName,
+      func: searchFunc,
+      active: true,
+      maxResultCount: maxResultCount ?? 50,
+      resultOrder: resultOrder ?? 0,
+    };
+    configs.push(config);
+    configs.sort((a, b) => a.resultOrder - b.resultOrder);
+    this._searchConfigs = configs;
+  }
+
+  public removeSearch(searchFunc: SearchFunction) {
+    this._searchConfigs = this._searchConfigs.filter((conf) => conf.func !== searchFunc);
+  }
+
+  createSearchInstance(): {
+    searchResults$: Observable<IResultSet[] | null>;
+    updateSearchTerm: (searchText: string) => void;
+  } {
+    const searchSubject = new BehaviorSubject<string>('');
+    let abortController: AbortController | undefined;
+
+    const searchResults$ = searchSubject.pipe(
+      debounceTime(300),
+      distinctUntilChanged(),
+      switchMap(async (searchText) => {
+        if (abortController) {
+          abortController.abort();
+        }
+        abortController = new AbortController();
+
+        return this.processConfigs(searchText, abortController);
+      }),
+    );
+
+    return {
+      searchResults$,
+      updateSearchTerm: (searchText: string) => {
+        searchSubject.next(searchText);
+      },
+    };
+  }
+
+  private async processConfigs(searchText: string, abortController: AbortController): Promise<IResultSet[] | null> {
+    if (searchText.length <= 1) {
+      return [];
+    }
+    const resultSets: IResultSet[] = [];
+
+    for (const config of this._searchConfigs) {
+      if (!config.active) continue;
+
+      if (abortController.signal.aborted) {
+        return null;
+      }
+
+      try {
+        const results = await config.func(searchText, config.maxResultCount);
+        if (results.length > 0) {
+          resultSets.push({ config, results, collapsed: 'peek' });
+        }
+      } catch (error: any) {
+        if (error.name === 'AbortError') {
+          return [];
+        }
+        console.error('Error on handle search config:', error);
+      }
+    }
+
+    return resultSets;
+  }
+}

--- a/packages/app/src/app/search/search.service.ts
+++ b/packages/app/src/app/search/search.service.ts
@@ -6,17 +6,23 @@ import {
   IResultSet,
   IZsMapSearchConfig,
   IZsMapSearchResult,
+  IZsGlobalSearchConfig,
   SearchFunction,
 } from '../../../../types/state/interfaces';
 import { coordinateFromString } from '../helper/coordinates-extract';
 import { I18NService } from '../state/i18n.service';
 import { GeoJSONFeature, default as GeoJSON } from 'ol/format/GeoJSON';
 import { Feature } from 'ol';
-import { Geometry, LineString, MultiLineString } from 'ol/geom';
-import { Extent, containsCoordinate, getCenter } from 'ol/extent';
-import { Coordinate, distance } from 'ol/coordinate';
-import { transform } from 'ol/proj';
+import { Geometry } from 'ol/geom';
+import { Extent, containsCoordinate, getCenter, extend, getIntersection, createEmpty } from 'ol/extent';
+import { Coordinate, distance, squaredDistance } from 'ol/coordinate';
+import { transform, transformExtent } from 'ol/proj';
 import { ZsMapStateService } from '../state/state.service';
+
+const FULL_WIDTH_SWISS = 350_000;
+const FULL_HEIGHT_SWISS = 226_000;
+
+type zoomToFitFunc = (extent: Extent, padding?: [number, number, number, number], maxZoom?: number) => void;
 
 @Injectable({
   providedIn: 'root',
@@ -24,11 +30,9 @@ import { ZsMapStateService } from '../state/state.service';
 export class SearchService {
   private _i18n = inject(I18NService);
   private _state = inject(ZsMapStateService);
+  private zoomToFit: zoomToFitFunc | null = null;
 
   private _searchConfigs: IZsMapSearchConfig[] = [];
-  private sortReferencePoint: Coordinate | null = null;
-  private filterArea: Extent | null = null;
-  private _softFilterMaxDist = 20_000;
 
   geocoderUrl = 'https://api3.geo.admin.ch/rest/services/api/SearchServer?type=locations&searchText=';
   streetGeometryUrl =
@@ -42,33 +46,63 @@ export class SearchService {
     this.addSearch(this.geoAdminLocationSearch.bind(this), 'Geo Admin', undefined, 100);
   }
 
-  public setSortReferencePoint(center: Coordinate) {
-    this.sortReferencePoint = center;
+  public setZoomToFit(func: zoomToFitFunc) {
+    this.zoomToFit = func;
   }
 
-  private getSortReferencePoint() {
-    return this.sortReferencePoint ?? this._state.getMapCenter();
+  public getDistanceReferenceCoordinate(searchConfig: IZsGlobalSearchConfig) {
+    return searchConfig.distanceReferenceCoordinate ?? this._state.getMapCenter();
   }
 
-  private getFilterArea() {
-    return this.filterArea;
+  private extendExtentAroundPoint(extent: Extent, refCoord: Coordinate) {
+    const [minX, minY, maxX, maxY] = extent;
+
+    const distanceLeft = refCoord[0] - minX;
+    const distanceRight = maxX - refCoord[0];
+    const distanceTop = maxY - refCoord[1];
+    const distanceBottom = refCoord[1] - minY;
+    const maxDistance = Math.max(distanceLeft, distanceRight, distanceTop, distanceBottom);
+
+    return this.getExtentByCoordAndDist(refCoord, maxDistance);
   }
 
-  private getSoftFilterArea() {
-    return this._state.getMapExtent();
+  public getExtentByCoordAndDist(center: Coordinate, dist: number) {
+    //web mercator / EPSG:3857 is a metric system so can calucate directly.
+    return [center[0] - dist, center[1] - dist, center[0] + dist, center[1] + dist];
   }
 
-  private filterByAreaOrDistance(locations: IZsMapSearchResult[]) {
-    const filterArea = this.getFilterArea();
-    if (filterArea) {
-      return locations.filter((l) => l.internal?.center && containsCoordinate(filterArea, l.internal.center));
+  private createOrCombineExtent(combinedExtent: Extent | null, newExtent: Extent) {
+    if (!combinedExtent) {
+      combinedExtent = createEmpty();
+      extend(combinedExtent, newExtent);
+    } else {
+      getIntersection(combinedExtent, newExtent, combinedExtent);
     }
-    const softFilterArea = this.getSoftFilterArea();
-    return locations.filter(
-      (l) =>
-        (l.internal?.center && containsCoordinate(softFilterArea, l.internal.center)) ||
-        (l.internal?.dist && l.internal.dist < this._softFilterMaxDist),
-    );
+    return combinedExtent;
+  }
+
+  public getSearchFilterArea(searchConfig: IZsGlobalSearchConfig) {
+    let combinedExtent: Extent | null = null;
+    if (searchConfig.filterByArea) {
+      const areaExtent = searchConfig.area;
+      if (areaExtent) {
+        combinedExtent = this.createOrCombineExtent(combinedExtent, areaExtent);
+      }
+    }
+
+    if (searchConfig.filterMapSection) {
+      const mapExtent = this._state.getMapExtent();
+      combinedExtent = this.createOrCombineExtent(combinedExtent, mapExtent);
+    }
+
+    if (searchConfig.filterByDistance) {
+      const distExtent = this.getExtentByCoordAndDist(
+        this.getDistanceReferenceCoordinate(searchConfig),
+        searchConfig.maxDistance,
+      );
+      combinedExtent = this.createOrCombineExtent(combinedExtent, distExtent);
+    }
+    return combinedExtent;
   }
 
   async coordinateSearch(text: string) {
@@ -79,7 +113,12 @@ export class SearchService {
     return [];
   }
 
-  async geoAdminLocationSearch(text: string, abortController: AbortController, maxResultCount?: number) {
+  async geoAdminLocationSearch(
+    text: string,
+    abortController: AbortController,
+    searchConfig: IZsGlobalSearchConfig,
+    maxResultCount?: number,
+  ) {
     if (!navigator.onLine) {
       return [];
     }
@@ -87,32 +126,77 @@ export class SearchService {
     if (maxResultCount !== undefined) {
       url = `${url}&limit=${maxResultCount}`;
     }
+
+    const refCoord = this.getDistanceReferenceCoordinate(searchConfig);
+    const filterArea = this.getSearchFilterArea(searchConfig);
+    let boxArea = filterArea;
+    let boxAreaManipulated = false;
+    if (searchConfig.sortedByDistance) {
+      if (!boxArea) {
+        //on geoadmin search the result can only be sorted by distance of center if there is an extent to get center from.
+        //so create an extent from refCoord that always includes at least the whole swiss.
+        boxArea = [
+          refCoord[0] - FULL_WIDTH_SWISS,
+          refCoord[1] - FULL_HEIGHT_SWISS,
+          refCoord[0] + FULL_WIDTH_SWISS,
+          refCoord[1] + FULL_HEIGHT_SWISS,
+        ];
+        boxAreaManipulated = true;
+      } else {
+        //if there is an filterArea, it's not guaranted that the center of the extend is refCoord
+        //so create a new on that is at least filterArea but have refCoord as center
+        if (containsCoordinate(boxArea, refCoord)) {
+          //if the refCoord is not in allowed area keep area as is
+          boxArea = this.extendExtentAroundPoint(boxArea, refCoord);
+          boxAreaManipulated = true;
+        }
+      }
+    }
+    if (boxArea) {
+      boxArea = transformExtent(boxArea, 'EPSG:3857', 'EPSG:21781');
+      url = `${url}&bbox=${boxArea?.join(',')}&sortbbox=${searchConfig.sortedByDistance}`;
+    }
+    if (abortController.signal.aborted) {
+      // if there is already a new search query skip request
+      return [];
+    }
+
     const result: { results: IFoundLocation[] } = await fetch(url).then((response) => response.json());
     if (abortController.signal.aborted) {
       // if there is already a new search query skip map results as they are not displayed.
       return [];
     }
-    const sortCenter = this.getSortReferencePoint();
-    const foundLocations: IZsMapSearchResult[] = [];
 
+    const foundLocations: IZsMapSearchResult[] = [];
     result.results
       .filter((r) => r?.attrs?.label)
       .forEach((r) => {
         const lonLat = [r.attrs.lon, r.attrs.lat];
         const mercatorCoordinates = transform(lonLat, 'EPSG:4326', 'EPSG:3857');
-        const dist = distance(sortCenter, mercatorCoordinates);
+        //if bbox is manipulated for sort order need to redo the area check
+        if (boxAreaManipulated && filterArea && !containsCoordinate(filterArea, mercatorCoordinates)) {
+          return;
+        }
+        if (
+          r.attrs.objectclass === 'TLM_GEBIETSNAME' &&
+          (r.attrs.label.indexOf('Grossregion') !== -1 || r.attrs.label.indexOf('Landschaftsname') !== -1)
+        ) {
+          return;
+        }
         foundLocations.push({
           label: r.attrs.label,
           lonLat,
           mercatorCoordinates,
-          internal: { ...r, dist, center: mercatorCoordinates },
         });
       });
-    foundLocations.sort((a, b) => a.internal.dist - b.internal.dist);
     return foundLocations;
   }
 
-  async geoAdminStreetGeometrySearch(text: string, abortController: AbortController) {
+  async geoAdminStreetGeometrySearch(
+    text: string,
+    abortController: AbortController,
+    searchConfig: IZsGlobalSearchConfig,
+  ) {
     if (!navigator.onLine) {
       return [];
     }
@@ -123,7 +207,9 @@ export class SearchService {
       // if there is already a new search query skip map results as they are not displayed.
       return [];
     }
-    const sortCenter = this.getSortReferencePoint();
+
+    const refCoord = this.getDistanceReferenceCoordinate(searchConfig);
+    const filterArea = this.getSearchFilterArea(searchConfig);
     const foundLocations: IZsMapSearchResult[] = [];
     result.results
       .filter((r) => r?.properties?.['stn_label'])
@@ -134,15 +220,25 @@ export class SearchService {
         if (geometry && 'getClosestPoint' in geometry) {
           center = geometry.getClosestPoint(center);
         }
-        const dist = distance(sortCenter, center);
-        foundLocations.push({
-          label: `${r.properties?.['stn_label']} (${r.properties?.['zip_label']})`,
-          feature,
-          internal: { dist, center },
-        });
+        if (!filterArea || containsCoordinate(filterArea, center)) {
+          const dist = squaredDistance(refCoord, center);
+          foundLocations.push({
+            label: `${r.properties?.['stn_label']} (${r.properties?.['zip_label']})`,
+            feature,
+            internal: {
+              dist,
+              center,
+            },
+          });
+        }
       });
-    foundLocations.sort((a, b) => a.internal.dist - b.internal.dist);
-    return this.filterByAreaOrDistance(foundLocations);
+    if (searchConfig.sortedByDistance) {
+      foundLocations.sort((a, b) => a.internal.dist - b.internal.dist);
+    } else {
+      const collator = new Intl.Collator();
+      foundLocations.sort((a, b) => collator.compare(a.label, b.label));
+    }
+    return foundLocations;
   }
 
   public async geoAdminStreetGeometryById(id: string) {
@@ -181,9 +277,10 @@ export class SearchService {
     this._searchConfigs = this._searchConfigs.filter((conf) => conf.func !== searchFunc);
   }
 
-  createSearchInstance(): {
+  createSearchInstance(searchConfig: IZsGlobalSearchConfig): {
     searchResults$: Observable<IResultSet[] | null>;
     updateSearchTerm: (searchText: string) => void;
+    updateSearchConfig: (newSearchConfig: IZsGlobalSearchConfig) => void;
   } {
     const searchSubject = new BehaviorSubject<string>('');
     let abortController: AbortController | undefined;
@@ -197,7 +294,7 @@ export class SearchService {
         }
         abortController = new AbortController();
 
-        return this.processConfigs(searchText, abortController);
+        return this.processConfigs(searchText, abortController, searchConfig);
       }),
     );
 
@@ -206,14 +303,22 @@ export class SearchService {
       updateSearchTerm: (searchText: string) => {
         searchSubject.next(searchText);
       },
+      updateSearchConfig: (newSearchConfig: IZsGlobalSearchConfig) => {
+        searchConfig = newSearchConfig;
+        searchSubject.next(searchSubject.value);
+      },
     };
   }
 
-  async simpleSearch(searchText: string): Promise<IResultSet[]> {
-    return (await this.processConfigs(searchText, new AbortController())) ?? [];
+  async simpleSearch(searchText: string, searchConfig: IZsGlobalSearchConfig): Promise<IResultSet[]> {
+    return (await this.processConfigs(searchText, new AbortController(), searchConfig)) ?? [];
   }
 
-  private async processConfigs(searchText: string, abortController: AbortController): Promise<IResultSet[] | null> {
+  private async processConfigs(
+    searchText: string,
+    abortController: AbortController,
+    searchConfig: IZsGlobalSearchConfig,
+  ): Promise<IResultSet[] | null> {
     if (searchText.length <= 1) {
       return [];
     }
@@ -227,7 +332,7 @@ export class SearchService {
       }
 
       try {
-        const results = await config.func(searchText, abortController, config.maxResultCount);
+        const results = await config.func(searchText, abortController, searchConfig, config.maxResultCount);
         if (results.length > 0) {
           resultSets.push({ config, results, collapsed: 'peek' });
         }
@@ -240,5 +345,37 @@ export class SearchService {
     }
 
     return resultSets;
+  }
+
+  public highlightResult(element: IZsMapSearchResult | null, focus: boolean) {
+    if (element) {
+      let coordinates: Coordinate | undefined;
+      if (element.mercatorCoordinates) {
+        coordinates = element.mercatorCoordinates;
+      } else if (element.lonLat) {
+        coordinates = element.mercatorCoordinates = transform(element.lonLat, 'EPSG:4326', 'EPSG:3857');
+      }
+      if (coordinates) {
+        this._state.updateSearchResultFeatures([]);
+        this._state.updatePositionFlag({ isVisible: true, coordinates });
+        if (focus) {
+          this._state.setMapCenter(coordinates);
+        }
+        return;
+      } else if (element.feature) {
+        this._state.updateSearchResultFeatures([element.feature]);
+        const extent = element.feature.getGeometry()?.getExtent();
+        if (focus && extent) {
+          if (this.zoomToFit) {
+            this.zoomToFit(extent);
+          }
+          this._state.updatePositionFlag({ isVisible: false, coordinates: [0, 0] });
+        } else {
+          this._state.updatePositionFlag({ isVisible: true, coordinates: element.internal.center ?? [0, 0] });
+        }
+        return;
+      }
+    }
+    this._state.updatePositionFlag({ isVisible: false, coordinates: [0, 0] });
   }
 }

--- a/packages/app/src/app/sidebar/sidebar-journal-entry/sidebar-journal-entry.component.ts
+++ b/packages/app/src/app/sidebar/sidebar-journal-entry/sidebar-journal-entry.component.ts
@@ -64,13 +64,7 @@ export class SidebarJournalEntryComponent implements OnDestroy {
         extendExtent(extent, featureExtent);
       }
     });
-    this._renderer
-      .getMap()
-      .getView()
-      .fit(extent, {
-        padding: [100, 600, 100, 100],
-        maxZoom: 18,
-      });
+    this._renderer.zoomToFit(extent, [100, 600, 100, 100]);
   }
 
   toggleHighlightAll() {

--- a/packages/app/src/app/state/i18n.service.ts
+++ b/packages/app/src/app/state/i18n.service.ts
@@ -3105,6 +3105,11 @@ export class I18NService {
       en: 'This journal entry has changes that are only local.',
       fr: 'Cette entrée de journal comporte des modifications qui sont uniquement locales.',
     },
+    streetSearch: {
+      de: 'Strassensuche',
+      en: 'Street search',
+      fr: 'Recherche dans la rue',
+    },
   };
 
   public getLabelForSign(sign: Sign): string {

--- a/packages/app/src/app/state/i18n.service.ts
+++ b/packages/app/src/app/state/i18n.service.ts
@@ -3110,6 +3110,41 @@ export class I18NService {
       en: 'Street search',
       fr: 'Recherche dans la rue',
     },
+    filterMapSection: {
+      de: 'Nur Ergebnisse aus Kartenausschnitt',
+      en: 'Only results from map section',
+      fr: 'Seuls les résultats de la section de la carte',
+    },
+    filterByDistance: {
+      de: 'Nur Ergebnisse bis max Distanz',
+      en: 'Only results up to max distance',
+      fr: "Résultats uniquement jusqu'à la distance maximale",
+    },
+    maxDistance: {
+      de: 'Max Distanz',
+      en: 'Max distance',
+      fr: 'Distance maximale',
+    },
+    filterByArea: {
+      de: 'Nur Ergebnisse aus definiertem Bereich',
+      en: 'Only results from a defined area',
+      fr: 'Résulte uniquement d’une zone définie',
+    },
+    defineArea: {
+      de: 'Bereich definieren',
+      en: 'Define area',
+      fr: 'Définir la zone',
+    },
+    endDefineArea: {
+      de: 'Bereich definieren beenden',
+      en: 'End define area',
+      fr: 'Quitter définir la zone',
+    },
+    sortedByDistance: {
+      de: 'Sortiert nach Distanz',
+      en: 'Sorted by distance',
+      fr: 'Triés par distance',
+    },
   };
 
   public getLabelForSign(sign: Sign): string {

--- a/packages/app/src/app/state/state.service.ts
+++ b/packages/app/src/app/state/state.service.ts
@@ -33,7 +33,7 @@ import { Patch, applyPatches, produce } from 'immer';
 import { isEqual } from 'lodash';
 import { Feature } from 'ol';
 import { Coordinate } from 'ol/coordinate';
-import { SimpleGeometry } from 'ol/geom';
+import { Geometry, SimpleGeometry } from 'ol/geom';
 import { getPointResolution, transform } from 'ol/proj';
 import { BehaviorSubject, Observable, Subject, combineLatest, lastValueFrom, merge } from 'rxjs';
 import { debounceTime, distinctUntilChanged, filter, map, takeUntil, takeWhile } from 'rxjs/operators';
@@ -64,6 +64,7 @@ import { JournalService } from '../journal/journal.service';
 import { Sort } from '@angular/material/sort';
 import { NavigationEnd, Router } from '@angular/router';
 import { Location } from '@angular/common';
+import { Extent } from 'ol/extent';
 
 type VIEW_NAMES = 'map' | 'journal';
 
@@ -108,6 +109,7 @@ export class ZsMapStateService {
   private _globalWmsSources = new BehaviorSubject<WmsSource[]>([]);
   private _globalMapLayers = new BehaviorSubject<MapLayer[]>([]);
   private _activeView = new BehaviorSubject<VIEW_NAMES>('map');
+  private _searchResultFeatures = new BehaviorSubject<Feature<Geometry>[]>([]);
   public urlFragment = signal<string | null>(null);
 
   constructor() {
@@ -156,6 +158,7 @@ export class ZsMapStateService {
       positionFlag: { coordinates: DEFAULT_COORDINATES, isVisible: false },
       mapCenter: DEFAULT_COORDINATES,
       mapZoom: DEFAULT_ZOOM,
+      mapExtent: [...DEFAULT_COORDINATES, ...DEFAULT_COORDINATES],
       dpi: DEFAULT_DPI,
       activeLayer: undefined,
       showMyLocation: false,
@@ -537,6 +540,41 @@ export class ZsMapStateService {
     this.updateDisplayState((draft) => {
       draft.mapCenter = coordinates;
     });
+  }
+
+  public getMapCenter() {
+    return this._display.value.mapCenter;
+  }
+
+  // searchResultFeatures
+  public observeSearchResultFeatures(): Observable<Feature<Geometry>[]> {
+    return this._searchResultFeatures.pipe(distinctUntilChanged((x, y) => isEqual(x, y)));
+  }
+
+  public updateSearchResultFeatures(result: Feature<Geometry>[]) {
+    this._searchResultFeatures.next(result);
+  }
+
+  public getSearchResultFeatures(): Feature<Geometry>[] {
+    return this._searchResultFeatures.value;
+  }
+
+  // mapExtent
+  public observeMapExtent(): Observable<Extent> {
+    return this._display.pipe(
+      map((o) => o.mapExtent),
+      distinctUntilChanged((x, y) => isEqual(x,y)),
+    );
+  }
+
+  public setMapExtent(extent: Extent) {
+    this.updateDisplayState((draft) => {
+      draft.mapExtent = extent;
+    });
+  }
+
+  public getMapExtent(): Extent {
+    return this._display.value.mapExtent;
   }
 
   // source

--- a/packages/app/src/app/state/state.service.ts
+++ b/packages/app/src/app/state/state.service.ts
@@ -3,6 +3,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import {
   IPositionFlag,
+  IZsGlobalSearchConfig,
   IZsJournalFilter,
   IZsMapDisplayState,
   IZsMapPrintExtent,
@@ -182,6 +183,15 @@ export class ZsMapStateService {
         decisionFilter: false,
         keyMessageFilter: false,
       },
+      searchConfig: {
+        filterMapSection: false,
+        filterByDistance: false,
+        maxDistance: 20_000,
+        filterByArea: false,
+        area: null,
+        sortedByDistance: false,
+        distanceReferenceCoordinate: null,
+      }
     };
     if (!mapState) {
       mapState = this._map.value;
@@ -575,6 +585,24 @@ export class ZsMapStateService {
 
   public getMapExtent(): Extent {
     return this._display.value.mapExtent;
+  }
+
+  // searchConfig
+  public observeSearchConfig(): Observable<IZsGlobalSearchConfig> {
+    return this._display.pipe(
+      map((o) => o.searchConfig),
+      distinctUntilChanged((x, y) => isEqual(x,y)),
+    );
+  }
+
+  public setSearchConfig(searchConfig: IZsGlobalSearchConfig) {
+    this.updateDisplayState((draft) => {
+      draft.searchConfig = searchConfig;
+    });
+  }
+
+  public getSearchConfig(): IZsGlobalSearchConfig {
+    return this._display.value.searchConfig;
   }
 
   // source

--- a/packages/app/src/app/state/state.service.ts
+++ b/packages/app/src/app/state/state.service.ts
@@ -107,7 +107,6 @@ export class ZsMapStateService {
   private _currentMapCenter: BehaviorSubject<number[]> | undefined;
   private _globalWmsSources = new BehaviorSubject<WmsSource[]>([]);
   private _globalMapLayers = new BehaviorSubject<MapLayer[]>([]);
-  private _searchConfigs = new BehaviorSubject<IZsMapSearchConfig[]>([]);
   private _activeView = new BehaviorSubject<VIEW_NAMES>('map');
   public urlFragment = signal<string | null>(null);
 
@@ -1249,33 +1248,6 @@ export class ZsMapStateService {
     const hasWritePermission = this._session.hasWritePermission();
     const isArchived = this._session.isArchived();
     return !hasWritePermission || isArchived || isHistoryMode;
-  }
-
-  public addSearch(
-    searchFunc: SearchFunction,
-    searchName: string,
-    maxResultCount: number | undefined = undefined,
-    resultOrder: number | undefined = undefined,
-  ) {
-    const configs = this._searchConfigs.value;
-    const config: IZsMapSearchConfig = {
-      label: searchName,
-      func: searchFunc,
-      active: true,
-      maxResultCount: maxResultCount ?? 50,
-      resultOrder: resultOrder ?? 0,
-    };
-    configs.push(config);
-    this._searchConfigs.next(configs);
-  }
-
-  public removeSearch(searchFunc: SearchFunction) {
-    const configs = this._searchConfigs.value.filter((conf) => conf.func !== searchFunc);
-    this._searchConfigs.next(configs);
-  }
-
-  public getSearchConfigs(): IZsMapSearchConfig[] {
-    return this._searchConfigs.value;
   }
 
   public canAddElements(): boolean {

--- a/packages/app/src/styles.scss
+++ b/packages/app/src/styles.scss
@@ -87,6 +87,10 @@ mat-action-list {
     0px 3px 14px 2px rgba(0, 0, 0, 0.12);
 }
 
+.cdk-overlay-pane:has(> .allow-overflow) {
+  overflow: visible;
+}
+
 .cdk-overlay-pane:not(:has(mat-option)) {
   box-shadow: none;
 }

--- a/packages/types/state/interfaces.ts
+++ b/packages/types/state/interfaces.ts
@@ -4,6 +4,8 @@ import { FillStyle, IconsOffset } from '../sign/interfaces';
 import { Feature } from 'ol';
 import { PermissionType } from '../session/interfaces';
 import { Sort } from '@angular/material/sort';
+import { Geometry } from 'ol/geom';
+import { Extent } from 'ol/extent';
 
 export enum ZsMapStateSource {
   OPEN_STREET_MAP = 'openStreetMap',
@@ -62,6 +64,7 @@ export interface IZsMapDisplayState {
   mapOpacity: number;
   mapCenter: Coordinate;
   mapZoom: number;
+  mapExtent: Extent;
   dpi?: number;
   showMyLocation: boolean;
   activeLayer: string | undefined;
@@ -252,7 +255,7 @@ export interface IZsMapSearchResult {
   internal?;
 }
 
-export type SearchFunction = (searchText: string, maxResultCount?: number) => Promise<IZsMapSearchResult[]>;
+export type SearchFunction = (searchText: string, abortController: AbortController, maxResultCount?: number) => Promise<IZsMapSearchResult[]>;
 
 export interface IZsMapSearchConfig {
   label: string;
@@ -266,4 +269,14 @@ export interface IResultSet {
   config: IZsMapSearchConfig;
   results: IZsMapSearchResult[];
   collapsed: boolean | 'peek';
+}
+
+export interface IFoundLocation {
+  attrs: IFoundLocationAttrs;
+}
+
+export interface IFoundLocationAttrs {
+  label: string;
+  lon: number;
+  lat: number;
 }

--- a/packages/types/state/interfaces.ts
+++ b/packages/types/state/interfaces.ts
@@ -83,6 +83,7 @@ export interface IZsMapDisplayState {
   enableClustering: boolean;
   journalSort: Sort;
   journalFilter: IZsJournalFilter;
+  searchConfig: IZsGlobalSearchConfig;
 }
 
 export interface IZsJournalFilter {
@@ -91,6 +92,16 @@ export interface IZsJournalFilter {
   outgoingFilter: boolean;
   decisionFilter: boolean;
   keyMessageFilter: boolean;
+}
+
+export interface IZsGlobalSearchConfig {
+  filterMapSection: boolean;
+  filterByDistance: boolean;
+  maxDistance: number;
+  filterByArea: false;
+  area: Extent | null;
+  sortedByDistance: boolean;
+  distanceReferenceCoordinate: Coordinate | null;
 }
 
 //DIN paper dimension in mm, landscape
@@ -255,7 +266,12 @@ export interface IZsMapSearchResult {
   internal?;
 }
 
-export type SearchFunction = (searchText: string, abortController: AbortController, maxResultCount?: number) => Promise<IZsMapSearchResult[]>;
+export type SearchFunction = (
+  searchText: string,
+  abortController: AbortController,
+  searchConfig: IZsGlobalSearchConfig,
+  maxResultCount?: number,
+) => Promise<IZsMapSearchResult[]>;
 
 export interface IZsMapSearchConfig {
   label: string;
@@ -279,4 +295,5 @@ export interface IFoundLocationAttrs {
   label: string;
   lon: number;
   lat: number;
+  objectclass?: string;
 }

--- a/packages/types/state/interfaces.ts
+++ b/packages/types/state/interfaces.ts
@@ -261,3 +261,9 @@ export interface IZsMapSearchConfig {
   maxResultCount: number;
   resultOrder: number;
 }
+
+export interface IResultSet {
+  config: IZsMapSearchConfig;
+  results: IZsMapSearchResult[];
+  collapsed: boolean | 'peek';
+}

--- a/packages/types/state/interfaces.ts
+++ b/packages/types/state/interfaces.ts
@@ -263,7 +263,7 @@ export interface IZsMapSearchResult {
   mercatorCoordinates?: Coordinate;
   lonLat?: Coordinate;
   feature?: Feature;
-  internal?;
+  internal?: Partial<IFoundLocationAttrs> & { id?: string | number, dist?: number; center?: Coordinate };
 }
 
 export type SearchFunction = (
@@ -289,6 +289,7 @@ export interface IResultSet {
 
 export interface IFoundLocation {
   attrs: IFoundLocationAttrs;
+  id?: number;
 }
 
 export interface IFoundLocationAttrs {
@@ -296,4 +297,7 @@ export interface IFoundLocationAttrs {
   lon: number;
   lat: number;
   objectclass?: string;
+  origin?: string;
+  featureId?: string;
+  geom_st_box2d: string;
 }


### PR DESCRIPTION
- refactor search logic to search service
- add logic to search street names (not only addresses) and show there geometry
- show geometry/area of geoAdmin results (cantons, regions, places)
- add option to filter:
  - by current screen
  - by distance to screen center
  - by defined extent/area
- add option to sort the result by distance to screen center
- auto redo search if:
  - any search option changes
  - map center or zoom change, if corresponding filter/sort is active
- extract search autocomplete display
  - and make sure "for" recognize still available results/elements (no angular update/recreate needed)