### PR TITLE
Migrate ZS Karte TEST to PostgreSQL 18

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -10,11 +10,11 @@ env:
   APP_NAME: zskarte-server
   FULL_IMAGE_NAME: zskarte/zskarte-server:${{ github.sha }}
   LETSENCRYPT_STAGE: prod
-  DB_HOST: postgresql.postgresql.svc.cluster.local
+  DB_HOST: db.db.svc.cluster.local
   DB_PORT: 5432
   DB_NAME: zskarte-test
-  DB_USER: zskarte
-  DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+  DB_USER: zskarte_test
+  DB_PASSWORD: ${{ secrets.DB_PASSWORD_PG18_TEST }}
   ADMIN_JWT_SECRET: ${{ secrets.STRAPI_ADMIN_JWT_SECRET_DEV }}
   JWT_SECRET: ${{ secrets.STRAPI_JWT_SECRET_DEV }}
   APP_KEYS: ${{ secrets.STRAPI_APP_KEYS_DEV }}
@@ -63,6 +63,28 @@ jobs:
         env:
           IMAGE_TAG: ${{ github.sha }}
           CHANGE_CAUSE: ${{ github.event.release.tag_name }}
+
+      - name: Verify Server Deployment
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          kubectl \
+            --namespace "$KUBERNETES_NAMESPACE" \
+            rollout status "deployment/$APP_NAME" \
+            --timeout=240s
+
+          curl \
+            --fail \
+            --silent \
+            --show-error \
+            --location \
+            --retry 12 \
+            --retry-all-errors \
+            --retry-delay 5 \
+            --max-time 15 \
+            "https://$BASE_URL/" \
+            --output /dev/null
 
   build-and-deploy-app:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -13,8 +13,8 @@ env:
   DB_HOST: db.db.svc.cluster.local
   DB_PORT: 5432
   DB_NAME: zskarte-test
-  DB_USER: zskarte_test
-  DB_PASSWORD: ${{ secrets.DB_PASSWORD_PG18_TEST }}
+  DB_USER: zskarte
+  DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
   ADMIN_JWT_SECRET: ${{ secrets.STRAPI_ADMIN_JWT_SECRET_DEV }}
   JWT_SECRET: ${{ secrets.STRAPI_JWT_SECRET_DEV }}
   APP_KEYS: ${{ secrets.STRAPI_APP_KEYS_DEV }}


### PR DESCRIPTION
## Summary

- point the ZS Karte TEST backend at the PostgreSQL 18 service
- retain the existing shared database user `zskarte` and existing GitHub Actions secret `DB_PASSWORD`
- verify the Kubernetes backend rollout and public API endpoint during deployment

## Target database credentials

- PostgreSQL 18 role: `zskarte`
- TEST database: `zskarte-test`
- PROD database: `zskarte`
- both PostgreSQL 18 connection secrets use the same password already deployed through `DB_PASSWORD`
- the PostgreSQL 18 TEST database and `public` schema are owned by `zskarte`

## Migration validation

- PostgreSQL 16 recovery dump verified with `pg_restore --list` and SHA-256
- restore rehearsal completed in an isolated PostgreSQL 18 database
- exact row counts matched across all 58 public tables
- the current Strapi production image started successfully against the restored PostgreSQL 18 rehearsal database and completed its application migrations
- server build and server lint pass locally

This PR targets `dev`, the default and TEST deployment branch. Its merge is coordinated with a fresh final TEST dump and restore and triggers the TEST deployment.