### PR TITLE
feat(map): improve icon size on zoom

### DIFF
--- a/packages/app/src/app/map-renderer/draw-style.ts
+++ b/packages/app/src/app/map-renderer/draw-style.ts
@@ -39,7 +39,7 @@ export class DrawStyle {
     return `assets/img/signs/${file}`;
   }
 
-  private static scale(resolution: number, scaleFactor: number, min = 0.1): number {
+  private static scale(resolution: number, scaleFactor: number, min = 0.05): number {
     return Math.max(min, (scaleFactor * Math.sqrt(0.5 * resolution)) / resolution);
   }
 
@@ -496,7 +496,7 @@ export class DrawStyle {
           } as any),
         );
 
-        // Draw a circle below the icon
+        // Draw a circle behind the icon
         const backgroundCircle = new Circle({
           radius: iconRadius,
           fill: this.getColorFill(`rgba(255, 255, 255, ${signature.iconOpacity})`),
@@ -545,21 +545,23 @@ export class DrawStyle {
 
         if (signature.labelShow) {
           iconTextScale = DrawStyle.scale(resolution, DrawStyle.textScaleFactor, 0.4);
+
           iconLabel = new Text({
             text: signature.label,
             font: '20px sans-serif',
             scale: iconTextScale,
             fill: this.getColorFill(signature.color ?? '#535353'),
             backgroundFill: DrawStyle.getColorFill(`rgba(255, 255, 255, ${signature.iconOpacity})`),
-            padding: [5, 5, 5, 5],
+            padding: Array(4).fill(20 * scale),
           });
 
           iconStyles.push(
             new Style({
               text: iconLabel,
               geometry(feature) {
+                const deltaY = iconRadius * resolution + (iconTextScale * 20 * resolution);
                 const coordinates = DrawStyle.getIconCoordinates(feature, resolution)[1];
-                return new Point([coordinates[0], coordinates[1] - (35 / iconTextScale) * Math.max(resolution / 3, 1)]);
+                return new Point([coordinates[0], coordinates[1] - deltaY]);
               },
               zIndex,
             }),

--- a/packages/app/src/app/map-renderer/layers/base-layer.ts
+++ b/packages/app/src/app/map-renderer/layers/base-layer.ts
@@ -67,8 +67,8 @@ export abstract class ZsMapBaseLayer {
 
     combineLatest([this.observeMapZoom(), this._state.observeEnableClustering()]).subscribe(
       ([mapZoom, enableClustering]) => {
-        // don't show clustering if zoomed in more than 14
-        const shouldCluster = enableClustering && mapZoom < 14;
+        // don't show clustering if zoomed in more than 12
+        const shouldCluster = enableClustering && mapZoom < 12;
         this._olLayer.setSource(shouldCluster ? this._clusterSource : this._olSource);
       },
     );

--- a/packages/app/src/app/state/state.service.ts
+++ b/packages/app/src/app/state/state.service.ts
@@ -174,7 +174,7 @@ export class ZsMapStateService {
       hiddenSymbols: [],
       hiddenFeatureTypes: [],
       highlightedFeature: [],
-      enableClustering: true,
+      enableClustering: false,
       journalSort: { active: 'messageNumber', direction: 'desc' },
       journalFilter: {
         department: '',


### PR DESCRIPTION
closes #683 

- Allow for smaller icons when zoomed out
- Disable clustering by default
- Cluster icons only when zoomed out more