### PR TITLE
feat(journal-sidebar): show meta infos (state,responsibility) in sidebar

### DIFF
--- a/packages/app/src/app/journal/journal.component.html
+++ b/packages/app/src/app/journal/journal.component.html
@@ -155,7 +155,7 @@
               {{ i18n.get('responsibility') }}
             </th>
             <td mat-cell *matCellDef="let element">
-              {{ getResponsibility(element) }}
+              {{ journal.getResponsibility(element) }}
             </td>
           </ng-container>
 

--- a/packages/app/src/app/journal/journal.component.ts
+++ b/packages/app/src/app/journal/journal.component.ts
@@ -193,7 +193,7 @@ export class JournalComponent implements AfterViewInit {
     this.dataSourceFiltered.sortingDataAccessor = (item, property) => {
       switch (property) {
         case 'entryResponsibility':
-          return this.getResponsibility(item);
+          return this.journal.getResponsibility(item);
         case 'entryStatus':
           return Object.values(JournalEntryStatus).indexOf(item[property]);
         default:
@@ -320,17 +320,6 @@ export class JournalComponent implements AfterViewInit {
 
   trackByFn(index: number, row: any): string {
     return row.uuid || row.documentId;
-  }
-
-  getResponsibility(entry: JournalEntry) {
-    switch (entry.entryStatus) {
-      case JournalEntryStatus.AWAITING_MESSAGE:
-        return entry.visumMessage;
-      case JournalEntryStatus.AWAITING_DECISION:
-        return this.i18n.get(entry.department ?? 'allDepartments');
-      default:
-        return this.i18n.get(`journalEntryResponsibility_${entry.entryStatus}`);
-    }
   }
 
   close() {

--- a/packages/app/src/app/journal/journal.service.ts
+++ b/packages/app/src/app/journal/journal.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, effect, inject, resource, signal } from '@angular/core';
-import { JournalDateFields, JournalEntry } from './journal.types';
+import { JournalDateFields, JournalEntry, JournalEntryStatus } from './journal.types';
 import { ApiResponse, ApiService } from '../api/api.service';
 import { SessionService } from '../session/session.service';
 import { tap } from 'rxjs';
@@ -830,5 +830,16 @@ export class JournalService {
         fileName,
       );
     });
+  }
+
+  public getResponsibility(entry: JournalEntry) {
+    switch (entry.entryStatus) {
+      case JournalEntryStatus.AWAITING_MESSAGE:
+        return entry.visumMessage;
+      case JournalEntryStatus.AWAITING_DECISION:
+        return this._i18n.get(entry.department ?? 'allDepartments');
+      default:
+        return this._i18n.get(`journalEntryResponsibility_${entry.entryStatus}`);
+    }
   }
 }

--- a/packages/app/src/app/sidebar/sidebar-journal-entry/sidebar-journal-entry.component.html
+++ b/packages/app/src/app/sidebar/sidebar-journal-entry/sidebar-journal-entry.component.html
@@ -1,3 +1,16 @@
+<div class="meta-infos">
+  <div class="entryStatus">{{ i18n.get('status') }}: {{ i18n.get('journalEntry_' + entry().entryStatus) }},</div>
+  <div class="responsibility">{{ i18n.get('responsibility') }}: {{ journal.getResponsibility(entry()) }}</div>
+  <button
+    class="showInJournal"
+    mat-icon-button
+    [attr.aria-label]="i18n.get('showInJournal')"
+    [attr.title]="i18n.get('showInJournal')"
+    (click)="openJournalClick($event)"
+  >
+    <mat-icon>menu_book</mat-icon>
+  </button>
+</div>
 <div class="created-date">{{ entry().dateMessage | date: 'dd.MM.yyyy, HH:mm' }}</div>
 <p
   class="preserve-linebreak"

--- a/packages/app/src/app/sidebar/sidebar-journal-entry/sidebar-journal-entry.component.scss
+++ b/packages/app/src/app/sidebar/sidebar-journal-entry/sidebar-journal-entry.component.scss
@@ -3,6 +3,15 @@ h3 {
   display: flex;
 }
 
+.meta-infos {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+.showInJournal {
+  margin-left: auto;
+}
+
 .created-date {
   color: #888;
   font-size: 12px;

--- a/packages/app/src/app/sidebar/sidebar-journal-entry/sidebar-journal-entry.component.ts
+++ b/packages/app/src/app/sidebar/sidebar-journal-entry/sidebar-journal-entry.component.ts
@@ -21,6 +21,8 @@ import { SearchService } from 'src/app/search/search.service';
 import { ReplaceAllAddressTokensPipe } from '../../search/replace-all-address-tokens.pipe';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { FormsModule } from '@angular/forms';
+import { JournalService } from 'src/app/journal/journal.service';
+import { Router } from '@angular/router';
 
 const ZOOM_TO_FIT_WITH_SIDEBAR_PADDING: [number, number, number, number] = [100, 600, 100, 100];
 @Component({
@@ -42,6 +44,8 @@ export class SidebarJournalEntryComponent implements OnDestroy {
   private _renderer = inject(MapRendererService);
   i18n = inject(I18NService);
   search = inject(SearchService);
+  journal = inject(JournalService);
+  private _router = inject(Router);
   entry = input.required<JournalEntry>();
   allHighlighted = false;
 
@@ -137,5 +141,10 @@ export class SidebarJournalEntryComponent implements OnDestroy {
   async showAllAddresses() {
     await this.search.showAllFeature(this.entry().messageContent, true, ZOOM_TO_FIT_WITH_SIDEBAR_PADDING);
     this.search.addressPreview.set(true);
+  }
+
+  openJournalClick(event: Event) {
+    event.stopPropagation();
+    this._router.navigate(['/main/journal'], { queryParams: { messageNumber: this.entry().messageNumber } });
   }
 }

--- a/packages/app/src/app/state/i18n.service.ts
+++ b/packages/app/src/app/state/i18n.service.ts
@@ -2582,6 +2582,11 @@ export class I18NService {
       en: 'Show on map',
       fr: 'Afficher sur la carte',
     },
+    showInJournal: {
+      de: 'Im Journal anzeigen',
+      en: 'Show in journal',
+      fr: 'Afficher dans le journal',
+    },
     journal: {
       de: 'Journal',
       en: 'Journal',


### PR DESCRIPTION
On the prozess of our ZSO it was decided to only draw on map after the triage was done, so we need the information of the state on the journal sidebar.

I also add an "back link" to the journal from the sidebar.
I'm not sure if using the same icon as for the sidebar for this back link is the best choose.