### PR TITLE
Global zoom factor for all symbols

### DIFF
--- a/packages/app/src/app/map-renderer/draw-style.ts
+++ b/packages/app/src/app/map-renderer/draw-style.ts
@@ -28,6 +28,7 @@ export class DrawStyle {
 
   static textScaleFactor = 1;
 
+  private static globalScaleFactor = 1;
   private static symbolStyleCache = {};
   private static vectorStyleCache = {};
   private static colorFill = {};
@@ -39,8 +40,18 @@ export class DrawStyle {
     return `assets/img/signs/${file}`;
   }
 
+  public static setGlobalScaleFactor(scale: number): void {
+    const nextScale = Number.isFinite(scale) && scale > 0 ? scale : 1;
+    if (nextScale === DrawStyle.globalScaleFactor) {
+      return;
+    }
+    DrawStyle.globalScaleFactor = nextScale;
+    DrawStyle.clearCaches();
+  }
+
   private static scale(resolution: number, scaleFactor: number, min = 0.05): number {
-    return Math.max(min, (scaleFactor * Math.sqrt(0.5 * resolution)) / resolution);
+    const baseScale = Math.max(min, (scaleFactor * Math.sqrt(0.5 * resolution)) / resolution);
+    return baseScale * DrawStyle.globalScaleFactor;
   }
 
   private static getDash(lineStyle: string | undefined, resolution: number): number[] {
@@ -352,7 +363,7 @@ export class DrawStyle {
     const symbolAnchorCoordinate = getFirstCoordinate(feature);
     const offsetX = signature.iconsOffset && signature.iconsOffset !== undefined ? signature.iconsOffset.x : 0.1;
     const offsetY = signature.iconsOffset && signature.iconsOffset !== undefined ? signature.iconsOffset.y : 0.1;
-    const resolutionFactor = resolution / 10;
+    const resolutionFactor = (resolution / 10) * DrawStyle.globalScaleFactor;
     const symbolCoordinate = [
       symbolAnchorCoordinate[0] - offsetX * resolutionFactor,
       symbolAnchorCoordinate[1] - offsetY * resolutionFactor,
@@ -370,7 +381,7 @@ export class DrawStyle {
     const offsetY = signature.iconsOffset ? 
       (signature.iconsOffset.endHasDifferentOffset && signature.iconsOffset.endY !== undefined ?
       signature.iconsOffset.endY : signature.iconsOffset.y) : 0.1;
-    const resolutionFactor = resolution / 10;
+    const resolutionFactor = (resolution / 10) * DrawStyle.globalScaleFactor;
     const symbolCoordinate = [
       symbolAnchorCoordinate[0] - offsetX * resolutionFactor,
       symbolAnchorCoordinate[1] - offsetY * resolutionFactor,

--- a/packages/app/src/app/map-renderer/map-renderer.service.ts
+++ b/packages/app/src/app/map-renderer/map-renderer.service.ts
@@ -29,6 +29,7 @@ import { I18NService } from '../state/i18n.service';
 import { ZsMapSources } from '../state/map-sources';
 import { ZsMapStateService } from '../state/state.service';
 import { SyncService } from '../sync/sync.service';
+import { DrawStyle } from './draw-style';
 import { ZsMapBaseDrawElement } from './elements/base/base-draw-element';
 import { ZsMapOLFeatureProps } from './elements/base/ol-feature-props';
 import { ZsMapBaseLayer } from './layers/base-layer';
@@ -101,6 +102,13 @@ export class MapRendererService {
 
   public constructor() {
     this._search.setZoomToFit(this.zoomToFit.bind(this));
+  }
+
+  private getZoomScaleFactor(zoom: number | undefined): number {
+    const baseZoom = DEFAULT_ZOOM;
+    const normalizedZoom = Number.isFinite(zoom) ? (zoom as number) : baseZoom;
+    const rawFactor = Math.pow(2, normalizedZoom - baseZoom);
+    return Math.min(4, Math.max(0.25, rawFactor));
   }
 
   public terminate() {
@@ -418,6 +426,18 @@ export class MapRendererService {
           }
           this._view.setZoom(zoom);
         }
+      });
+
+    combineLatest([
+      this._state.observeGlobalSymbolScale(),
+      this._state.observeGlobalSymbolScaleMode(),
+      this._state.observeMapZoom(),
+    ])
+      .pipe(takeUntil(this._ngUnsubscribe))
+      .subscribe(([scale, mode, zoom]) => {
+        const factor = mode === 'zoom' ? scale * this.getZoomScaleFactor(zoom) : scale;
+        DrawStyle.setGlobalScaleFactor(factor);
+        this._map?.render();
       });
 
     this._state

--- a/packages/app/src/app/map-renderer/map-renderer.service.ts
+++ b/packages/app/src/app/map-renderer/map-renderer.service.ts
@@ -437,6 +437,7 @@ export class MapRendererService {
       .subscribe(([scale, mode, zoom]) => {
         const factor = mode === 'zoom' ? scale * this.getZoomScaleFactor(zoom) : scale;
         DrawStyle.setGlobalScaleFactor(factor);
+        this._allLayers.forEach((layer) => layer.changed());
         this._map?.render();
       });
 

--- a/packages/app/src/app/map-renderer/map-renderer.service.ts
+++ b/packages/app/src/app/map-renderer/map-renderer.service.ts
@@ -99,6 +99,8 @@ export class MapRendererService {
   private _searchArea = inject(MapSearchAreaService);
   private _state = inject(ZsMapStateService);
   private _drawElementCache: Record<string, { layer: string | undefined; element: ZsMapBaseDrawElement }> = {};
+  private _globalSymbolScale = 1;
+  private _globalSymbolScaleMode: 'manual' | 'zoom' = 'manual';
 
   public constructor() {
     this._search.setZoomToFit(this.zoomToFit.bind(this));
@@ -109,6 +111,16 @@ export class MapRendererService {
     const normalizedZoom = Number.isFinite(zoom) ? (zoom as number) : baseZoom;
     const rawFactor = Math.pow(2, normalizedZoom - baseZoom);
     return Math.min(4, Math.max(0.25, rawFactor));
+  }
+
+  private applyGlobalSymbolScale(zoom?: number) {
+    const factor =
+      this._globalSymbolScaleMode === 'zoom'
+        ? this._globalSymbolScale * this.getZoomScaleFactor(zoom ?? this._view?.getZoom())
+        : this._globalSymbolScale;
+    DrawStyle.setGlobalScaleFactor(factor);
+    this._allLayers.forEach((layer) => layer.changed());
+    this._map?.render();
   }
 
   public terminate() {
@@ -398,6 +410,9 @@ export class MapRendererService {
 
     this._view.on('change:resolution', () => {
       debouncedZoomSave();
+      if (this._globalSymbolScaleMode === 'zoom') {
+        this.applyGlobalSymbolScale(this._view.getZoom());
+      }
     });
 
     this._view.on('change:rotation', () => {
@@ -428,17 +443,20 @@ export class MapRendererService {
         }
       });
 
-    combineLatest([
-      this._state.observeGlobalSymbolScale(),
-      this._state.observeGlobalSymbolScaleMode(),
-      this._state.observeMapZoom(),
-    ])
+    this._state
+      .observeGlobalSymbolScale()
       .pipe(takeUntil(this._ngUnsubscribe))
-      .subscribe(([scale, mode, zoom]) => {
-        const factor = mode === 'zoom' ? scale * this.getZoomScaleFactor(zoom) : scale;
-        DrawStyle.setGlobalScaleFactor(factor);
-        this._allLayers.forEach((layer) => layer.changed());
-        this._map?.render();
+      .subscribe((scale) => {
+        this._globalSymbolScale = scale;
+        this.applyGlobalSymbolScale();
+      });
+
+    this._state
+      .observeGlobalSymbolScaleMode()
+      .pipe(takeUntil(this._ngUnsubscribe))
+      .subscribe((mode) => {
+        this._globalSymbolScaleMode = mode;
+        this.applyGlobalSymbolScale();
       });
 
     this._state

--- a/packages/app/src/app/map-renderer/map-renderer.service.ts
+++ b/packages/app/src/app/map-renderer/map-renderer.service.ts
@@ -100,24 +100,13 @@ export class MapRendererService {
   private _state = inject(ZsMapStateService);
   private _drawElementCache: Record<string, { layer: string | undefined; element: ZsMapBaseDrawElement }> = {};
   private _globalSymbolScale = 1;
-  private _globalSymbolScaleMode: 'manual' | 'zoom' = 'manual';
 
   public constructor() {
     this._search.setZoomToFit(this.zoomToFit.bind(this));
   }
 
-  private getZoomScaleFactor(zoom: number | undefined): number {
-    const baseZoom = DEFAULT_ZOOM;
-    const normalizedZoom = Number.isFinite(zoom) ? (zoom as number) : baseZoom;
-    const rawFactor = Math.pow(2, normalizedZoom - baseZoom);
-    return Math.min(4, Math.max(0.25, rawFactor));
-  }
-
-  private applyGlobalSymbolScale(zoom?: number) {
-    const factor =
-      this._globalSymbolScaleMode === 'zoom'
-        ? this._globalSymbolScale * this.getZoomScaleFactor(zoom ?? this._view?.getZoom())
-        : this._globalSymbolScale;
+  private applyGlobalSymbolScale() {
+    const factor = this._globalSymbolScale;
     DrawStyle.setGlobalScaleFactor(factor);
     this._allLayers.forEach((layer) => layer.changed());
     this._map?.render();
@@ -410,9 +399,6 @@ export class MapRendererService {
 
     this._view.on('change:resolution', () => {
       debouncedZoomSave();
-      if (this._globalSymbolScaleMode === 'zoom') {
-        this.applyGlobalSymbolScale(this._view.getZoom());
-      }
     });
 
     this._view.on('change:rotation', () => {
@@ -448,14 +434,6 @@ export class MapRendererService {
       .pipe(takeUntil(this._ngUnsubscribe))
       .subscribe((scale) => {
         this._globalSymbolScale = scale;
-        this.applyGlobalSymbolScale();
-      });
-
-    this._state
-      .observeGlobalSymbolScaleMode()
-      .pipe(takeUntil(this._ngUnsubscribe))
-      .subscribe((mode) => {
-        this._globalSymbolScaleMode = mode;
         this.applyGlobalSymbolScale();
       });
 

--- a/packages/app/src/app/selected-feature/selected-feature.component.html
+++ b/packages/app/src/app/selected-feature/selected-feature.component.html
@@ -223,7 +223,7 @@
                       <div>
                         <mat-label>{{ i18n.get('symbolSize') }}</mat-label>
 
-                        <mat-slider [max]="2" [min]="0.1" [step]="0.1">
+                        <mat-slider [max]="2" [min]="0.5" [step]="0.1">
                           <input
                             matSliderThumb
                             [ngModel]="drawElement.iconSize"

--- a/packages/app/src/app/sidebar/sidebar-filters/sidebar-filters.component.html
+++ b/packages/app/src/app/sidebar/sidebar-filters/sidebar-filters.component.html
@@ -17,9 +17,9 @@
         <mat-slide-toggle [checked]="enableClustering$ | async" (change)="toggleClustering()">
           {{ i18n.get('featureClustering') }}
         </mat-slide-toggle>
-        <div>
+        <div class="global-scale">
           <div class="mat-caption">{{ i18n.get('globalSymbolScale') }}</div>
-          <mat-slider [max]="4" [min]="0.1" [step]="0.1">
+          <mat-slider class="global-scale-slider" [max]="1.5" [min]="0.5" [step]="0.1">
             <input
               matSliderThumb
               [ngModel]="(globalSymbolScale$ | async) ?? 1"

--- a/packages/app/src/app/sidebar/sidebar-filters/sidebar-filters.component.html
+++ b/packages/app/src/app/sidebar/sidebar-filters/sidebar-filters.component.html
@@ -17,6 +17,22 @@
         <mat-slide-toggle [checked]="enableClustering$ | async" (change)="toggleClustering()">
           {{ i18n.get('featureClustering') }}
         </mat-slide-toggle>
+        <div>
+          <div class="mat-caption">{{ i18n.get('globalSymbolScale') }}</div>
+          <mat-slider [max]="4" [min]="0.1" [step]="0.1">
+            <input
+              matSliderThumb
+              [ngModel]="(globalSymbolScale$ | async) ?? 1"
+              (ngModelChange)="setGlobalSymbolScale($event)"
+            />
+          </mat-slider>
+        </div>
+        <mat-slide-toggle
+          [checked]="(globalSymbolScaleMode$ | async) === 'zoom'"
+          (change)="setGlobalSymbolScaleMode($event.checked)"
+        >
+          {{ i18n.get('globalSymbolScaleZoomBased') }}
+        </mat-slide-toggle>
       </div>
     </ng-template>
   </mat-expansion-panel>

--- a/packages/app/src/app/sidebar/sidebar-filters/sidebar-filters.component.html
+++ b/packages/app/src/app/sidebar/sidebar-filters/sidebar-filters.component.html
@@ -19,20 +19,14 @@
         </mat-slide-toggle>
         <div class="global-scale">
           <div class="mat-caption">{{ i18n.get('globalSymbolScale') }}</div>
-          <mat-slider class="global-scale-slider" [max]="1.5" [min]="0.5" [step]="0.1">
+          <mat-slider class="global-scale-slider" [max]="2" [min]="0.5" [step]="0.05">
             <input
               matSliderThumb
-              [ngModel]="(globalSymbolScale$ | async) ?? 1"
+              [ngModel]="(globalSymbolScale$ | async) ?? 1.25"
               (ngModelChange)="setGlobalSymbolScale($event)"
             />
           </mat-slider>
         </div>
-        <mat-slide-toggle
-          [checked]="(globalSymbolScaleMode$ | async) === 'zoom'"
-          (change)="setGlobalSymbolScaleMode($event.checked)"
-        >
-          {{ i18n.get('globalSymbolScaleZoomBased') }}
-        </mat-slide-toggle>
       </div>
     </ng-template>
   </mat-expansion-panel>

--- a/packages/app/src/app/sidebar/sidebar-filters/sidebar-filters.component.scss
+++ b/packages/app/src/app/sidebar/sidebar-filters/sidebar-filters.component.scss
@@ -4,6 +4,11 @@
   gap: 14px;
 }
 
+.global-scale {
+  display: flex;
+  flex-direction: column;
+}
+
 .filterItem {
   height: 100%;
   width: 100%;

--- a/packages/app/src/app/sidebar/sidebar-filters/sidebar-filters.component.ts
+++ b/packages/app/src/app/sidebar/sidebar-filters/sidebar-filters.component.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Component, OnDestroy, OnInit, inject } from '@angular/core';
-import { debounceTime, takeUntil } from 'rxjs/operators';
+import { takeUntil } from 'rxjs/operators';
 import { Observable } from 'rxjs/internal/Observable';
 import { combineLatest, Subject } from 'rxjs';
 import { I18NService } from 'src/app/state/i18n.service';
@@ -43,7 +43,6 @@ import { MatSliderModule } from '@angular/material/slider';
 export class SidebarFiltersComponent implements OnInit, OnDestroy {
   i18n = inject(I18NService);
   private mapState = inject(ZsMapStateService);
-  private globalScaleChanges = new Subject<number>();
 
   filterSymbols: any[] = [];
   signCategories: any[] = [...signCategories.values()];
@@ -76,9 +75,6 @@ export class SidebarFiltersComponent implements OnInit, OnDestroy {
         this.updateFilterSymbolsAndFeatureTypes(drawElements, hiddenSymbols, hiddenFeatureTypes);
       });
 
-    this.globalScaleChanges
-      .pipe(debounceTime(200), takeUntil(this._ngUnsubscribe))
-      .subscribe((scale) => this.mapState.setGlobalSymbolScale(scale));
   }
 
   ngOnDestroy(): void {
@@ -201,7 +197,7 @@ export class SidebarFiltersComponent implements OnInit, OnDestroy {
   }
 
   public setGlobalSymbolScale(scale: number) {
-    this.globalScaleChanges.next(scale);
+    this.mapState.setGlobalSymbolScale(scale);
   }
 
   public setGlobalSymbolScaleMode(zoomBased: boolean) {

--- a/packages/app/src/app/sidebar/sidebar-filters/sidebar-filters.component.ts
+++ b/packages/app/src/app/sidebar/sidebar-filters/sidebar-filters.component.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Component, OnDestroy, OnInit, inject } from '@angular/core';
-import { takeUntil } from 'rxjs/operators';
+import { debounceTime, takeUntil } from 'rxjs/operators';
 import { Observable } from 'rxjs/internal/Observable';
 import { combineLatest, Subject } from 'rxjs';
 import { I18NService } from 'src/app/state/i18n.service';
@@ -43,6 +43,7 @@ import { MatSliderModule } from '@angular/material/slider';
 export class SidebarFiltersComponent implements OnInit, OnDestroy {
   i18n = inject(I18NService);
   private mapState = inject(ZsMapStateService);
+  private globalScaleChanges = new Subject<number>();
 
   filterSymbols: any[] = [];
   signCategories: any[] = [...signCategories.values()];
@@ -74,6 +75,10 @@ export class SidebarFiltersComponent implements OnInit, OnDestroy {
       .subscribe(([drawElements, hiddenSymbols, hiddenFeatureTypes]) => {
         this.updateFilterSymbolsAndFeatureTypes(drawElements, hiddenSymbols, hiddenFeatureTypes);
       });
+
+    this.globalScaleChanges
+      .pipe(debounceTime(200), takeUntil(this._ngUnsubscribe))
+      .subscribe((scale) => this.mapState.setGlobalSymbolScale(scale));
   }
 
   ngOnDestroy(): void {
@@ -196,7 +201,7 @@ export class SidebarFiltersComponent implements OnInit, OnDestroy {
   }
 
   public setGlobalSymbolScale(scale: number) {
-    this.mapState.setGlobalSymbolScale(scale);
+    this.globalScaleChanges.next(scale);
   }
 
   public setGlobalSymbolScaleMode(zoomBased: boolean) {

--- a/packages/app/src/app/sidebar/sidebar-filters/sidebar-filters.component.ts
+++ b/packages/app/src/app/sidebar/sidebar-filters/sidebar-filters.component.ts
@@ -50,7 +50,6 @@ export class SidebarFiltersComponent implements OnInit, OnDestroy {
   hiddenFeatureTypes$: Observable<string[]>;
   enableClustering$: Observable<boolean>;
   globalSymbolScale$: Observable<number>;
-  globalSymbolScaleMode$: Observable<'manual' | 'zoom'>;
   filtersOpenState = false;
   filtersGeneralOpenState = false;
   capitalizeFirstLetter = capitalizeFirstLetter;
@@ -61,7 +60,6 @@ export class SidebarFiltersComponent implements OnInit, OnDestroy {
     this.hiddenFeatureTypes$ = this.mapState.observeHiddenFeatureTypes().pipe(takeUntil(this._ngUnsubscribe));
     this.enableClustering$ = this.mapState.observeEnableClustering().pipe(takeUntil(this._ngUnsubscribe));
     this.globalSymbolScale$ = this.mapState.observeGlobalSymbolScale().pipe(takeUntil(this._ngUnsubscribe));
-    this.globalSymbolScaleMode$ = this.mapState.observeGlobalSymbolScaleMode().pipe(takeUntil(this._ngUnsubscribe));
   }
 
   ngOnInit(): void {
@@ -200,7 +198,4 @@ export class SidebarFiltersComponent implements OnInit, OnDestroy {
     this.mapState.setGlobalSymbolScale(scale);
   }
 
-  public setGlobalSymbolScaleMode(zoomBased: boolean) {
-    this.mapState.setGlobalSymbolScaleMode(zoomBased ? 'zoom' : 'manual');
-  }
 }

--- a/packages/app/src/app/sidebar/sidebar-filters/sidebar-filters.component.ts
+++ b/packages/app/src/app/sidebar/sidebar-filters/sidebar-filters.component.ts
@@ -13,11 +13,13 @@ import { MatAccordion, MatExpansionModule } from '@angular/material/expansion';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatDividerModule } from '@angular/material/divider';
 import { AsyncPipe } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { MatGridListModule } from '@angular/material/grid-list';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxChange, MatCheckboxModule } from '@angular/material/checkbox';
+import { MatSliderModule } from '@angular/material/slider';
 
 @Component({
   selector: 'app-sidebar-filters',
@@ -33,7 +35,9 @@ import { MatCheckboxChange, MatCheckboxModule } from '@angular/material/checkbox
     MatIconModule,
     MatListModule,
     MatButtonModule,
-    MatCheckboxModule
+    MatCheckboxModule,
+    MatSliderModule,
+    FormsModule
   ],
 })
 export class SidebarFiltersComponent implements OnInit, OnDestroy {
@@ -45,6 +49,8 @@ export class SidebarFiltersComponent implements OnInit, OnDestroy {
   hiddenSymbols$: Observable<number[]>;
   hiddenFeatureTypes$: Observable<string[]>;
   enableClustering$: Observable<boolean>;
+  globalSymbolScale$: Observable<number>;
+  globalSymbolScaleMode$: Observable<'manual' | 'zoom'>;
   filtersOpenState = false;
   filtersGeneralOpenState = false;
   capitalizeFirstLetter = capitalizeFirstLetter;
@@ -54,6 +60,8 @@ export class SidebarFiltersComponent implements OnInit, OnDestroy {
     this.hiddenSymbols$ = this.mapState.observeHiddenSymbols().pipe(takeUntil(this._ngUnsubscribe));
     this.hiddenFeatureTypes$ = this.mapState.observeHiddenFeatureTypes().pipe(takeUntil(this._ngUnsubscribe));
     this.enableClustering$ = this.mapState.observeEnableClustering().pipe(takeUntil(this._ngUnsubscribe));
+    this.globalSymbolScale$ = this.mapState.observeGlobalSymbolScale().pipe(takeUntil(this._ngUnsubscribe));
+    this.globalSymbolScaleMode$ = this.mapState.observeGlobalSymbolScaleMode().pipe(takeUntil(this._ngUnsubscribe));
   }
 
   ngOnInit(): void {
@@ -185,5 +193,13 @@ export class SidebarFiltersComponent implements OnInit, OnDestroy {
 
   public toggleClustering() {
     this.mapState.toggleClustering();
+  }
+
+  public setGlobalSymbolScale(scale: number) {
+    this.mapState.setGlobalSymbolScale(scale);
+  }
+
+  public setGlobalSymbolScaleMode(zoomBased: boolean) {
+    this.mapState.setGlobalSymbolScaleMode(zoomBased ? 'zoom' : 'manual');
   }
 }

--- a/packages/app/src/app/state/i18n.service.ts
+++ b/packages/app/src/app/state/i18n.service.ts
@@ -1069,6 +1069,16 @@ export class I18NService {
       en: 'Global filters',
       fr: 'Filtre globale',
     },
+    globalSymbolScale: {
+      de: 'Globale Symbolgrösse',
+      en: 'Global symbol scale',
+      fr: 'Échelle globale des symboles',
+    },
+    globalSymbolScaleZoomBased: {
+      de: 'Grösse nach Zoom',
+      en: 'Zoom-based size',
+      fr: 'Taille basée sur le zoom',
+    },
     showAllElements: {
       de: 'Alle Elemente anzeigen',
       en: 'Show all elements',

--- a/packages/app/src/app/state/i18n.service.ts
+++ b/packages/app/src/app/state/i18n.service.ts
@@ -1074,11 +1074,6 @@ export class I18NService {
       en: 'Global symbol scale',
       fr: 'Échelle globale des symboles',
     },
-    globalSymbolScaleZoomBased: {
-      de: 'Grösse nach Zoom',
-      en: 'Zoom-based size',
-      fr: 'Taille basée sur le zoom',
-    },
     showAllElements: {
       de: 'Alle Elemente anzeigen',
       en: 'Show all elements',

--- a/packages/app/src/app/state/state.service.ts
+++ b/packages/app/src/app/state/state.service.ts
@@ -21,7 +21,6 @@ import {
   ZsMapDrawElementState,
   ZsMapDrawElementStateType,
   ZsMapElementToDraw,
-  ZsMapGlobalSymbolScaleMode,
   ZsMapLayerState,
   ZsMapLayerStateType,
   ZsMapPolygonDrawElementState,
@@ -176,8 +175,7 @@ export class ZsMapStateService {
       hiddenFeatureTypes: [],
       highlightedFeature: [],
       enableClustering: false,
-      globalSymbolScale: 1,
-      globalSymbolScaleMode: 'manual',
+      globalSymbolScale: 1.25,
       journalSort: { active: 'messageNumber', direction: 'desc' },
       journalFilter: {
         department: '',
@@ -515,23 +513,10 @@ export class ZsMapStateService {
     );
   }
 
-  public observeGlobalSymbolScaleMode(): Observable<ZsMapGlobalSymbolScaleMode> {
-    return this._display.pipe(
-      map((o) => o.globalSymbolScaleMode ?? 'manual'),
-      distinctUntilChanged((x, y) => x === y),
-    );
-  }
-
   public setGlobalSymbolScale(scale: number) {
     const nextScale = Number.isFinite(scale) ? Math.max(0.1, scale) : 1;
     this.updateDisplayState((draft) => {
       draft.globalSymbolScale = nextScale;
-    });
-  }
-
-  public setGlobalSymbolScaleMode(mode: ZsMapGlobalSymbolScaleMode) {
-    this.updateDisplayState((draft) => {
-      draft.globalSymbolScaleMode = mode;
     });
   }
 

--- a/packages/app/src/app/state/state.service.ts
+++ b/packages/app/src/app/state/state.service.ts
@@ -21,6 +21,7 @@ import {
   ZsMapDrawElementState,
   ZsMapDrawElementStateType,
   ZsMapElementToDraw,
+  ZsMapGlobalSymbolScaleMode,
   ZsMapLayerState,
   ZsMapLayerStateType,
   ZsMapPolygonDrawElementState,
@@ -175,6 +176,8 @@ export class ZsMapStateService {
       hiddenFeatureTypes: [],
       highlightedFeature: [],
       enableClustering: false,
+      globalSymbolScale: 1,
+      globalSymbolScaleMode: 'manual',
       journalSort: { active: 'messageNumber', direction: 'desc' },
       journalFilter: {
         department: '',
@@ -324,7 +327,24 @@ export class ZsMapStateService {
 
   public setDisplayState(newState?: IZsMapDisplayState): void {
     this.updateDisplayState(() => {
-      return newState || this._getDefaultDisplayState();
+      if (!newState) {
+        return this._getDefaultDisplayState();
+      }
+      const defaults = this._getDefaultDisplayState();
+      return {
+        ...defaults,
+        ...newState,
+        layerVisibility: newState.layerVisibility ?? defaults.layerVisibility,
+        layerOpacity: newState.layerOpacity ?? defaults.layerOpacity,
+        layerOrder: newState.layerOrder ?? defaults.layerOrder,
+        elementVisibility: newState.elementVisibility ?? defaults.elementVisibility,
+        elementOpacity: newState.elementOpacity ?? defaults.elementOpacity,
+        layers: newState.layers ?? defaults.layers,
+        wmsSources: newState.wmsSources ?? defaults.wmsSources,
+        journalFilter: { ...defaults.journalFilter, ...newState.journalFilter },
+        searchConfig: { ...defaults.searchConfig, ...newState.searchConfig },
+        journalMessageEditConfig: { ...defaults.journalMessageEditConfig, ...newState.journalMessageEditConfig },
+      };
     });
   }
 
@@ -486,6 +506,33 @@ export class ZsMapStateService {
       map((o) => o.enableClustering),
       distinctUntilChanged((x, y) => x === y),
     );
+  }
+
+  public observeGlobalSymbolScale(): Observable<number> {
+    return this._display.pipe(
+      map((o) => o.globalSymbolScale ?? 1),
+      distinctUntilChanged((x, y) => x === y),
+    );
+  }
+
+  public observeGlobalSymbolScaleMode(): Observable<ZsMapGlobalSymbolScaleMode> {
+    return this._display.pipe(
+      map((o) => o.globalSymbolScaleMode ?? 'manual'),
+      distinctUntilChanged((x, y) => x === y),
+    );
+  }
+
+  public setGlobalSymbolScale(scale: number) {
+    const nextScale = Number.isFinite(scale) ? Math.max(0.1, scale) : 1;
+    this.updateDisplayState((draft) => {
+      draft.globalSymbolScale = nextScale;
+    });
+  }
+
+  public setGlobalSymbolScaleMode(mode: ZsMapGlobalSymbolScaleMode) {
+    this.updateDisplayState((draft) => {
+      draft.globalSymbolScaleMode = mode;
+    });
   }
 
   public updateShowCurrentLocation(show: boolean) {

--- a/packages/types/state/interfaces.ts
+++ b/packages/types/state/interfaces.ts
@@ -55,6 +55,8 @@ export enum ZsMapDisplayMode {
   HISTORY = 'history',
 }
 
+export type ZsMapGlobalSymbolScaleMode = 'manual' | 'zoom';
+
 export interface IZsMapDisplayState {
   id?: string;
   version: number;
@@ -80,6 +82,8 @@ export interface IZsMapDisplayState {
   hiddenFeatureTypes: string[];
   highlightedFeature: string[];
   enableClustering: boolean;
+  globalSymbolScale: number;
+  globalSymbolScaleMode: ZsMapGlobalSymbolScaleMode;
   journalSort: Sort;
   journalFilter: IZsJournalFilter;
   searchConfig: IZsGlobalSearchConfig;

--- a/packages/types/state/interfaces.ts
+++ b/packages/types/state/interfaces.ts
@@ -55,8 +55,6 @@ export enum ZsMapDisplayMode {
   HISTORY = 'history',
 }
 
-export type ZsMapGlobalSymbolScaleMode = 'manual' | 'zoom';
-
 export interface IZsMapDisplayState {
   id?: string;
   version: number;
@@ -83,7 +81,6 @@ export interface IZsMapDisplayState {
   highlightedFeature: string[];
   enableClustering: boolean;
   globalSymbolScale: number;
-  globalSymbolScaleMode: ZsMapGlobalSymbolScaleMode;
   journalSort: Sort;
   journalFilter: IZsJournalFilter;
   searchConfig: IZsGlobalSearchConfig;


### PR DESCRIPTION
Closes #53 

The location of the slider in the global filter for symbols is not great but currently we have no other accordion tab that would make sense.