### PR TITLE
changeset optimisations

### DIFF
--- a/packages/app/src/app/changeset/changeset.service.ts
+++ b/packages/app/src/app/changeset/changeset.service.ts
@@ -619,7 +619,7 @@ export class ChangesetService {
         }
       }
 
-      if (changeset.changedDrawElements.some((elemId) => !modifiedDrawElements.has(elemId))) {
+      if (Array.from(modifiedDrawElements).some(elemId => !changeset.changedDrawElements.includes(elemId))) {
         //new drawElement is changed
         const timestamp = new Date().getTime();
         if (


### PR DESCRIPTION
Fix incorrect submit while editing same element in multi element changeset after _createMultiElementChangesetDelta timeout.

TODO:
- prevent any flickering while (prepare) to submit changeset.