### PR TITLE
feat(geodienste): add handling for geodienste layers, add AV as basemap

### DIFF
--- a/packages/app/src/app/map-layer/geodienste/geodienste.service.ts
+++ b/packages/app/src/app/map-layer/geodienste/geodienste.service.ts
@@ -1,0 +1,102 @@
+import { Injectable, inject } from '@angular/core';
+import { WMSMapLayer, WmsSource } from '@zskarte/types';
+import { WmsService } from '../wms/wms.service';
+import { SessionService } from 'src/app/session/session.service';
+
+export const GEODIENSTE_DOMAIN = 'https://geodienste.ch/db/';
+const GEODIENSTE_ATTRIBUTION: [string, string][] = [['geodienste', 'https://geodienste.ch/terms-of-use']];
+
+@Injectable({
+  providedIn: 'root',
+})
+export class GeodiensteService {
+  private wmsService = inject(WmsService);
+  private session = inject(SessionService);
+
+  private _layersCache: WMSMapLayer[] | undefined;
+
+  private layersAndOpacity: Record<string, number> = {
+    gefahrenkarten_v1_3_0: 0.8,
+    naturereigniskataster_v1_0_0: 0.8,
+    stromversorgungssicherheit_netzgebiete_v1_2_0: 0.8,
+    waldreservate_v2_0_0: 0.8,
+    wildruhezonen_v2_1_1: 0.8,
+    av_0: 1,
+    avc_0: 1,
+    av_situationsplan_0: 1,
+    av_situationsplan_oereb_0: 1,
+  };
+
+  public async getLayers(): Promise<WMSMapLayer[]> {
+    if (this._layersCache) {
+      return this._layersCache;
+    }
+    const language = this.getLanguageSuffix();
+    const mapLayers: WMSMapLayer[] = [];
+    for (const [layerId, opacity] of Object.entries(this.layersAndOpacity)) {
+      const mapLayer = await this.getLayer(layerId, opacity, language);
+      if (mapLayer) {
+        mapLayers.push(mapLayer);
+      }
+    }
+    this._layersCache = mapLayers;
+    return this._layersCache;
+  }
+
+  public getLanguageSuffix() {
+    switch (this.session.getLocale()) {
+      case 'de': {
+        return '/deu';
+      }
+      case 'fr': {
+        return '/fra';
+      }
+      /*
+      case 'it': {
+        return'/ita';
+      }
+      */
+    }
+    return '';
+  }
+
+  public getSource(layerId: string, language = this.getLanguageSuffix()) {
+    return {
+      url: `${GEODIENSTE_DOMAIN}${layerId}${language}`,
+      label: `geodienste ${layerId}`,
+      type: 'wms',
+      attribution: GEODIENSTE_ATTRIBUTION,
+    } as WmsSource;
+  }
+
+  public getServerLayerName(language = this.getLanguageSuffix()) {
+    return language === '/fra' ? 'donnees' : language === '/ita' ? 'dati' : 'daten';
+  }
+
+  public async getLayer(
+    layerId: string,
+    opacity = 0.8,
+    language = this.getLanguageSuffix(),
+  ): Promise<WMSMapLayer | null> {
+    if (!layerId) {
+      return null;
+    }
+    const source = this.getSource(layerId, language);
+    const capa = await this.wmsService.getWMSCapa(source);
+    let gutter: number | undefined = undefined;
+    if (layerId === 'stromversorgungssicherheit_netzgebiete_v1_2_0') {
+      gutter = 0;
+    }
+    return {
+      label: capa.Capability.Layer.Title,
+      opacity,
+      serverLayerName: this.getServerLayerName(language),
+      type: 'wms',
+      tileSize: 512,
+      gutter,
+      source,
+      fullId: `geodienste|${layerId}`,
+      geodiensteSourceLayerId: layerId,
+    } as WMSMapLayer;
+  }
+}

--- a/packages/app/src/app/map-layer/organisation-layer-settings/organisation-layer-settings.component.html
+++ b/packages/app/src/app/map-layer/organisation-layer-settings/organisation-layer-settings.component.html
@@ -98,6 +98,7 @@
           <mat-select [formControl]="sourceFilter">
             <mat-option value="ALL">{{ i18n.get('allSources') }}</mat-option>
             <mat-option value="_GeoAdmin_">GeoAdmin</mat-option>
+            <mat-option value="_geodienste_">geodienste</mat-option>
             <mat-option value="_OwnMapLayers_">{{ i18n.get('ownMapLayers') }}</mat-option>
             <mat-option value="_GlobalMapLayers_">{{ i18n.get('globalMapLayers') }}</mat-option>
             <mat-option value="_ManagedMapLayers_">{{ i18n.get('managedMapLayers') }}</mat-option>

--- a/packages/app/src/app/map-layer/organisation-layer-settings/organisation-layer-settings.component.ts
+++ b/packages/app/src/app/map-layer/organisation-layer-settings/organisation-layer-settings.component.ts
@@ -91,6 +91,8 @@ export class OrganisationLayerSettingsComponent {
             layers = layers.filter((f) => f.id !== undefined && !f.owner && !f.managed);
           } else if (source === '_ManagedMapLayers_') {
             layers = layers.filter((f) => f.id !== undefined && f.managed);
+          } else if (source === '_geodienste_') {
+            layers = layers.filter((f) => f.fullId.startsWith('geodienste|'));
           } else {
             const sourceFilter = source === '_GeoAdmin_' ? undefined : source;
             layers = layers.filter((f) => f.source?.url === sourceFilter);

--- a/packages/app/src/app/map-layer/wms/wms-layer-options/wms-layer-options.component.html
+++ b/packages/app/src/app/map-layer/wms/wms-layer-options/wms-layer-options.component.html
@@ -19,6 +19,7 @@
       [disabled]="layer.type !== 'wms_custom'"
     >
       <mat-option value="_GeoAdmin_" disabled>GeoAdmin</mat-option>
+      <mat-option value="_geodienste_" [disabled]="!layer.geodiensteSourceLayerId">geodienste</mat-option>
       <mat-option value="_CUSTOM_">custom</mat-option>
       @for (item of sources; track item) {
         <mat-option [value]="item" [disabled]="item.type !== 'wms'">
@@ -27,6 +28,12 @@
       }
     </mat-select>
   </mat-form-field>
+  @if (geodienste_source) {
+    <mat-form-field appearance="outline" subscriptSizing="dynamic">
+      <mat-label>{{ i18n.get('geodiensteLayerId') }}</mat-label>
+      <input matInput type="url" [(ngModel)]="layer.geodiensteSourceLayerId" [disabled]="layer.type !== 'wms_custom'"/>
+    </mat-form-field>
+  }
   @if (custom_source) {
     <mat-form-field appearance="outline" subscriptSizing="dynamic">
       <mat-label>{{ i18n.get('layerSourceUrl') }}</mat-label>

--- a/packages/app/src/app/map-layer/wms/wms-layer-options/wms-layer-options.component.ts
+++ b/packages/app/src/app/map-layer/wms/wms-layer-options/wms-layer-options.component.ts
@@ -14,6 +14,7 @@ import { MatIcon } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { DialogBodyComponent, DialogFooterComponent, DialogHeaderComponent } from '../../../ui/dialog-layout';
+import { GEODIENSTE_DOMAIN, GeodiensteService } from '../../geodienste/geodienste.service';
 
 @Component({
   selector: 'app-wms-layer-options',
@@ -40,12 +41,14 @@ export class WmsLayerOptionsComponent {
   i18n = inject(I18NService);
   mapState = inject(ZsMapStateService);
   private wmsService = inject(WmsService);
+  private geodiensteService = inject(GeodiensteService);
 
   hasSublayers = false;
   sublayerHidden: { name: string; hidden: boolean }[] = [];
   sources: WmsSource[] = [];
   tileFormats: string[] = ['image/png'];
   custom_source?: MapSource;
+  geodienste_source?: WmsSource;
   constructor() {
     let layer = this.layer;
     const mapState = this.mapState;
@@ -73,12 +76,21 @@ export class WmsLayerOptionsComponent {
     firstValueFrom(mapState.observeWmsSources$()).then((val) => {
       if (val) {
         this.sources = val;
-        if (this.layer.type === 'wms_custom' && !this.sources.find((s) => s === layer.source)) {
-          this.custom_source = layer.source;
+        if (!this.sources.find((s) => s === layer.source)) {
+          if (layer.geodiensteSourceLayerId) {
+            this.geodienste_source = layer.source as WmsSource;
+            layer.source = '_geodienste_' as any;
+          } else {
+            this.custom_source = layer.source ? { ...layer.source } : { url: '' };
+            layer.source = '_CUSTOM_' as any;
+            if (this.custom_source?.url.startsWith(GEODIENSTE_DOMAIN)) {
+              layer.geodiensteSourceLayerId = this.custom_source.url.substring(GEODIENSTE_DOMAIN.length).split('/')[0];
+            }
+          }
         }
       }
     });
-    if (layer.source) {
+    if (typeof layer.source !== 'string') {
       wmsService.getTileFormats(layer.source as WmsSource).then((formats) => (this.tileFormats = formats));
     }
   }
@@ -121,18 +133,36 @@ export class WmsLayerOptionsComponent {
         this.layer.source = this.sources.find((s) => s.url === this.custom_source?.url);
         this.custom_source = undefined;
       }
+      if (!this.layer.source && this.layer.geodiensteSourceLayerId) {
+        this.layer.source = '_geodienste_' as any;
+        this.geodienste_source = this.geodiensteService.getSource(this.layer.geodiensteSourceLayerId);
+        this.layer.serverLayerName = this.geodiensteService.getServerLayerName();
+      }
     }
     this.layer.type = event.value;
   }
 
   async onSelectionChange($event: MatSelectChange) {
     if ($event.value === '_CUSTOM_') {
-      if (this.layer.source) {
+      if (this.layer.geodiensteSourceLayerId) {
+        this.custom_source = this.geodiensteService.getSource(this.layer.geodiensteSourceLayerId);
+      } else if (this.layer.source && this.layer.source !== ('_geodienste_' as any)) {
         this.custom_source = { url: this.layer.source?.url };
-        this.layer.source = $event.value;
+      } else {
+        this.custom_source = { url: '' };
       }
+      this.layer.source = $event.value;
+      this.geodienste_source = undefined;
+    } else if ($event.value === '_geodienste_') {
+      this.custom_source = undefined;
+      const source = this.geodiensteService.getSource(this.layer.geodiensteSourceLayerId ?? '');
+      this.geodienste_source = source;
+      this.layer.source = $event.value;
+      this.layer.serverLayerName = this.geodiensteService.getServerLayerName();
+      this.tileFormats = await this.wmsService.getTileFormats(source);
     } else if ($event.value) {
       this.custom_source = undefined;
+      this.geodienste_source = undefined;
       this.layer.source = $event.value;
       this.tileFormats = await this.wmsService.getTileFormats($event.value);
     }
@@ -149,6 +179,10 @@ export class WmsLayerOptionsComponent {
         }
       }
       delete this.layer.originalServerLayerName;
+      if (this.geodienste_source && this.layer.geodiensteSourceLayerId) {
+        this.layer.source = this.geodiensteService.getSource(this.layer.geodiensteSourceLayerId);
+        this.layer.serverLayerName = this.geodiensteService.getServerLayerName();
+      }
     } else if (this.layer.type === 'wms_custom') {
       if (this.hasSublayers) {
         const visibleLayers = this.layer.serverLayerName.split(',');
@@ -161,6 +195,11 @@ export class WmsLayerOptionsComponent {
       }
       if (this.custom_source) {
         this.layer.source = this.custom_source;
+        this.layer.geodiensteSourceLayerId = undefined;
+      } else if (this.geodienste_source && this.layer.geodiensteSourceLayerId) {
+        this.layer.source = this.geodiensteService.getSource(this.layer.geodiensteSourceLayerId);
+      } else {
+        console.error('no valid source could be set', this.layer, this.custom_source, this.geodienste_source);
       }
     }
     if (!this.layer.noneTiled) {

--- a/packages/app/src/app/map-layer/wms/wms-source/wms-source.component.html
+++ b/packages/app/src/app/map-layer/wms/wms-source/wms-source.component.html
@@ -36,6 +36,7 @@
       <mat-label>{{ i18n.get('layerSource') }}</mat-label>
       <mat-select [value]="selectedSource" (selectionChange)="onSelectionChange($event)">
         <mat-option value="_GeoAdmin_" disabled>GeoAdmin</mat-option>
+        <mat-option value="_geodienste_" disabled>geodienste</mat-option>
         @if (this.filteredGlobalSources$.value.length > 0) {
           <mat-option value="__SELECT__">{{ i18n.get('selectLayerSource') }}</mat-option>
         }

--- a/packages/app/src/app/map-layer/wms/wms.service.ts
+++ b/packages/app/src/app/map-layer/wms/wms.service.ts
@@ -309,7 +309,8 @@ export class WmsService {
       return [];
     }
     options.attributions =
-      this._sourceAttributionCache.get(mapLayer.source.url) ?? this._capabilitiesAttributionCache.get(mapLayer.source.url);
+      this._sourceAttributionCache.get(mapLayer.source.url) ??
+      this._capabilitiesAttributionCache.get(mapLayer.source.url);
 
     /*
     const scaling = 0.5;
@@ -351,6 +352,7 @@ export class WmsService {
     MaxScaleDenominator: number | undefined,
     tileSize: number | undefined,
     tileFormat: string | undefined,
+    gutter: number | undefined,
   ) {
     const sourceParams: { [key: string]: unknown } = {
       LAYERS: layers,
@@ -377,7 +379,7 @@ export class WmsService {
       let sourceOptionAddons = {};
       if (tileSize && mercatorProjection) {
         const defaultTileGrid = getForProjection(mercatorProjection);
-        const gutter = Math.min(50, Math.ceil(tileSize * 0.1));
+        gutter = gutter ?? Math.min(50, Math.ceil(tileSize * 0.1));
         const scaling = (tileSize - gutter - gutter) / 256;
         const gridParams = WmsService._getScaledTileGridInfos(defaultTileGrid, scaling);
         if (gridParams) {
@@ -388,6 +390,8 @@ export class WmsService {
             gutter,
           };
         }
+      } else {
+        gutter = gutter ?? 12;
       }
       sourceParams['TILED'] = true;
       return new OlTileLayer({
@@ -395,7 +399,7 @@ export class WmsService {
         source: new TileWMS({
           ...sourceOptions,
           transition: 0,
-          gutter: 12, //prevent cutted features on image boundaries => need to use same projection for tile as for view!
+          gutter, //prevent cutted features on image boundaries => need to use same projection for tile as for view!
           ...sourceOptionAddons,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         }) as any,
@@ -414,11 +418,18 @@ export class WmsService {
     if (!mapLayer.source) {
       return [];
     }
-    const capa = await this.getWMSCapa(mapLayer.source as WmsSource);
+    let capa: any;
+    try {
+      capa = await this.getWMSCapa(mapLayer.source as WmsSource);
+    } catch (error) {
+      console.error(error, mapLayer);
+    }
     if (!capa) {
       return [];
     }
-    const capaInfos = capa['Capability']['Layer']['Layer'].find((capaLayer) => capaLayer.Name === mapLayer.serverLayerName);
+    const capaInfos = capa['Capability']['Layer']['Layer'].find(
+      (capaLayer) => capaLayer.Name === mapLayer.serverLayerName,
+    );
     if (!capaInfos) {
       return [];
     }
@@ -428,7 +439,9 @@ export class WmsService {
       this._mapLayerService.createAttributionFromArray(mapLayer.attribution) ??
       this.getAttribution(
         capaInfos['Attribution'],
-        this._sourceAttributionCache.get(mapLayer.source.url) ?? this._capabilitiesAttributionCache.get(mapLayer.source.url) ?? '',
+        this._sourceAttributionCache.get(mapLayer.source.url) ??
+          this._capabilitiesAttributionCache.get(mapLayer.source.url) ??
+          '',
       );
 
     let layerInfos = [capaInfos];
@@ -453,17 +466,18 @@ export class WmsService {
         capa['version'],
         wmsUrl,
         this.getAttribution(info['Attribution'], attributionHtml),
-        mapLayer.opacity,
         mapLayer.zIndex,
+        mapLayer.opacity,
         //use layer based value as fallback or as default based on splitIntoSubLayers value
-        mapLayer.splitIntoSubLayers ?
-          info.MinScaleDenominator ?? mapLayer.MinScaleDenominator
-        : mapLayer.MinScaleDenominator ?? info.MinScaleDenominator,
-        mapLayer.splitIntoSubLayers ?
-          info.MaxScaleDenominator ?? mapLayer.MaxScaleDenominator
-        : mapLayer.MaxScaleDenominator ?? info.MaxScaleDenominator,
+        mapLayer.splitIntoSubLayers
+          ? (info.MinScaleDenominator ?? mapLayer.MinScaleDenominator)
+          : (mapLayer.MinScaleDenominator ?? info.MinScaleDenominator),
+        mapLayer.splitIntoSubLayers
+          ? (info.MaxScaleDenominator ?? mapLayer.MaxScaleDenominator)
+          : (mapLayer.MaxScaleDenominator ?? info.MaxScaleDenominator),
         mapLayer.tileSize,
         mapLayer.tileFormat,
+        mapLayer.gutter,
       ),
     );
   }
@@ -474,7 +488,7 @@ export class WmsService {
     }
 
     let capa;
-    let wmsUrl = new URL(mapLayer.source.url).origin;
+    let wmsUrl = mapLayer.source.url;
     try {
       capa = await this.getWMSCapa(mapLayer.source as WmsSource);
       wmsUrl = capa['Capability']['Request']['GetMap']['DCPType'][0]['HTTP']['Get']['OnlineResource'];
@@ -495,12 +509,13 @@ export class WmsService {
         capa?.version ?? WMS_DEFAULT_VERSION,
         wmsUrl,
         attributionHtml,
-        mapLayer.opacity,
         mapLayer.zIndex,
+        mapLayer.opacity,
         mapLayer.MinScaleDenominator,
         mapLayer.MaxScaleDenominator,
         mapLayer.tileSize,
         mapLayer.tileFormat,
+        mapLayer.gutter,
       ),
     ];
   }
@@ -539,7 +554,7 @@ export class WmsService {
       console.error('saveGlobalWMSSource', error);
     } else if (result) {
       //on save the referenced organisation is no returned
-      result.organization = { documentId: organizationId }
+      result.organization = { documentId: organizationId };
       return WmsService.mapWmsSourceResponse(result, organizationId);
     }
     return null;

--- a/packages/app/src/app/map-layer/wms/wms.service.ts
+++ b/packages/app/src/app/map-layer/wms/wms.service.ts
@@ -377,7 +377,7 @@ export class WmsService {
       let sourceOptionAddons = {};
       if (tileSize && mercatorProjection) {
         const defaultTileGrid = getForProjection(mercatorProjection);
-        const gutter = Math.min(50, Math.ceil(tileSize * 0.05));
+        const gutter = Math.min(50, Math.ceil(tileSize * 0.1));
         const scaling = (tileSize - gutter - gutter) / 256;
         const gridParams = WmsService._getScaledTileGridInfos(defaultTileGrid, scaling);
         if (gridParams) {

--- a/packages/app/src/app/map-renderer/map-renderer.service.ts
+++ b/packages/app/src/app/map-renderer/map-renderer.service.ts
@@ -26,7 +26,7 @@ import { GeoJSONService } from '../map-layer/geojson/geojson.service';
 import { WmsService } from '../map-layer/wms/wms.service';
 import { DEFAULT_COORDINATES, DEFAULT_ZOOM } from '../session/default-map-values';
 import { I18NService } from '../state/i18n.service';
-import { ZsMapSources } from '../state/map-sources';
+import { MapSourcesService } from '../state/map-sources';
 import { ZsMapStateService } from '../state/state.service';
 import { SyncService } from '../sync/sync.service';
 import { DrawStyle } from './draw-style';
@@ -58,6 +58,7 @@ export class MapRendererService {
   private wmsService = inject(WmsService);
   private geoJSONService = inject(GeoJSONService);
   private _search = inject(SearchService);
+  private mapSources = inject(MapSourcesService);
 
   private _ngUnsubscribe = new Subject<void>();
   private _map!: OlMap;
@@ -409,7 +410,7 @@ export class MapRendererService {
             // Show names as tooltip, if they are not already shown
             const label = feature.get('sig')?.label;
             if (tooltip && label) {
-              tooltip = `${label} (${tooltip})`
+              tooltip = `${label} (${tooltip})`;
             } else if (label) {
               tooltip = label;
             }
@@ -505,7 +506,7 @@ export class MapRendererService {
         takeUntil(this._ngUnsubscribe),
         concatMap(async (source) => {
           this._map.removeLayer(this._mapLayer);
-          this._mapLayer = await ZsMapSources.get(source);
+          this._mapLayer = await this.mapSources.get(source);
           this._map.getLayers().insertAt(0, this._mapLayer);
         }),
       )
@@ -536,12 +537,12 @@ export class MapRendererService {
 
         // remove deleted layers
         for (const [key, layer] of Object.entries(this._layerCache)) {
-          if (layers.some(l => l.getId() === key)) {
+          if (layers.some((l) => l.getId() === key)) {
             continue;
           }
 
           this._map.removeLayer(layer.getOlLayer());
-          this._allLayers = this._allLayers.filter(olLayer => olLayer !== layer.getOlLayer());
+          this._allLayers = this._allLayers.filter((olLayer) => olLayer !== layer.getOlLayer());
           delete this._layerCache[key];
         }
       });

--- a/packages/app/src/app/sidebar/sidebar/sidebar.component.html
+++ b/packages/app/src/app/sidebar/sidebar/sidebar.component.html
@@ -275,6 +275,7 @@
                 <mat-icon class="wmsSourceError" [title]="geoAdminLayerError">warning</mat-icon>
               }
             </mat-option>
+            <mat-option value="_geodienste_">geodienste</mat-option>
             <mat-option value="_OwnMapLayers_">{{ i18n.get('ownMapLayers') }}</mat-option>
             <mat-option value="_GlobalMapLayers_">{{ i18n.get('globalMapLayers') }}</mat-option>
             <mat-option value="_ManagedMapLayers_">{{ i18n.get('managedMapLayers') }}</mat-option>

--- a/packages/app/src/app/sidebar/sidebar/sidebar.component.ts
+++ b/packages/app/src/app/sidebar/sidebar/sidebar.component.ts
@@ -32,6 +32,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { SidebarFiltersComponent } from '../sidebar-filters/sidebar-filters.component';
 import {
+  GeoAdminMapLayer,
   GeoJSONMapLayer,
   IZsMapOrganizationMapLayerSettings,
   MapLayer,
@@ -45,6 +46,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { SidebarDrawLayers } from '../sidebar-draw-layers/sidebar-draw-layers';
 import { DialogBodyComponent, DialogFooterComponent, DialogHeaderComponent } from '../../ui/dialog-layout';
 import { OfflineService } from '../../db/offline-service';
+import { GeodiensteService } from 'src/app/map-layer/geodienste/geodienste.service';
 
 @Component({
   selector: 'app-sidebar',
@@ -111,6 +113,11 @@ export class SidebarComponent implements OnDestroy {
     'undefined|ch.swisstopo.swisstlm3d-strassen',
     'undefined|ch.babs.kulturgueter',
     'undefined|ch.kantone.cadastralwebmap-farbe',
+    'geodienste|gefahrenkarten_v1_3_0',
+    'geodienste|naturereigniskataster_v1_0_0',
+    'geodienste|stromversorgungssicherheit_netzgebiete_v1_2_0',
+    'geodienste|waldreservate_v2_0_0',
+    'geodienste|wildruhezonen_v2_1_1',
   ];
 
   layerFilter = new FormControl('');
@@ -125,6 +132,7 @@ export class SidebarComponent implements OnDestroy {
   constructor() {
     const mapState = this.mapState;
     const geoAdminService = inject(GeoadminService);
+    const geodiensteService = inject(GeodiensteService);
     const wmsService = this.wmsService;
     const _session = this._session;
 
@@ -138,10 +146,11 @@ export class SidebarComponent implements OnDestroy {
       catchError((err) => {
         console.error('get geoAdminLayers failed with error', err);
         this.geoAdminLayerError = err.message;
-        return of([]);
+        return of([] as GeoAdminMapLayer[]);
       }),
       share(),
     );
+    const geodiensteLayers = geodiensteService.getLayers();
 
     function flatten<T>(arr: T[][]): T[] {
       return ([] as T[]).concat(...arr);
@@ -167,9 +176,9 @@ export class SidebarComponent implements OnDestroy {
 
     const globalMapLayers$ = mapState.observeGlobalMapLayers$();
 
-    this.allLayers$ = combineLatest([geoAdminLayers$, wmsLayers$, globalMapLayers$]).pipe(
-      map(([geo, wms, globalMapLayers]) => {
-        return [...geo, ...wms, ...globalMapLayers];
+    this.allLayers$ = combineLatest([geoAdminLayers$, geodiensteLayers, wmsLayers$, globalMapLayers$]).pipe(
+      map(([geo, geodienste, wms, globalMapLayers]) => {
+        return [...geo, ...geodienste, ...wms, ...globalMapLayers];
       }),
     );
 
@@ -195,6 +204,8 @@ export class SidebarComponent implements OnDestroy {
             layers = layers.filter((f) => f.id !== undefined && !f.owner && !f.managed);
           } else if (source === '_ManagedMapLayers_') {
             layers = layers.filter((f) => f.id !== undefined && f.managed);
+          } else if (source === '_geodienste_') {
+            layers = layers.filter((f) => f.fullId.startsWith('geodienste|'));
           } else {
             const sourceFilter = source === '_GeoAdmin_' ? undefined : source;
             layers = layers.filter((f) => f.source?.url === sourceFilter);

--- a/packages/app/src/app/state/i18n.service.ts
+++ b/packages/app/src/app/state/i18n.service.ts
@@ -2171,6 +2171,16 @@ export class I18NService {
       fr: 'Carte pixelisée en gris',
       en: 'Gray pixel map',
     },
+    geodiensteAV: {
+      de: 'geodienste Amtliche Vermessung farbig',
+      en: 'geodienste official measurement colored',
+      fr: 'geodienste Mensuration officielle en couleur',
+    },
+    geodiensteAVSituation: {
+      de: 'geodienste Amtliche Vermessung Situationsplan',
+      en: 'geodienste official measurement situation map',
+      fr: 'geodienste Mensuration officielle Plan de situation',
+    },
     noBaseMap: {
       de: 'keine Basiskarte',
       fr: 'pas de carte de base',

--- a/packages/app/src/app/state/i18n.service.ts
+++ b/packages/app/src/app/state/i18n.service.ts
@@ -2416,6 +2416,11 @@ export class I18NService {
       en: 'source URL',
       fr: 'URL source',
     },
+    geodiensteLayerId: {
+      de: 'Geodienste Ebenen Id',
+      en: 'Geodienste layer id',
+      fr: 'Id de couche geodienste',
+    },
     mapLayerType: {
       de: 'Ebenentyp',
       en: 'Layer type',

--- a/packages/app/src/app/state/map-sources.ts
+++ b/packages/app/src/app/state/map-sources.ts
@@ -1,4 +1,5 @@
-import { ZsMapStateSource, zsMapStateSourceToDownloadUrl } from '@zskarte/types';
+import { inject, Injectable } from '@angular/core';
+import { WMSMapLayer, ZsMapStateSource, zsMapStateSourceToDownloadUrl } from '@zskarte/types';
 import OlTileXYZ from 'ol/source/XYZ';
 import { PMTilesVectorSource } from 'ol-pmtiles';
 import OlTileLayer from '../map-renderer/utils';
@@ -8,15 +9,20 @@ import { stylefunction } from 'ol-mapbox-style';
 import { db } from '../db/db';
 import { BlobService } from '../db/blob.service';
 import { LOCAL_MAP_STYLE_PATH, LOCAL_MAP_STYLE_SOURCE } from '../session/default-map-values';
+import { WmsService } from '../map-layer/wms/wms.service';
 
-export const ZsMapSources = {
+@Injectable({
+  providedIn: 'root',
+})
+export class MapSourcesService {
+  private wmsService = inject(WmsService);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getOlTileLayer(source: any) {
     return new OlTileLayer({
       zIndex: 0,
       source,
     });
-  },
+  }
   async get(source: ZsMapStateSource): Promise<Layer> {
     switch (source) {
       case ZsMapStateSource.GEO_ADMIN_SWISS_IMAGE:
@@ -46,6 +52,40 @@ export const ZsMapSources = {
             crossOrigin: 'anonymous',
           }),
         );
+      case ZsMapStateSource.GEODIENSTE_AV:
+        return (
+          await this.wmsService.createWMSCustomLayer({
+            label: 'geodienste Amtliche Vermessung farbig',
+            opacity: 1,
+            serverLayerName: 'daten',
+            type: 'wms',
+            tileSize: 512,
+            source: {
+              url: 'https://geodienste.ch/db/avc_0/deu',
+              label: 'geodienste AV farbig',
+              type: 'wms',
+              attribution: [['geodienste', 'https://geodienste.ch/terms-of-use']],
+            },
+            fullId: 'https://geodienste.ch/db/avc_0/deu|daten',
+          } as WMSMapLayer)
+        )[0];
+      case ZsMapStateSource.GEODIENSTE_AV_SITUATION:
+        return (
+          await this.wmsService.createWMSCustomLayer({
+            label: 'geodienste Amtliche Vermessung Situationsplan',
+            opacity: 1,
+            serverLayerName: 'daten',
+            type: 'wms',
+            tileSize: 512,
+            source: {
+              url: 'https://geodienste.ch/db/av_situationsplan_0/deu',
+              label: 'geodienste AV grau',
+              type: 'wms',
+              attribution: [['geodienste', 'https://geodienste.ch/terms-of-use']],
+            },
+            fullId: 'https://geodienste.ch/db/av_situationsplan_0/deu|daten',
+          } as WMSMapLayer)
+        )[0];
       case ZsMapStateSource.LOCAL: {
         const downloadUrl = zsMapStateSourceToDownloadUrl[source];
         const mapMeta = await db.localMapInfo.get(source);
@@ -74,7 +114,9 @@ export const ZsMapSources = {
       case undefined:
         return this.getOlTileLayer(
           new OlTileXYZ({
-            attributions: ['© <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors'],
+            attributions: [
+              '© <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors',
+            ],
             url: 'https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png',
             maxZoom: 19,
             crossOrigin: 'anonymous',
@@ -84,12 +126,14 @@ export const ZsMapSources = {
         console.error(`Map source ${source} is not implemented`);
         return this.getOlTileLayer(
           new OlTileXYZ({
-            attributions: ['© <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors'],
+            attributions: [
+              '© <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors',
+            ],
             url: 'https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png',
             maxZoom: 19,
             crossOrigin: 'anonymous',
           }),
         );
     }
-  },
-};
+  }
+}

--- a/packages/app/src/app/state/map-sources.ts
+++ b/packages/app/src/app/state/map-sources.ts
@@ -10,12 +10,14 @@ import { db } from '../db/db';
 import { BlobService } from '../db/blob.service';
 import { LOCAL_MAP_STYLE_PATH, LOCAL_MAP_STYLE_SOURCE } from '../session/default-map-values';
 import { WmsService } from '../map-layer/wms/wms.service';
+import { GeodiensteService } from '../map-layer/geodienste/geodienste.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class MapSourcesService {
   private wmsService = inject(WmsService);
+  private geodiensteService = inject(GeodiensteService);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getOlTileLayer(source: any) {
     return new OlTileLayer({
@@ -52,40 +54,26 @@ export class MapSourcesService {
             crossOrigin: 'anonymous',
           }),
         );
-      case ZsMapStateSource.GEODIENSTE_AV:
-        return (
-          await this.wmsService.createWMSCustomLayer({
-            label: 'geodienste Amtliche Vermessung farbig',
-            opacity: 1,
-            serverLayerName: 'daten',
-            type: 'wms',
-            tileSize: 512,
-            source: {
-              url: 'https://geodienste.ch/db/avc_0/deu',
-              label: 'geodienste AV farbig',
-              type: 'wms',
-              attribution: [['geodienste', 'https://geodienste.ch/terms-of-use']],
-            },
-            fullId: 'https://geodienste.ch/db/avc_0/deu|daten',
-          } as WMSMapLayer)
-        )[0];
-      case ZsMapStateSource.GEODIENSTE_AV_SITUATION:
-        return (
-          await this.wmsService.createWMSCustomLayer({
-            label: 'geodienste Amtliche Vermessung Situationsplan',
-            opacity: 1,
-            serverLayerName: 'daten',
-            type: 'wms',
-            tileSize: 512,
-            source: {
-              url: 'https://geodienste.ch/db/av_situationsplan_0/deu',
-              label: 'geodienste AV grau',
-              type: 'wms',
-              attribution: [['geodienste', 'https://geodienste.ch/terms-of-use']],
-            },
-            fullId: 'https://geodienste.ch/db/av_situationsplan_0/deu|daten',
-          } as WMSMapLayer)
-        )[0];
+      case ZsMapStateSource.GEODIENSTE_AV: {
+        const layerConfig = await this.geodiensteService.getLayer('avc_0', 1);
+        if (layerConfig) {
+          return (await this.wmsService.createWMSCustomLayer(layerConfig))[0];
+        } else {
+          return new OlTileLayer({
+            zIndex: 0,
+          });
+        }
+      }
+      case ZsMapStateSource.GEODIENSTE_AV_SITUATION: {
+        const layerConfig = await this.geodiensteService.getLayer('av_situationsplan_0', 1);
+        if (layerConfig) {
+          return (await this.wmsService.createWMSCustomLayer(layerConfig))[0];
+        } else {
+          return new OlTileLayer({
+            zIndex: 0,
+          });
+        }
+      }
       case ZsMapStateSource.LOCAL: {
         const downloadUrl = zsMapStateSourceToDownloadUrl[source];
         const mapMeta = await db.localMapInfo.get(source);

--- a/packages/types/map-layer/interfaces.ts
+++ b/packages/types/map-layer/interfaces.ts
@@ -78,6 +78,8 @@ export interface WMSMapLayer extends MapLayer, GenericOptionalMapLayerOptions {
   originalServerLayerName?: string;
   tileSize?: number;
   tileFormat?: string;
+  gutter?: number;
+  geodiensteSourceLayerId?: string;
 }
 
 export interface GeoJSONMapLayer extends MapLayer, GenericOptionalMapLayerOptions {

--- a/packages/types/state/interfaces.ts
+++ b/packages/types/state/interfaces.ts
@@ -11,6 +11,8 @@ export enum ZsMapStateSource {
   GEO_ADMIN_SWISS_IMAGE = 'geoAdminSwissImage',
   GEO_ADMIN_PIXEL = 'geoAdminPixel',
   GEO_ADMIN_PIXEL_BW = 'geoAdminPixelBW',
+  GEODIENSTE_AV = 'geodiensteAV',
+  GEODIENSTE_AV_SITUATION = 'geodiensteAVSituation',
   LOCAL = 'local',
   NONE = 'noBaseMap',
 }


### PR DESCRIPTION
fixed #63 
Added 2 variants as base layer, perhaps we need to rename/shorten the layer name in i18n for the basemap?
<img width="932" height="672" alt="grafik" src="https://github.com/user-attachments/assets/533d808a-bd86-44a0-890d-b3c89799ba9a" />


added the others as favorites and also in the avail layers. (this names are directly taken from geodienste WMS config)
<img width="948" height="586" alt="grafik" src="https://github.com/user-attachments/assets/f6918fcc-10ed-41bc-a83b-e307fd2f3a4f" />

add special handling for the geodienste layers also on the expert view / layer options.

The general problem with WMS services are the images are generated on the fly, which may result in artefacts/cutted words:
<img width="280" height="214" alt="grafik" src="https://github.com/user-attachments/assets/d973f1c2-b6d6-4f5b-be27-42f64946a467" />
I try to work against that by increasing the default downloaded tilesize and the gutter, but increasing it also result in more image data are downloaded and not used.