### PR TITLE
fix(mainnav): main nav on history mode, info journal show current data

### DIFF
--- a/packages/app/src/app/app.component.html
+++ b/packages/app/src/app/app.component.html
@@ -1,5 +1,5 @@
 <main [style.height.px]="height" [class.journal-address-preview]="journalAddressPreview()">
-  @if (operationId() && !isHistoryMode()) {
+  @if (operationId()) {
   <nav class="main-tabs mat-elevation-z3" mat-tab-nav-bar [tabPanel]="tabPanel">
     <a mat-tab-link *ngFor="let link of navLinks" [routerLink]="link.link" routerLinkActive #rla="routerLinkActive" [active]="rla.isActive">
       {{ i18n.get(link.label) }}

--- a/packages/app/src/app/app.component.ts
+++ b/packages/app/src/app/app.component.ts
@@ -21,7 +21,6 @@ export class AppComponent implements OnInit {
   private _session = inject(SessionService);
   private _state = inject(ZsMapStateService);
   readonly journalAddressPreview = toSignal(this._state.observeJournalAddressPreview());
-  readonly isHistoryMode = toSignal(this._state.observeIsHistoryMode());
   readonly operationId = toSignal(this._session.observeOperationId());
   
 

--- a/packages/app/src/app/journal/journal.component.html
+++ b/packages/app/src/app/journal/journal.component.html
@@ -11,6 +11,9 @@
     <div class="journal-header mat-elevation-z3">
       <div class="journal-header-content">
         <h1>{{ i18n.get('journal') }}</h1>
+        @if(isHistoryMode() && !isCurrentMapData()) {
+          <div class="notHistory">{{ i18n.get('journalNotHistory') }}</div>
+        }
         <div class="buttons">
           @if (!isOnline()) {
             <mat-icon class="offline" [attr.aria-label]="i18n.get('youAreOffline')" [title]="i18n.get('youAreOffline')"

--- a/packages/app/src/app/journal/journal.component.scss
+++ b/packages/app/src/app/journal/journal.component.scss
@@ -25,6 +25,11 @@
   margin-bottom: 0;
 }
 
+.journal-header .notHistory {
+  color: red;
+  font-size: 1.25em;
+}
+
 .journal-sidebar {
   width: 50rem;
   max-width: 75%;

--- a/packages/app/src/app/journal/journal.component.ts
+++ b/packages/app/src/app/journal/journal.component.ts
@@ -71,6 +71,8 @@ export class JournalComponent implements AfterViewInit {
   private _destroyRef = inject(DestroyRef);
   readonly isOnline = toSignal(this._session.observeIsOnline());
   readonly isReadOnly = toSignal(this._state.observeIsReadOnly());
+  readonly isHistoryMode = toSignal(this._state.observeIsHistoryMode());
+  readonly isCurrentMapData = toSignal(this._state.observeIsCurrentMapData());
 
   DepartmentValues = DepartmentValues;
   JournalEntryStatus = JournalEntryStatus;

--- a/packages/app/src/app/session/session.service.ts
+++ b/packages/app/src/app/session/session.service.ts
@@ -215,7 +215,7 @@ export class SessionService {
             });
         } else {
           await this._router.navigate(['operations'], { queryParamsHandling: 'preserve', preserveFragment: true });
-          this._state.setMapState(undefined);
+          this._state.setMapState(undefined, undefined);
           this._state.setDisplayState(undefined);
         }
         return;

--- a/packages/app/src/app/sidebar/sidebar-history/sidebar-history.component.ts
+++ b/packages/app/src/app/sidebar/sidebar-history/sidebar-history.component.ts
@@ -57,7 +57,7 @@ export class SidebarHistoryComponent implements AfterViewInit {
   async setHistory(snapshot: IZsMapSnapshot) {
     const { result } = await this.apiService.get(`${this.apiPath}/${snapshot.documentId}`);
 
-    this.stateService.setMapState(result.mapState);
+    this.stateService.setMapState(result.mapState, snapshot.createdAt);
 
     this.snackBarService.open(
       `${this.i18n.get('toastSnapshotApplied')}: ${snapshot.createdAt.toLocaleString()}`,
@@ -68,7 +68,15 @@ export class SidebarHistoryComponent implements AfterViewInit {
     );
   }
 
-  setCurrent() {
-    this.stateService.refreshMapState();
+  async setCurrent() {
+    await this.stateService.refreshMapState();
+
+    this.snackBarService.open(
+      this.i18n.get('currentStateActive'),
+      'OK',
+      {
+        duration: 2000,
+      },
+    );
   }
 }

--- a/packages/app/src/app/state/i18n.service.ts
+++ b/packages/app/src/app/state/i18n.service.ts
@@ -1942,6 +1942,11 @@ export class I18NService {
       en: 'Backup applied',
       fr: 'Sauvegarde appliqué',
     },
+    currentStateActive: {
+      de: 'Aktuelle Karte',
+      en: 'Most recent map',
+      fr: 'Actuel map',
+    },
     noSignature: {
       de: 'Ohne Signatur',
       en: 'Without signature',
@@ -2586,6 +2591,11 @@ export class I18NService {
       de: 'Journal',
       en: 'Journal',
       fr: 'Journal',
+    },
+    journalNotHistory: {
+      de: 'Anzeige aktuell, nicht auf Stand Sicherungszeitpunkt.',
+      en: 'Display is current, not at the time of backup.',
+      fr: "L'affichage est actuel, pas au moment de la sauvegarde.",
     },
     noMessagesToProcess: {
       de: 'Keine Meldungen zu verarbeiten',

--- a/packages/app/src/app/state/state.service.ts
+++ b/packages/app/src/app/state/state.service.ts
@@ -83,6 +83,7 @@ export class ZsMapStateService {
   private _location = inject(Location);
 
   private _map = new BehaviorSubject<ZsMapState>(getDefaultZsMapState());
+  private _mapHistoryDate = new BehaviorSubject<Date|null|undefined>(undefined);
   private _mapPatches = new BehaviorSubject<Patch[]>([]);
   private _mapInversePatches = new BehaviorSubject<Patch[]>([]);
   private _undoStackPointer = new BehaviorSubject<number>(0);
@@ -297,7 +298,7 @@ export class ZsMapStateService {
     return this._elementToDraw.asObservable();
   }
 
-  public setMapState(newState?: ZsMapState): void {
+  public setMapState(newState?: ZsMapState, mapHistoryDate:Date|null|undefined = undefined): void {
     newState = zsMapStateMigration(newState);
 
     const cached = Object.keys(this._layerCache);
@@ -318,6 +319,7 @@ export class ZsMapStateService {
     this.updateMapState(() => {
       return newState || getDefaultZsMapState();
     }, true);
+    this._mapHistoryDate.next(mapHistoryDate);
   }
 
   public setDisplayState(newState?: IZsMapDisplayState): void {
@@ -365,6 +367,23 @@ export class ZsMapStateService {
 
   public isHistoryMode(): boolean {
     return this._display.value?.displayMode === ZsMapDisplayMode.HISTORY;
+  }
+
+  public observeHistoryDate(){
+    return this._mapHistoryDate.asObservable();
+  }
+
+  public observeIsCurrentMapData(): Observable<boolean> {
+    return this._mapHistoryDate.pipe(
+      map((o) => {
+        return o === null;
+      }),
+      distinctUntilChanged((x, y) => x === y),
+    );
+  }
+
+  public isCurrentMapData(): boolean {
+    return this._mapHistoryDate.value === null;
   }
 
   public toggleExpertView() {
@@ -1176,8 +1195,10 @@ export class ZsMapStateService {
   }
 
   public applyMapStatePatches(patches: Patch[]) {
-    const newState = applyPatches(this._map.value, patches);
-    this._map.next(newState);
+    if (!this.isHistoryMode() || this.isCurrentMapData()) {
+      const newState = applyPatches(this._map.value, patches);
+      this._map.next(newState);
+    }
   }
 
   public updateDisplayState(fn: (draft: IZsMapDisplayState) => void): void {
@@ -1314,7 +1335,9 @@ export class ZsMapStateService {
           sha256(JSON.stringify(operation.mapState)),
         ]);
         if (oldDigest !== newDigest) {
-          this.setMapState(operation.mapState);
+          this.setMapState(operation.mapState, null);
+        } else {
+          this._mapHistoryDate.next(null);
         }
       }
     }


### PR DESCRIPTION
Hold information which backup date is current shown or if it's current.
Prevent update mapState from patches if historyMode and NOT show current (=> read only mode).
Show main nav / switch to journal even in historyMode (possible same as if readyonly share link, or archived).
Show information in journal that it always shown current information and not the state of current loaded backup / history.
fixes #702 