### PR TITLE
Update deployment values for kubernetes: more memory, more timeout fo…

### DIFF
--- a/.azure/k8s/deployment.yml
+++ b/.azure/k8s/deployment.yml
@@ -29,15 +29,16 @@ spec:
             httpGet:
               path: /
               port: http
-            initialDelaySeconds: 45
-            failureThreshold: 5
-            periodSeconds: 5
+            initialDelaySeconds: 30
+            failureThreshold: 6
+            periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /
               port: http
-            failureThreshold: 3
+            failureThreshold: 6
             periodSeconds: 5
+            timeoutSeconds: 10
           env:
             - name: DATABASE_HOST
               valueFrom:
@@ -132,4 +133,4 @@ spec:
               memory: 256Mi
             limits:
               cpu: 1000m
-              memory: 512Mi
+              memory: 2Gi


### PR DESCRIPTION
…r the liveness probe.

@swerder the question is this operation to generate map layers is this blocking? Because nodejs runs on a single thread and if this operation blocks the whole javascript engine for example for 30 seconds then it gets killed because it doesn't answer to the liveness probe on K8S anymore. I increased the timeout per test now it could theoretically not respond for 60 seconds before it gets killed. Not optimal but maybe this will already help.

In the logs are no useful information that could be responsible for the restart means it is definitely the memory or the liveness probe.