### PR TITLE
feat(journalSidebar): allow to collapse toDraw/drawn block

### DIFF
--- a/packages/app/src/app/sidebar/sidebar-journal/sidebar-journal.component.html
+++ b/packages/app/src/app/sidebar/sidebar-journal/sidebar-journal.component.html
@@ -8,9 +8,11 @@
     <p>{{ i18n.get('noMessagesToProcess') }}</p>
   </div>
 } @else {
-  <h2 class="journal-header">{{ i18n.get('messagesToDraw') }}</h2>
+  <h2 class="journal-header" (click)="toggle('toDraw')">
+    {{ i18n.get('messagesToDraw') }}<mat-icon class="toggle-icon" [class.rotated]="isOpen.toDraw">expand_more</mat-icon>
+  </h2>
   <mat-divider></mat-divider>
-  <mat-accordion multi displayMode="flat">
+  <mat-accordion *ngIf="isOpen.toDraw" multi displayMode="flat">
     @for (entry of journalEntriesToDraw(); track entry.documentId || entry.uuid) {
       <mat-expansion-panel
         class="mat-elevation-z0"
@@ -43,9 +45,11 @@
     }
   </mat-accordion>
 
-  <h2 class="journal-header">{{ i18n.get('drawnMessages') }}</h2>
+  <h2 class="journal-header" (click)="toggle('drawn')">
+    {{ i18n.get('drawnMessages') }}<mat-icon class="toggle-icon" [class.rotated]="isOpen.drawn">expand_more</mat-icon>
+  </h2>
   <mat-divider></mat-divider>
-  <mat-accordion multi displayMode="flat">
+  <mat-accordion *ngIf="isOpen.drawn" multi displayMode="flat">
     @for (entry of journalEntriesDrawn(); track entry.documentId || entry.uuid) {
       <mat-expansion-panel
         class="mat-elevation-z0"

--- a/packages/app/src/app/sidebar/sidebar-journal/sidebar-journal.component.scss
+++ b/packages/app/src/app/sidebar/sidebar-journal/sidebar-journal.component.scss
@@ -52,4 +52,18 @@ mat-panel-title {
 
 .journal-header {
   margin: 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+}
+
+.toggle-icon {
+  transition: transform 0.3s ease;
+  vertical-align: middle;
+  margin-left: auto;
+}
+
+.toggle-icon.rotated {
+  transform: rotate(180deg);
 }

--- a/packages/app/src/app/sidebar/sidebar-journal/sidebar-journal.component.ts
+++ b/packages/app/src/app/sidebar/sidebar-journal/sidebar-journal.component.ts
@@ -5,6 +5,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDividerModule } from '@angular/material/divider';
+import { MatIcon } from '@angular/material/icon';
 import { I18NService } from '../../state/i18n.service';
 import { SidebarJournalEntryComponent } from '../sidebar-journal-entry/sidebar-journal-entry.component';
 import { JournalService } from '../../journal/journal.service';
@@ -21,6 +22,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
     MatProgressSpinnerModule,
     MatButtonModule,
     MatDividerModule,
+    MatIcon,
     SidebarJournalEntryComponent,
   ],
   templateUrl: './sidebar-journal.component.html',
@@ -35,6 +37,7 @@ export class SidebarJournalComponent {
   readonly journalEntriesDrawn = signal<JournalEntry[]>([]);
   readonly isReadOnly = toSignal(this._state.observeIsReadOnly());
   currentMessageNumber: number | undefined;
+  isOpen = { toDraw: true, drawn: true };
 
   constructor(private elementRef: ElementRef) {
     effect(() => {
@@ -77,5 +80,9 @@ export class SidebarJournalComponent {
   startDrawing(entry: JournalEntry) {
     this._sidebar.close();
     this.journal.startDrawing(entry, true);
+  }
+
+  toggle(section: string) {
+    this.isOpen[section] = !this.isOpen[section];
   }
 }


### PR DESCRIPTION
Mainly used for the drawn block, hide it resulting in better overall state visibility of open drawn tasks.

I first try to do it with mat-expansion-panel but this "destroy" the current design, so I implement the simple logic manually.

**Attention:** if we would decide to let on of them default closed the "navigation" (e.g. from journal view) to a message over `#message=1` would still "open" that message but as the block is hidden would not be visible until user expand it manually, and than also not scroll that message into view.