### PR TITLE
feat(journal): print empty message formular

### DIFF
--- a/packages/app/src/app/journal/journal.component.ts
+++ b/packages/app/src/app/journal/journal.component.ts
@@ -424,6 +424,11 @@ export class JournalComponent implements AfterViewInit {
               this.updateMessagePdfTemplate(newTemplate);
             });
           }
+          if ('print' in instance) {
+            instance.print.subscribe(() => {
+              this.journal.print({} as JournalEntry);
+            });
+          }
         }
       }
     });

--- a/packages/app/src/app/journal/journal.service.ts
+++ b/packages/app/src/app/journal/journal.service.ts
@@ -679,6 +679,12 @@ export class JournalService {
     if (organizationFull?.logo?.provider === 'local') {
       organization.logo_url = `${environment.apiUrl}${organization.logo_url}`;
     }
+    let fileName = `${operation.name}_message${entry.messageNumber}_${new Date().toISOString().slice(0, 16)}.pdf`;
+    if (Object.keys(entry).length === 0){
+      operation.documentId = "";
+      operation.name = "";
+      fileName = `${organization.name}_message_template_${new Date().toISOString().slice(0, 10)}.pdf`;
+    }
     let entryUrl;
     if (entry.messageNumber && entry.createdAt) {
       entryUrl = `${window.location.origin}/main/journal?operationId=${operation.documentId}&messageNumber=${entry.messageNumber}`;
@@ -694,7 +700,6 @@ export class JournalService {
         url_entry: entryUrl,
       },
     ];
-    const fileName = `${operation.name}_message${entry.messageNumber}_${new Date().toISOString().slice(0, 16)}.pdf`;
     await pdfService.downloadPdf(template, data, fileName);
   }
 

--- a/packages/app/src/app/pdf/pdf-designer/pdf-designer.component.html
+++ b/packages/app/src/app/pdf/pdf-designer/pdf-designer.component.html
@@ -45,6 +45,14 @@
         </button>
         <button
           mat-icon-button
+          (click)="printEmptyTemplate()"
+          [attr.aria-label]="i18n.get('printEmptySavedTemplate')"
+          [attr.title]="i18n.get('printEmptySavedTemplate')"
+        >
+          <mat-icon>print</mat-icon>
+        </button>
+        <button
+          mat-icon-button
           (click)="closeDesigner()"
           [attr.aria-label]="i18n.get('cancel')"
           [title]="i18n.get('cancel')"

--- a/packages/app/src/app/pdf/pdf-designer/pdf-designer.component.ts
+++ b/packages/app/src/app/pdf/pdf-designer/pdf-designer.component.ts
@@ -38,6 +38,7 @@ export class PdfDesignerComponent implements OnDestroy, AfterViewInit {
   defaultTemplate = input<object>();
   templateName = input<string>();
   save = output<object | null>();
+  print = output<void>();
 
   i18n = inject(I18NService);
   private _dialog = inject(MatDialog);
@@ -153,6 +154,10 @@ export class PdfDesignerComponent implements OnDestroy, AfterViewInit {
 
   saveTemplate() {
     this.save.emit(this._designer!.getTemplate());
+  }
+
+  printEmptyTemplate() {
+    this.print.emit();
   }
 
   closeDesigner() {

--- a/packages/app/src/app/state/i18n.service.ts
+++ b/packages/app/src/app/state/i18n.service.ts
@@ -2992,6 +2992,11 @@ export class I18NService {
       en: 'Message template',
       fr: 'Modèle de message',
     },
+    printEmptySavedTemplate: {
+      de: 'Gespeicherte Vorlage drucken, leer',
+      en: 'Print saved template, empty',
+      fr: 'Imprimer le modèle enregistré, vide',
+    },
     errorSaving: {
       de: 'Fehler beim Speichern',
       en: 'Error saving',


### PR DESCRIPTION
For the ZSO that work partly offline:
To have the same formular, add an option to create/print an empty formular ("hidden" behind the formular design options.)