### PR TITLE
feat(lagedarstellung): add new department for drawn on map only

### DIFF
--- a/packages/app/src/app/journal/journal-form/journal-form.component.ts
+++ b/packages/app/src/app/journal/journal-form/journal-form.component.ts
@@ -240,7 +240,7 @@ export class JournalFormComponent {
 
   onEnterForResetState(event: Event) {
     event.preventDefault();
-    this.resetState(); 
+    this.resetState();
   }
 
   async resetState() {
@@ -318,14 +318,25 @@ export class JournalFormComponent {
       InfoDialogComponent.showErrorDialog(this._dialog, this.i18n.get('fillAllFields'));
       return;
     }
-    const newEntryStatus = JournalEntryStatusNext[entryStatus];
+    let newEntryStatus = JournalEntryStatusNext[entryStatus];
     const nextReset = JournalEntryStatusReset[newEntryStatus];
+
+    if (
+      entryStatus === JournalEntryStatus.AWAITING_TRIAGE &&
+      this.journalForm.controls.department.value === 'lagedarstellung' &&
+      this.entry()?.isDrawnOnMap
+    ) {
+      //if department is set to 'lagedarstellung' only drawn on map is required, if that is already done on time of triage, set it directly to complete.
+      newEntryStatus = JournalEntryStatus.COMPLETED;
+    }
 
     //prepare object with only allowed/changed fields to save
     const { dateCreatedTime, dateCreatedDate, ...rest } = this.journalForm.value;
     const values: Partial<JournalEntry> = {
       ...(rest as JournalEntry),
-      ...(dateCreatedDate && dateCreatedTime ? {dateMessage: this.combineDateAndTime(dateCreatedDate, dateCreatedTime)} : {}),
+      ...(dateCreatedDate && dateCreatedTime
+        ? { dateMessage: this.combineDateAndTime(dateCreatedDate, dateCreatedTime) }
+        : {}),
     };
     if (nextReset && values[nextReset.required]) {
       //clear reset field of next step, so it's not longer filled
@@ -418,7 +429,9 @@ export class JournalFormComponent {
     const { dateCreatedTime, dateCreatedDate, ...rest } = this.journalForm.value;
     const entry: JournalEntry = {
       ...(rest as JournalEntry),
-      ...(dateCreatedDate && dateCreatedTime ? {dateMessage: this.combineDateAndTime(dateCreatedDate, dateCreatedTime)} : {}),
+      ...(dateCreatedDate && dateCreatedTime
+        ? { dateMessage: this.combineDateAndTime(dateCreatedDate, dateCreatedTime) }
+        : {}),
       documentId: this.entry()?.documentId,
     };
 

--- a/packages/app/src/app/journal/journal.types.ts
+++ b/packages/app/src/app/journal/journal.types.ts
@@ -66,6 +66,7 @@ export const DepartmentValues = [
   'fb-gesundheit',
   'fb-logistik',
   'fb-infrastrukturen',
+  'lagedarstellung',
 ] as const;
 export type Department = (typeof DepartmentValues)[number] | null;
 

--- a/packages/app/src/app/state/i18n.service.ts
+++ b/packages/app/src/app/state/i18n.service.ts
@@ -2827,6 +2827,11 @@ export class I18NService {
       en: 'DP Infrastructure',
       fr: 'DP Infrastructure',
     },
+    lagedarstellung: {
+      de: 'Lagedarstellung',
+      en: 'Situation presentation',
+      fr: 'Présentation de la situation',
+    },
     wrongContent: {
       de: 'Falscher Inhalt',
       en: 'Wrong content',

--- a/packages/server/src/api/journal-entry/content-types/journal-entry/schema.json
+++ b/packages/server/src/api/journal-entry/content-types/journal-entry/schema.json
@@ -101,7 +101,8 @@
         "fb-schutz-rettung",
         "fb-gesundheit",
         "fb-logistik",
-        "fb-infrastrukturen"
+        "fb-infrastrukturen",
+        "lagedarstellung"
       ]
     },
     "isDrawingOnMap": {

--- a/packages/server/types/generated/contentTypes.d.ts
+++ b/packages/server/types/generated/contentTypes.d.ts
@@ -398,6 +398,7 @@ export interface ApiJournalEntryJournalEntry extends Struct.CollectionTypeSchema
         'fb-gesundheit',
         'fb-logistik',
         'fb-infrastrukturen',
+        'lagedarstellung',
       ]
     >;
     entryStatus: Schema.Attribute.Enumeration<


### PR DESCRIPTION
Our ZSO discussed how we want to integrate zskarte in our message flow.
We notice that there are messages that are only relevant for drawn on map and don't have to be processes by an department.

Therefore this PR add a new department named "lagedarstellung", and add special handling that mark message as complete as soon the message is drawn on map.