### PR TITLE
Persist ZS Karte PROD PostgreSQL 18 host

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -10,7 +10,7 @@ env:
   APP_NAME: zskarte-server
   IMAGE_TAG: zskarte/zskarte-server
   LETSENCRYPT_STAGE: prod
-  DB_HOST: postgresql.postgresql.svc.cluster.local
+  DB_HOST: db.db.svc.cluster.local
   DB_PORT: 5432
   DB_NAME: zskarte
   DB_USER: zskarte


### PR DESCRIPTION
## Summary

- persist the already completed live PROD cutover by changing only the PostgreSQL service host in `deploy-main.yml`
- retain the existing `zskarte` user, `DB_PASSWORD` secret, database name and current release flow

## Scope safety

- branch created directly from `origin/main`
- exactly one file changed with one replacement
- no commits or application changes from `dev` are included

## Live validation

- fresh stopped-source dump restored to PostgreSQL 18
- exact counts matched for 58 tables, 58,029 rows and 58 sequences
- current PROD image `v6.0.3` is running unchanged
- API returns HTTP 200 and browser login loads without errors
- PostgreSQL 16 has zero ZS Karte sessions; PostgreSQL 18 is active
- PGBackWeb tests both `zskarte` and `zskarte-test` successfully on PostgreSQL 18

Merging this PR does not deploy by itself; the PROD workflow runs only for a published release. It prevents a future release from switching PROD back to PostgreSQL 16.