### PR TITLE
Fix backend workspace packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,10 @@ USER node
 EXPOSE 1337
 
 COPY --from=build --chown=node:node /app/node_modules /app/node_modules
+COPY --from=build --chown=node:node /app/packages/common /app/packages/common
 COPY --from=build --chown=node:node /app/packages/server /app/packages/server
+COPY --from=build --chown=node:node /app/packages/types /app/packages/types
 COPY --from=build --chown=node:node /app/package.json /app/package.json
 
 # start command
-CMD ["npm", "run", "start:server:prod"] 
+CMD ["npm", "run", "start:server:prod"]

--- a/packages/app/tests/journal.spec.ts
+++ b/packages/app/tests/journal.spec.ts
@@ -63,12 +63,12 @@ test.describe('Journal', () => {
   });
 
   test('should add journal entry', async ({ page }) => {
-    const id = random(1, 99).toString();
+    const id = random(1000, 999999).toString();
     await createJournalEntry({ reportId: id }, page);
     
     const rows = page.locator('tbody').getByRole('row');
     const rowCount = await rows.count();
-    const firstRow = rows.first();
+    const firstRow = rows.filter({ has: page.getByRole('cell', { name: id, exact: true }) }).first();
     await expect(firstRow.getByRole('cell').first()).toHaveText(id);
     await expect(firstRow.getByRole('cell').nth(1)).toHaveText('Betreff');
     await expect(firstRow.getByRole('cell').nth(2)).toHaveText('Inhalt');


### PR DESCRIPTION
## Summary

- Include the built common and types workspace packages in the backend release image.
- Restore runtime module resolution for the production server.
- Stabilize the journal E2E assertion against existing sorted test data.

## Verification

- Built the complete Docker release image locally.
- Loaded both workspace packages from their compiled dist directories in the final image.
- Started Strapi with NODE_ENV=production against an isolated PostgreSQL instance.
- Verified /_health returns HTTP 204.
- Ran the complete Playwright E2E suite: 9 tests passed.