### PR TITLE
Added location to journal entries.

### DIFF
--- a/packages/app/src/app/contenteditable/contenteditable.component.scss
+++ b/packages/app/src/app/contenteditable/contenteditable.component.scss
@@ -1,7 +1,3 @@
-.contenteditable {
-  min-height: 200px;
-}
-
 .contenteditable[contenteditable='true']:focus {
   outline: none;
   word-wrap: break-word;

--- a/packages/app/src/app/journal-draw-overlay/journal-draw-overlay.component.html
+++ b/packages/app/src/app/journal-draw-overlay/journal-draw-overlay.component.html
@@ -6,7 +6,11 @@
       <button mat-icon-button class="expand" (click)="toggleExpanded()">
         <mat-icon>{{ expanded() ? 'expand_less' : 'expand_more' }}</mat-icon>
       </button>
-    </div>
+    </div><p
+      class="preserve-linebreak"
+      [innerHTML]="entry()!.location | replaceAllAddressTokens: true : markPotentialAddresses()"
+      (click)="search.handleMessageContentClick($event)"
+    ></p>
     <p
       class="preserve-linebreak"
       [innerHTML]="entry()!.messageContent | replaceAllAddressTokens: true : markPotentialAddresses()"

--- a/packages/app/src/app/journal-draw-overlay/journal-draw-overlay.component.ts
+++ b/packages/app/src/app/journal-draw-overlay/journal-draw-overlay.component.ts
@@ -59,6 +59,7 @@ export class JournalDrawOverlayComponent {
   }
 
   async showAllAddresses() {
+    await this.search.showAllFeature(this.entry()!.location, true, [100, 100, 100, 100]);
     await this.search.showAllFeature(this.entry()!.messageContent, true, [100, 100, 100, 100]);
     this.search.addressPreview.set(true);
   }

--- a/packages/app/src/app/journal/journal-form/journal-form.component.html
+++ b/packages/app/src/app/journal/journal-form/journal-form.component.html
@@ -125,6 +125,17 @@
             </tr>
             <tr>
               <td>
+                <strong>{{ i18n.get('location') }}:</strong>
+              </td>
+              <td
+                class="preserve-linebreak"
+                [innerHTML]="
+                journalForm.value.location | replaceAllAddressTokens: true : markPotentialAddresses()
+                "
+                (click)="search.handleMessageContentClick($event)"></td>
+            </tr>
+            <tr>
+              <td>
                 <strong>{{ i18n.get('messageContent') }}:</strong>
               </td>
               <td
@@ -190,10 +201,18 @@
                 </mat-form-field>
               </div>
 
+              <app-location-with-address-search
+                #location
+                [label]="i18n.get('location')"
+                [formVisible]="formVisible()"
+                [locationControl]="locationControl"
+              ></app-location-with-address-search>
+
               <mat-form-field appearance="outline">
                 <mat-label>{{ i18n.get('messageTitle') }}</mat-label>
                 <input matInput formControlName="messageSubject" />
               </mat-form-field>
+              
               <app-text-area-with-address-search
                 #messageContent
                 [label]="i18n.get('messageContent')"

--- a/packages/app/src/app/journal/journal-form/journal-form.component.ts
+++ b/packages/app/src/app/journal/journal-form/journal-form.component.ts
@@ -35,6 +35,7 @@ import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { TextAreaWithAddressSearchComponent } from '../text-area-with-address-search/text-area-with-address-search.component';
 import { SearchService } from 'src/app/search/search.service';
 import { ReplaceAllAddressTokensPipe } from '../../search/replace-all-address-tokens.pipe';
+import { LocationWithAddressSearchComponent } from '../location-with-address-search/location-with-address-search.component';
 
 @Component({
   selector: 'app-journal-form',
@@ -53,6 +54,7 @@ import { ReplaceAllAddressTokensPipe } from '../../search/replace-all-address-to
     CommonModule,
     TextAreaWithAddressSearchComponent,
     ReplaceAllAddressTokensPipe,
+    LocationWithAddressSearchComponent,
   ],
   providers: [provideNativeDateAdapter()],
   templateUrl: './journal-form.component.html',
@@ -68,6 +70,7 @@ export class JournalFormComponent {
   readonly isReadOnly = toSignal(this._state.observeIsReadOnly());
   @ViewChild('formDirective') private formDirective!: FormGroupDirective;
   messageContentEl = viewChild<TextAreaWithAddressSearchComponent>('messageContent');
+  locationEl = viewChild<LocationWithAddressSearchComponent>('location');
 
   JournalEntryStatus = JournalEntryStatus;
   DepartmentValues = DepartmentValues;
@@ -108,6 +111,10 @@ export class JournalFormComponent {
     communicationDetails: new FormControl('', {
       nonNullable: true,
       validators: [this.requiredField('communicationDetails')],
+    }),
+    location: new FormControl('', {
+      nonNullable: true,
+      validators: [this.requiredField('location')],
     }),
     messageSubject: new FormControl('', {
       nonNullable: true,
@@ -176,6 +183,10 @@ export class JournalFormComponent {
 
   get messageContentControl(): FormControl {
     return this.journalForm.get('messageContent') as FormControl;
+  }
+
+  get locationControl(): FormControl {
+    return this.journalForm.get('location') as FormControl;
   }
 
   private combineDateAndTime(dateObj: Date, timeObj: Date) {
@@ -371,8 +382,17 @@ export class JournalFormComponent {
   @HostListener('window:keydown.Escape', ['$event'])
   closeSidebareOnEsc(event: KeyboardEvent): void {
     const messageContentEl = this.messageContentEl();
+    const locationEl = this.locationEl();
     if (messageContentEl) {
       if (messageContentEl.abortOnEsc(event)) {
+        return;
+      }
+    } else if (this.search.handleEsc(event)) {
+      return;
+    }
+
+    if (locationEl) {
+      if (locationEl.abortOnEsc(event)) {
         return;
       }
     } else if (this.search.handleEsc(event)) {
@@ -424,6 +444,7 @@ export class JournalFormComponent {
 
     await this.journal.print({
       ...entry,
+      location: this.search.removeAllAddressTokens(entry.location, false),
       messageContent: this.search.removeAllAddressTokens(entry.messageContent, false),
     });
 
@@ -435,6 +456,7 @@ export class JournalFormComponent {
   }
 
   async showAllAddresses() {
+    await this.search.showAllFeature(this.locationControl.value, true);
     await this.search.showAllFeature(this.messageContentControl.value, true);
     this.search.addressPreview.set(true);
   }

--- a/packages/app/src/app/journal/journal.types.ts
+++ b/packages/app/src/app/journal/journal.types.ts
@@ -46,6 +46,7 @@ export const JournalEntryStatusFields: Record<JournalEntryStatus, (keyof Journal
     'sender',
     'creator',
     'visumMessage',
+    'location',
   ],
   [JournalEntryStatus.AWAITING_TRIAGE]: ['isKeyMessage', 'department', 'visumTriage', 'dateTriage'],
   [JournalEntryStatus.AWAITING_DECISION]: ['decision', 'decisionReceiver', 'visumDecider', 'dateDecision'],
@@ -105,6 +106,7 @@ export interface JournalEntry {
   entryStatus: JournalEntryStatus;
 
   messageNumber: number;
+  location: string;
   messageSubject: string;
   messageContent: string;
   dateMessage: Date;

--- a/packages/app/src/app/journal/location-with-address-search/location-with-address-search.component.html
+++ b/packages/app/src/app/journal/location-with-address-search/location-with-address-search.component.html
@@ -1,0 +1,132 @@
+<div class="hint-box">
+  <div class="hint">{{ i18n.get('searchAddressUsageHint') }}</div>
+  <mat-icon
+    matSuffix
+    [ngClass]="{
+      active: showAllAddresses() || showLinkedText(),
+    }"
+    class="settings"
+    cdkOverlayOrigin
+    #trigger="cdkOverlayOrigin"
+    (click)="toggleSettings($event)"
+    >settings</mat-icon
+  >
+</div>
+<mat-form-field appearance="outline" subscriptSizing="dynamic" [class.linkedText]="showLinkedText()">
+  <mat-label>{{ label() }}</mat-label>
+  @if (showLinkedText()) {
+    <app-contenteditable
+      #linkedTextContent
+      class="linkedTextContent"
+      [formControl]="locationControl()"
+      [formattingRules]="formattingRules"
+      (keydown)="onKeyDownFormatedText($event)"
+      (input)="onInputFormatedText()"
+      (click)="handleTextContentClick($event)"
+      (dblclick)="handleTextContentDblClick($event)"
+    ></app-contenteditable>
+  } @else {
+    <textarea
+      #textContent
+      class="textContent"
+      matInput
+      [formControl]="locationControl()"
+      (keydown)="onKeyDownText($event)"
+      (input)="onInputText()"
+      (dblclick)="onDoubleClickText($event)"
+      rows="2"
+      [readonly]="addressSelection()"
+    ></textarea>
+  }
+</mat-form-field>
+<div
+  class="addresSearch"
+  [class.linkedText]="showLinkedText()"
+  [style.display]="
+    addressSelection() ?
+      showLinkedText() ? 'block'
+      : 'flex'
+    : 'none'
+  "
+  [ngStyle]="showLinkedText() ? { 'left.px': addressSelectionPosition.x, 'top.px': addressSelectionPosition.y } : null"
+>
+  <!--
+  [style.left.px]="addressSelectionPosition.x"
+  [style.top.px]="addressSelectionPosition.y"
+-->
+  <div class="title">{{ i18n.get('searchAddress') }}</div>
+  <input
+    #addresSearchField
+    matInput
+    class="mat-mdc-form-field"
+    [matAutocomplete]="autocomplete.autocompleteRef"
+    [ngModelOptions]="{ standalone: true }"
+    [ngModel]="addressSearchTerm()"
+    (ngModelChange)="addressSearchTerm.set($event)"
+    (keydown)="onKeydownAddressSearch($event)"
+  />
+  <app-search-autocomplete
+    #autocomplete
+    [searchTerm]="addressSearchTerm()"
+    [foundLocations]="foundLocations()"
+    (active)="previewCoordinate($event)"
+    (selected)="useResult($event)"
+  ></app-search-autocomplete>
+</div>
+<div class="spacer"></div>
+
+<ng-template
+  cdkConnectedOverlay
+  (overlayOutsideClick)="toggleSettings($event)"
+  [cdkConnectedOverlayOrigin]="trigger"
+  [cdkConnectedOverlayOpen]="settingsVisible()"
+  [cdkConnectedOverlayOffsetX]="15"
+  [cdkConnectedOverlayOffsetY]="5"
+  [cdkConnectedOverlayPositions]="[
+    {
+      originX: 'end',
+      originY: 'bottom',
+      overlayX: 'end',
+      overlayY: 'top',
+    },
+  ]"
+>
+  <div class="overlay-container allow-overflow">
+    <svg class="overlay-arrow-top" width="20" height="10" xmlns="http://www.w3.org/2000/svg">
+      <polygon points="10,0 0,10 20,10" class="arrow-shape-top" />
+    </svg>
+
+    <div class="overlay-content">
+      <div>
+        <mat-icon>map</mat-icon>
+        <mat-checkbox [disabled]="showAllAddresses()" [ngModel]="showAllAddresses() ? true : showMap()" (ngModelChange)="showMap.set($event)">{{
+          i18n.get('showMap')
+        }}</mat-checkbox>
+      </div>
+      <div>
+        <mat-icon>select_all</mat-icon>
+        <mat-checkbox [ngModel]="showAllAddresses()" (ngModelChange)="showAllAddresses.set($event)">{{
+          i18n.get('showAllAddresses')
+        }}</mat-checkbox>
+      </div>
+      <div>
+        <mat-icon>link</mat-icon>
+        <mat-checkbox [ngModel]="showLinkedText()" (ngModelChange)="showLinkedText.set($event)">{{
+          i18n.get('showLinkedText')
+        }}</mat-checkbox>
+      </div>
+      <div>
+        <button mat-stroked-button type="button" (click)="markPotentialAddresses()">
+          <mat-icon>search</mat-icon>
+          {{ i18n.get('markPotentialAddresses') }}
+        </button>
+      </div>
+      <div>
+        <button mat-stroked-button type="button" (click)="unmarkPotentialAddresses()">
+          <mat-icon>restore</mat-icon>
+          {{ i18n.get('unmarkPotentialAddresses') }}
+        </button>
+      </div>
+    </div>
+  </div>
+</ng-template>

--- a/packages/app/src/app/journal/location-with-address-search/location-with-address-search.component.scss
+++ b/packages/app/src/app/journal/location-with-address-search/location-with-address-search.component.scss
@@ -4,7 +4,6 @@
 
 mat-form-field {
   width: 100%;
-  min-height: 200px;
 }
 
 .hint-box {

--- a/packages/app/src/app/journal/location-with-address-search/location-with-address-search.component.spec.ts
+++ b/packages/app/src/app/journal/location-with-address-search/location-with-address-search.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LocationWithAddressSearchComponent } from './location-with-address-search.component';
+
+describe('LocationWithAddressSearchComponent', () => {
+  let component: LocationWithAddressSearchComponent;
+  let fixture: ComponentFixture<LocationWithAddressSearchComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LocationWithAddressSearchComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LocationWithAddressSearchComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/packages/app/src/app/journal/location-with-address-search/location-with-address-search.component.ts
+++ b/packages/app/src/app/journal/location-with-address-search/location-with-address-search.component.ts
@@ -1,0 +1,577 @@
+import { CommonModule } from '@angular/common';
+import { Component, ElementRef, HostListener, effect, inject, input, signal, viewChild } from '@angular/core';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatAutocompleteModule, MatAutocompleteTrigger } from '@angular/material/autocomplete';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { SearchAutocompleteComponent } from 'src/app/search/search-autocomplete/search-autocomplete.component';
+import {
+  ADDRESS_TOKEN_REGEX,
+  ADDRESS_TOKEN_REPLACEMENT_EDIT_MARKER,
+  ADDRESS_TOKEN_REPLACEMENT_EDIT_MARKER_MISSING,
+  SearchService,
+  getGlobalAddressTokenRegex,
+} from 'src/app/search/search.service';
+import { I18NService } from 'src/app/state/i18n.service';
+import { ZsMapStateService } from 'src/app/state/state.service';
+import {
+  IResultSet,
+  IZsGlobalSearchConfig,
+  IZsJournalMessageEditConfig,
+  IZsMapSearchResult,
+} from '../../../../../types/state/interfaces';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { ContenteditableComponent } from 'src/app/contenteditable/contenteditable.component';
+import { debounceLeading } from 'src/app/helper/debounce';
+import { MatButtonModule } from '@angular/material/button';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+
+@Component({
+  selector: 'app-location-with-address-search',
+  imports: [
+    MatIconModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatCheckboxModule,
+    ReactiveFormsModule,
+    FormsModule,
+    CommonModule,
+    SearchAutocompleteComponent,
+    MatAutocompleteModule,
+    OverlayModule,
+    ContenteditableComponent,
+  ],
+  templateUrl: './location-with-address-search.component.html',
+  styleUrl: './location-with-address-search.component.scss',
+})
+export class LocationWithAddressSearchComponent {
+  private _state = inject(ZsMapStateService);
+  private _search = inject(SearchService);
+  readonly i18n = inject(I18NService);
+  readonly label = input<string>('');
+  readonly formVisible = input(false);
+  locationControl = input<FormControl>(new FormControl());
+
+  readonly addressSearchTerm = signal('');
+  readonly addressSelection = signal(false);
+  readonly foundLocations = signal<IResultSet[]>([]);
+  readonly autocompleteTrigger = viewChild.required(MatAutocompleteTrigger);
+  readonly addresSearchField = viewChild.required<ElementRef<HTMLInputElement>>('addresSearchField');
+
+  readonly showMap = signal(false);
+  readonly showAllAddresses = signal(false);
+  readonly showLinkedText = signal(true);
+  readonly settingsVisible = signal(false);
+  readonly textContentInput = viewChild.required<ElementRef<HTMLTextAreaElement>>('textContent');
+  readonly linkedTextContent = viewChild.required<ContenteditableComponent>('linkedTextContent');
+  textContentSelectedArea: [number, number] = [0, 0];
+
+  private addrEditElem: HTMLElement | null = null;
+  addressSelectionPosition = { x: 0, y: 0 };
+  formattingRules: {
+    regex: RegExp;
+    replacement?: string;
+    replacementFunc?: (match, ...args) => string;
+    editBlocked: boolean;
+  }[] = [
+    {
+      regex: getGlobalAddressTokenRegex(),
+      replacementFunc: (match, p1, p2) =>
+        p2 ? ADDRESS_TOKEN_REPLACEMENT_EDIT_MARKER(p1, p2) : ADDRESS_TOKEN_REPLACEMENT_EDIT_MARKER_MISSING(p1),
+      editBlocked: true,
+    },
+  ];
+
+  constructor(private elementRef: ElementRef) {
+    const config = this._state.getJournalMessageEditConfig();
+    if (config) {
+      this.showMap.set(config.showMap);
+      this.showAllAddresses.set(config.showAllAddresses);
+      this.showLinkedText.set(config.showLinkedText);
+    }
+
+    effect(() => {
+      if (!this.formVisible()) {
+        this.addressSelection.set(false);
+        this._search.addressPreview.set(false);
+      }
+    });
+    effect(() => {
+      //save values in local vars to make sure the effect is triggered on all changes, also if it would evaluate to true without it.
+      const showMap = this.showMap();
+      const addressPreview = this._search.addressPreview();
+      const showAllAddresses = this.showAllAddresses();
+      const acivateMapView = this.formVisible() && (showMap || addressPreview || showAllAddresses);
+      this._state.setJournalAddressPreview(acivateMapView);
+    });
+    effect(() => {
+      if (!this.addressSelection()) {
+        if (this.addrEditElem) {
+          this.addrEditElem.classList.remove('edit-active');
+          this.addrEditElem = null;
+        }
+      }
+    });
+    effect(() => {
+      //do not call `this.updateShownFeature();` here as this would not get triggered by angular's effect logic
+      if (this.formVisible() && this.showAllAddresses()) {
+        this._search.showAllFeature(this.locationControl().value, true);
+      } else {
+        this._state.updateSearchResultFeatures([]);
+      }
+    });
+    effect(() => {
+      //if showLinkedText is updated
+      this.showLinkedText();
+      const formControl = this.locationControl();
+      if (formControl) {
+        //make sure displayed value is updated if changed in other view
+        const value = formControl.value;
+        formControl.setValue(value);
+      }
+    });
+    effect(() => {
+      const config: IZsJournalMessageEditConfig = {
+        showMap: this.showMap(),
+        showAllAddresses: this.showAllAddresses(),
+        showLinkedText: this.showLinkedText(),
+      };
+      this._state.setJournalMessageEditConfig(config);
+    });
+    this._state
+      .observeJournalMessageEditConfig()
+      .pipe(takeUntilDestroyed())
+      .subscribe((config: IZsJournalMessageEditConfig) => {
+        if (config) {
+          this.showMap.set(config.showMap);
+          this.showAllAddresses.set(config.showAllAddresses);
+          this.showLinkedText.set(config.showLinkedText);
+        }
+      });
+
+    //handle address search
+    const searchConfig = this._state.getSearchConfig();
+    const { searchResults$, updateSearchTerm, updateSearchConfig } = this._search.createSearchInstance(searchConfig);
+
+    this._state
+      .observeSearchConfig()
+      .pipe(takeUntilDestroyed())
+      .subscribe((config: IZsGlobalSearchConfig) => {
+        if (!config.filterMapSection && !config.filterByDistance && !config.filterByArea && !config.sortedByDistance) {
+          //fallback config: sort by distance if nothing set
+          updateSearchConfig({ ...config, sortedByDistance: true });
+        } else {
+          updateSearchConfig(config);
+        }
+      });
+    effect(() => {
+      updateSearchTerm(this.addressSearchTerm());
+    });
+
+    searchResults$.pipe(takeUntilDestroyed()).subscribe((newResultSets) => {
+      if (newResultSets === null) {
+        //request aborted by new search
+        return;
+      }
+
+      this.foundLocations().forEach((s) => s.results.forEach((x) => x.feature?.unset('ZsMapSearchResult')));
+      newResultSets.forEach((s) => s.results.forEach((x) => x.feature?.set('ZsMapSearchResult', true)));
+      if (newResultSets.length > 3) {
+        newResultSets.forEach((s) => (s.collapsed = true));
+      }
+      this.foundLocations.set(newResultSets);
+      this.autocompleteTrigger().openPanel();
+    });
+  }
+
+  toggleSettings(event?: MouseEvent) {
+    event?.stopPropagation();
+    this.settingsVisible.set(!this.settingsVisible());
+  }
+
+  @HostListener('window:keydown.Escape', ['$event'])
+  abortOnEsc(event: KeyboardEvent) {
+    if (this.addressSelection()) {
+      this.autocompleteTrigger().closePanel();
+      event.preventDefault();
+      event.stopPropagation();
+      setTimeout(() => {
+        if (!this.showLinkedText()) {
+          this.textContentInput().nativeElement.focus();
+        } else {
+          if (this.addrEditElem) {
+            this.linkedTextContent().handleBlockSelection(this.addrEditElem);
+            this.removeCaret();
+          }
+          this.linkedTextContent().inputField().nativeElement.focus();
+        }
+        this.addressSelection.set(false);
+      });
+      this.updateShownFeature();
+      return true;
+    } else if (this._search.handleEsc(event)) {
+      this.updateShownFeature();
+      return true;
+    }
+    return undefined;
+  }
+
+  updateShownFeature = debounceLeading(
+    async () => {
+      if (!this.addressSelection()) {
+        if (this.formVisible() && this.showAllAddresses()) {
+          this._search.showAllFeature(this.locationControl().value, true);
+        } else {
+          this._state.updateSearchResultFeatures([]);
+        }
+        return true;
+      }
+      return false;
+    },
+    2000,
+    this,
+  );
+
+  async onKeyDownText(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      //abort address search, not close form
+      this.abortOnEsc(event);
+      return;
+    }
+    //use intelisense keystroke to start address search
+    if (event.ctrlKey && event.key === ' ') {
+      this.handleTextSelection(event, false);
+    }
+  }
+
+  onDoubleClickText(event: MouseEvent) {
+    this.handleTextSelection(event, true);
+  }
+
+  private handleTextSelection(event: Event, onlyAddressBlock: boolean) {
+    const textarea = this.textContentInput().nativeElement;
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const text = textarea.value;
+    let selectedText = text.substring(start, end);
+
+    //check if text cursor is on/inside textToken
+    let foundTextToken = false;
+    if (!ADDRESS_TOKEN_REGEX.test(selectedText)) {
+      let match: RegExpExecArray | null;
+      const regex = getGlobalAddressTokenRegex();
+      while ((match = regex.exec(text)) !== null) {
+        if (match.index <= start && match.index + match[0].length >= start) {
+          foundTextToken = true;
+          selectedText = match[0];
+          textarea.selectionStart = match.index;
+          textarea.selectionEnd = match.index + match[0].length;
+          break;
+        }
+      }
+    }
+
+    if (!foundTextToken && onlyAddressBlock) {
+      return;
+    }
+
+    //if not, select current word
+    if (!foundTextToken && start === end) {
+      const beforeCursor = text.substring(0, start);
+      const afterCursor = text.substring(end);
+
+      const startOfWord = Math.max(beforeCursor.lastIndexOf(' ') + 1, beforeCursor.lastIndexOf('\n') + 1);
+      const afterPos = Math.min(afterCursor.indexOf(' '), afterCursor.indexOf('\n'));
+      const endOfWord = afterPos === -1 ? text.length : end + afterPos;
+
+      selectedText = text.substring(startOfWord, endOfWord);
+      textarea.selectionStart = startOfWord;
+      textarea.selectionEnd = endOfWord;
+    }
+
+    this.textContentSelectedArea = [textarea.selectionStart, textarea.selectionEnd];
+    const { address, locationInfo } = this._search.parseAddressToken(selectedText);
+    this._search.showFeature(locationInfo);
+    this.startEdit(address);
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  onInputText() {
+    const textarea = this.textContentInput().nativeElement;
+    const cursorPosition = textarea.selectionStart || 0;
+    if (cursorPosition >= 5 && textarea.value.slice(cursorPosition - 5, cursorPosition) === 'addr:') {
+      textarea.selectionStart = cursorPosition - 5;
+      textarea.selectionEnd = cursorPosition;
+      this.textContentSelectedArea = [textarea.selectionStart, textarea.selectionEnd];
+      this.startEdit('');
+    } else {
+      this.updateShownFeature();
+    }
+  }
+
+  previewCoordinate(element: IZsMapSearchResult | null) {
+    this._search.highlightResult(element, false);
+  }
+
+  useResult(value: IZsMapSearchResult) {
+    const addressToken = value.internal?.addressToken;
+    if (this.showLinkedText()) {
+      if (addressToken) {
+        this.linkedTextContent().replaceToken(this.addrEditElem, addressToken);
+      }
+    } else {
+      const textarea = this.textContentInput().nativeElement;
+      if (addressToken) {
+        [textarea.selectionStart, textarea.selectionEnd] = this.textContentSelectedArea;
+        textarea.setRangeText(addressToken);
+        textarea.selectionStart = textarea.selectionEnd = textarea.selectionStart + addressToken.length;
+        this.locationControl().setValue(textarea.value);
+      }
+      setTimeout(() => {
+        textarea.focus();
+      });
+    }
+    this.addressSelection.set(false);
+    this._state.updatePositionFlag({ isVisible: false, coordinates: [0, 0] });
+
+    this.updateShownFeature();
+  }
+
+  markPotentialAddresses() {
+    this.locationControl().setValue(
+      this._search.tokenizeAllPotentialAddresses(this.locationControl().value),
+    );
+    this.settingsVisible.set(false);
+  }
+
+  unmarkPotentialAddresses() {
+    this.locationControl().setValue(this._search.removeAllPotentialAddresses(this.locationControl().value));
+    this.settingsVisible.set(false);
+  }
+
+  onKeydownAddressSearch(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+      //prevent form submit
+      event.preventDefault();
+    } else if (event.key === 'Escape') {
+      //abort address search, not close form
+      this.abortOnEsc(event);
+    }
+  }
+
+  private startEdit(address: string) {
+    if (this.showLinkedText()) {
+      this.setInputFieldPositionEditElem();
+    }
+    this.addressSelection.set(true);
+    this._search.addressPreview.set(false);
+    this.addressSearchTerm.set(address);
+    this.autocompleteTrigger().openPanel();
+    setTimeout(() => {
+      this.addresSearchField().nativeElement.focus();
+    });
+  }
+
+  //adjusted logic Methods for formatedText
+
+  onInputFormatedText(onlyAddrKeyword = true) {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return;
+
+    const range = selection.getRangeAt(0);
+
+    if (range.startContainer.nodeType === Node.TEXT_NODE) {
+      const cursorPosition = range.endOffset || range.startOffset || 0;
+      if (
+        cursorPosition >= 5 &&
+        range.startContainer.textContent?.slice(cursorPosition - 5, cursorPosition) === 'addr:'
+      ) {
+        range.setStart(range.startContainer, cursorPosition - 5);
+        range.setEnd(range.startContainer, cursorPosition);
+        range.deleteContents();
+        this.insertCaret(range, '');
+        this.startEdit('');
+        return;
+      }
+    }
+    if (onlyAddrKeyword) {
+      this.updateShownFeature();
+      return;
+    }
+
+    //check inside block to edit
+    const block = this.linkedTextContent().getCurrentBlock();
+    if (block) {
+      const addrElem = block.querySelector('.addr-geo');
+      if (addrElem) {
+        this.editAddr(addrElem as HTMLElement);
+        return;
+      }
+    }
+
+    let selectedText = '';
+    if (range.startContainer.nodeType === Node.TEXT_NODE && range.startContainer === range.endContainer) {
+      const text = range.startContainer.textContent ?? '';
+      const start = range.startOffset;
+      const end = range.endOffset;
+
+      let insertStart: number;
+      let insertEnd: number;
+      if (!range.collapsed) {
+        // There is a selection: use the selected text
+        selectedText = text.substring(start, end);
+        insertStart = start;
+        insertEnd = end;
+      } else {
+        // No selection: find word under cursor
+        const beforeCursor = text.substring(0, start);
+        const afterCursor = text.substring(end);
+
+        // Find last space or line break before the cursor
+        const lastSpace = Math.max(beforeCursor.lastIndexOf(' '), beforeCursor.lastIndexOf('\n'));
+        insertStart = lastSpace + 1;
+
+        // Find first space or line break after the cursor
+        let afterSpace = afterCursor.search(/[ \n]/);
+        if (afterSpace === -1) afterSpace = afterCursor.length;
+        insertEnd = end + afterSpace;
+
+        selectedText = text.substring(insertStart, insertEnd);
+      }
+
+      // Create a new range collapsed at the insertStart position
+      const insertRange = document.createRange();
+      insertRange.setStart(range.startContainer, insertStart);
+      insertRange.setEnd(range.startContainer, insertEnd);
+      insertRange.deleteContents();
+
+      insertRange.collapse(true);
+      this.insertCaret(range, selectedText);
+      this.startEdit(selectedText);
+      return;
+    }
+
+    //fallback empty text at current possition
+    range.collapse(true);
+    this.insertCaret(range, '');
+    this.startEdit('');
+  }
+
+  private insertCaret(range: Range, text: string) {
+    this.addrEditElem = document.createElement('span');
+    this.addrEditElem.className = 'addr-caret';
+    this.addrEditElem.textContent = text || '';
+    range.insertNode(this.addrEditElem);
+  }
+
+  private removeCaret() {
+    if (this.addrEditElem?.classList.contains('addr-caret')) {
+      const prev = this.addrEditElem.previousSibling;
+      const next = this.addrEditElem.nextSibling;
+      const text = this.addrEditElem.textContent || '';
+      this.addrEditElem.remove();
+      this.linkedTextContent().mergeTextNodes(prev, text, next);
+    }
+  }
+
+  async onKeyDownFormatedText(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      //abort address search, not close form
+      this.abortOnEsc(event);
+      return;
+    }
+    //use intelisense keystroke to start address search
+    if (event.ctrlKey && event.key === ' ') {
+      this.onInputFormatedText(false);
+    }
+    this.updateShownFeature();
+  }
+
+  setInputFieldPositionEditElem() {
+    if (this.addrEditElem) {
+      const rect = this.addrEditElem.getBoundingClientRect();
+
+      // calc relative pos
+      const parentRect = this.elementRef.nativeElement.getBoundingClientRect();
+      if (parentRect) {
+        this.addressSelectionPosition.x = rect.left - parentRect.left;
+        this.addressSelectionPosition.y = rect.top - parentRect.top;
+      }
+    } else {
+      this.setInputFieldPositionSelection();
+    }
+  }
+
+  setInputFieldPositionSelection() {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return;
+
+    const range = selection.getRangeAt(0);
+    const rect = range.getBoundingClientRect();
+
+    // calc relative pos
+    const parentRect = this.elementRef.nativeElement.getBoundingClientRect();
+    if (parentRect) {
+      this.addressSelectionPosition.x = rect.left - parentRect.left;
+      this.addressSelectionPosition.y = rect.top - parentRect.top;
+    }
+  }
+
+  async handleTextContentClick(event: MouseEvent) {
+    const target = event.target as HTMLElement;
+    const addrElem = target.closest('.addr-geo') as HTMLElement;
+    if (addrElem) {
+      event.preventDefault();
+      if (target.closest('.addr-edit')) {
+        this.editAddr(addrElem);
+        return;
+      } else if (target.closest('.addr-show')) {
+        const geo = addrElem.dataset['geo'];
+        const feature = await this._search.showFeature(geo);
+        if (feature) {
+          this._search.addressPreview.set(true);
+          this.addressSelection.set(false);
+          return;
+        }
+      }
+      if (event.detail === 2) {
+        //double click
+        return;
+      }
+    }
+    if (!target.closest('.addresSearch')) {
+      this._search.addressPreview.set(false);
+      this.removeCaret();
+      this.addressSelection.set(false);
+      this.updateShownFeature();
+    }
+  }
+
+  async handleTextContentDblClick(event: Event) {
+    const target = event.target as HTMLElement;
+    const addrElem = target.closest('.addr-geo') as HTMLElement;
+    if (addrElem) {
+      event.preventDefault();
+      this.editAddr(addrElem);
+      return;
+    }
+    this._search.addressPreview.set(false);
+    this.addressSelection.set(false);
+    this.updateShownFeature();
+  }
+
+  private async editAddr(addrElem: HTMLElement) {
+    const geo = addrElem.dataset['geo'];
+    await this._search.showFeature(geo);
+    const textEl = addrElem.querySelector('.text') as HTMLElement;
+    if (textEl) {
+      this.addrEditElem = addrElem;
+      this.addrEditElem.classList.add('edit-active');
+      this.startEdit(textEl.innerText);
+    }
+  }
+}

--- a/packages/app/src/app/sidebar/sidebar-journal-entry/sidebar-journal-entry.component.html
+++ b/packages/app/src/app/sidebar/sidebar-journal-entry/sidebar-journal-entry.component.html
@@ -1,3 +1,8 @@
+<p
+  class="preserve-linebreak"
+  [innerHTML]="entry()!.location | replaceAllAddressTokens: true : markPotentialAddresses()"
+  (click)="search.handleMessageContentClick($event)"
+></p>
 <div class="created-date">{{ entry().dateMessage | date: 'dd.MM.yyyy, HH:mm' }}</div>
 <p
   class="preserve-linebreak"

--- a/packages/app/src/app/sidebar/sidebar-journal-entry/sidebar-journal-entry.component.ts
+++ b/packages/app/src/app/sidebar/sidebar-journal-entry/sidebar-journal-entry.component.ts
@@ -135,6 +135,7 @@ export class SidebarJournalEntryComponent implements OnDestroy {
   }
 
   async showAllAddresses() {
+    await this.search.showAllFeature(this.entry().location, true, ZOOM_TO_FIT_WITH_SIDEBAR_PADDING);
     await this.search.showAllFeature(this.entry().messageContent, true, ZOOM_TO_FIT_WITH_SIDEBAR_PADDING);
     this.search.addressPreview.set(true);
   }

--- a/packages/app/src/app/state/i18n.service.ts
+++ b/packages/app/src/app/state/i18n.service.ts
@@ -2682,6 +2682,11 @@ export class I18NService {
       en: 'Other',
       fr: 'Autre',
     },
+    location: {
+      de: 'Ort',
+      en: 'Location',
+      fr: 'Lieu',
+    },
     messageContent: {
       de: 'Meldungsinhalt',
       en: 'Message content',

--- a/packages/server/src/api/journal-entry/content-types/journal-entry/schema.json
+++ b/packages/server/src/api/journal-entry/content-types/journal-entry/schema.json
@@ -27,6 +27,9 @@
     "communicationDetails": {
       "type": "string"
     },
+    "location": {
+      "type": "string"
+    },
     "messageSubject": {
       "type": "string"
     },

--- a/packages/server/types/generated/contentTypes.d.ts
+++ b/packages/server/types/generated/contentTypes.d.ts
@@ -409,6 +409,7 @@ export interface ApiJournalEntryJournalEntry extends Struct.CollectionTypeSchema
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<'oneToMany', 'api::journal-entry.journal-entry'> &
       Schema.Attribute.Private;
+    location: Schema.Attribute.String;
     messageContent: Schema.Attribute.Text;
     messageNumber: Schema.Attribute.Integer;
     messageSubject: Schema.Attribute.String;


### PR DESCRIPTION
# Location added to journal entries
## Description
A field for location has been added to journal entries with address search used for message content. The location is can be viewed in the input tab of an entry and also in the message to draw sidebar in the map. The location column has been added to the table of journal entrires.

CSS files have been edited to fit the location field when creating a new entry to have two different sizes for location and message content.

### Existing journal entries with no location
Journal entries with no location have null value for location in database and just display nothing in frontend.
### Creating new journal entry
<img width="961" height="758" alt="image" src="https://github.com/user-attachments/assets/f4b8a43f-271a-49ec-a8e9-81349084ddfc" />


## Possible improvement
When viewing messages to draw in the sidebar on the map, the recognize adresses checkbox works only for the message content at the moment. Adding the a checkbox or make the already existing checkbox also recognize adressses in location in case people do not enter an actual address in location field when creating new journal entry.