### PR TITLE
fix(multiple dialog): fix + shortcut, only allow one instance of dialog

### DIFF
--- a/packages/app/src/app/shortcut/shortcut.service.ts
+++ b/packages/app/src/app/shortcut/shortcut.service.ts
@@ -167,9 +167,11 @@ export class ShortcutService {
 
   private _openAdd() {
     return () => {
-      const layer = this._state.getActiveLayer();
-      const ref = this._dialog.open(DrawDialogComponent);
-      ref.componentRef?.instance.setLayer(layer);
+      if (this._dialog.openDialogs.length === 0) {
+        const layer = this._state.getActiveLayer();
+        const ref = this._dialog.open(DrawDialogComponent);
+        ref.componentRef?.instance.setLayer(layer);
+      }
     };
   }
 


### PR DESCRIPTION
It was possible to open the add dialog multiple times by pressing the + shortcut.