### PR TITLE
Increase the memory limit to 4GB for map layer generation spikes.

### DIFF
--- a/.azure/k8s/deployment.yml
+++ b/.azure/k8s/deployment.yml
@@ -133,4 +133,4 @@ spec:
               memory: 256Mi
             limits:
               cpu: 1000m
-              memory: 2Gi
+              memory: 4Gi


### PR DESCRIPTION
Increase the memory limit to 4GB for map layer generation spikes.