### PR TITLE
Mittelübersicht — a resource (Mittel) catalogue for an operation, from CSV import through to tracking what is deployed where on the map.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,12 @@ scripts/offlineData/swissNAMES3D/canton_layer_mapping.env
 !packages/app/src/app/resource/testing/*.csv
 
 ############################
+# shipped assets (exempt from the *.csv rule above)
+############################
+
+!packages/app/src/assets/doc/resource/*.csv
+
+############################
 # local db backups (see DEVELOPER_GUIDE.md "update init.sql")
 ############################
 

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,16 @@ scripts/offlineData/swissNAMES3D/swissboundaries3d_*.zip
 scripts/offlineData/swissNAMES3D/swissBOUNDARIES3D_*
 scripts/offlineData/swissNAMES3D/swissNAMES3D_PLY*.csv
 scripts/offlineData/swissNAMES3D/canton_layer_mapping.env
+
+############################
+# test fixtures (exempt from the *.csv rule above)
+############################
+
+!packages/app/tests/fixtures/*.csv
+!packages/app/src/app/resource/testing/*.csv
+
+############################
+# local db backups (see DEVELOPER_GUIDE.md "update init.sql")
+############################
+
+data_backup*

--- a/packages/app/src/app/app-factory.ts
+++ b/packages/app/src/app/app-factory.ts
@@ -9,6 +9,7 @@ import { SearchService } from './search/search.service';
 import { OperationService } from './session/operations/operation.service';
 import { ChangesetService } from './changeset/changeset.service';
 import { SidebarService } from './sidebar/sidebar.service';
+import { ResourceService } from './resource/resource.service';
 
 registerLocaleData(localeCH);
 
@@ -22,6 +23,7 @@ export function appFactory(
   operation: OperationService,
   changeset: ChangesetService,
   sidebar: SidebarService,
+  resource: ResourceService,
 ) {
   return async () => {
     // "inject" services to prevent circular dependencies
@@ -34,6 +36,7 @@ export function appFactory(
     changeset.setStateService(state);
     changeset.setSidebarService(sidebar);
     changeset.setSessionService(session);
+    resource.setStateService(state);
 
     if (!window.location.pathname.startsWith('/share/')) {
       await session.loadSavedSession();

--- a/packages/app/src/app/changeset/changeset.service.ts
+++ b/packages/app/src/app/changeset/changeset.service.ts
@@ -1087,7 +1087,12 @@ export class ChangesetService {
           .filter((k) => k.startsWith(path))
           .forEach((k) => delete changes[k]);
         changes[path] = null;
-      } else if (typeof value === 'object' && !path.endsWith('coordinates') && !path.endsWith('reportNumber')) {
+      } else if (
+        typeof value === 'object' &&
+        !path.endsWith('coordinates') &&
+        !path.endsWith('reportNumber') &&
+        !path.endsWith('resourceItems')
+      ) {
         Object.entries(value).forEach(([key, val]) => {
           updateValue(changes, op, path ? `${path}.${key}` : key, val);
         });

--- a/packages/app/src/app/db/db.ts
+++ b/packages/app/src/app/db/db.ts
@@ -9,6 +9,7 @@ import {
   IZsMapOperation,
   WmsSource,
   IZsChangesetInternal,
+  ResourceArticleApi,
 } from '@zskarte/types';
 import { JournalEntry } from '../journal/journal.types';
 
@@ -59,6 +60,8 @@ export type PatchJournalEntry = {
 
 export type LocalJournalEntry = JournalEntry & { operationId: string; organizationId: string; fromCache: boolean };
 
+export type LocalResourceArticle = ResourceArticleApi & { operationId: string; organizationId: string; fromCache: boolean };
+
 export class AppDB extends Dexie {
   sessions!: Table<IZsMapSession, string>;
   displayStates!: Table<IZsMapDisplayState, string>;
@@ -72,6 +75,7 @@ export class AppDB extends Dexie {
   localMapLayerSettings!: Table<LocalMapLayerSettings, string>;
   patchJournalEntries!: Table<PatchJournalEntry, number>;
   localJournalEntries!: Table<LocalJournalEntry, string>;
+  localResourceArticles!: Table<LocalResourceArticle, string>;
 
   constructor(databaseName: string) {
     super(databaseName);
@@ -160,6 +164,14 @@ export class AppDB extends Dexie {
     this.version(10).stores({
       patchSyncQueue: null,
       changesetOutgoingQueue: 'id, operationId',
+    });
+    this.version(11).stores({
+      localResourceArticles: '[operationId+articleNumber], operationId, organizationId, importId',
+    });
+    //the catalogue is always read/replaced per operation+organization, so index that pair
+    this.version(12).stores({
+      localResourceArticles:
+        '[operationId+articleNumber], [operationId+organizationId], operationId, organizationId, importId',
     });
   }
 }

--- a/packages/app/src/app/floating-ui/floating-ui.component.html
+++ b/packages/app/src/app/floating-ui/floating-ui.component.html
@@ -15,9 +15,10 @@
           </button>
         }
       </div>
-      <app-changeset-overlay/>
+      <app-changeset-overlay />
     </div>
     <app-journal-draw-overlay [ngClass]="{ 'sidebar-open': sidebar.observeIsOpen() | async }" />
+    <app-resource-placement-overlay [ngClass]="{ 'sidebar-open': sidebar.observeIsOpen() | async }" />
     <app-coordinates [ngClass]="{ 'sidebar-open': sidebar.observeIsOpen() | async }" />
   </div>
   <div class="action-buttons noprint" [ngClass]="{ 'sidebar-open': sidebar.observeIsOpen() | async }">
@@ -46,9 +47,7 @@
             @if (isOnline | async) {
               <mat-icon matBadgeColor="warn" matBadge="!" aria-hidden="false">network_wifi</mat-icon>
             } @else {
-              <mat-icon matBadgeColor="warn" matBadge="!" aria-hidden="false"
-                >signal_wifi_off</mat-icon
-              >
+              <mat-icon matBadgeColor="warn" matBadge="!" aria-hidden="false">signal_wifi_off</mat-icon>
             }
           }
         } @else {

--- a/packages/app/src/app/floating-ui/floating-ui.component.scss
+++ b/packages/app/src/app/floating-ui/floating-ui.component.scss
@@ -45,7 +45,7 @@
   align-self: flex-start;
   justify-content: space-between;
   container: floating-ui-top-row / inline-size;
-    
+
   &.sidebar-open {
     width: calc(100% - var(--sidebar-width));
   }
@@ -143,6 +143,14 @@ app-journal-draw-overlay {
   z-index: 1;
 }
 
+app-resource-placement-overlay {
+  position: fixed;
+  bottom: 5rem;
+  left: 1.25rem;
+  width: 400px;
+  z-index: 1;
+}
+
 app-coordinates {
   position: absolute;
   bottom: 1.25rem;
@@ -175,6 +183,11 @@ app-geocoder {
     bottom: 8.5rem;
     width: calc(100vw - 1.25rem - 80px);
   }
+
+  app-resource-placement-overlay {
+    bottom: 8.5rem;
+    width: calc(100vw - 1.25rem - 80px);
+  }
 }
 
 @media (max-width: 800px) {
@@ -185,6 +198,9 @@ app-geocoder {
 
 :host-context(.journal-address-preview) {
   app-journal-draw-overlay {
+    display: none;
+  }
+  app-resource-placement-overlay {
     display: none;
   }
   app-coordinates {

--- a/packages/app/src/app/floating-ui/floating-ui.component.ts
+++ b/packages/app/src/app/floating-ui/floating-ui.component.ts
@@ -23,6 +23,7 @@ import { MAX_DRAW_ELEMENTS_GUEST } from '../session/default-map-values';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { GuestLimitDialogComponent } from '../guest-limit-dialog/guest-limit-dialog.component';
 import { JournalDrawOverlayComponent } from '../journal-draw-overlay/journal-draw-overlay.component';
+import { ResourcePlacementOverlayComponent } from '../resource/placement/resource-placement-overlay.component';
 import { SearchService } from '../search/search.service';
 import { CompassButtonComponent } from '../compass-button/compass-button.component';
 import { JournalService } from '../journal/journal.service';
@@ -41,6 +42,7 @@ import { ChangesetOverlayComponent } from '../changeset/changeset-overlay/change
     GeocoderComponent,
     CoordinatesComponent,
     JournalDrawOverlayComponent,
+    ResourcePlacementOverlayComponent,
     ChangesetOverlayComponent,
     CommonModule,
     CompassButtonComponent,

--- a/packages/app/src/app/map-renderer/draw-style.ts
+++ b/packages/app/src/app/map-renderer/draw-style.ts
@@ -44,6 +44,9 @@ export class DrawStyle {
     } else if (signature.id === Signs.FORMATION_SIGN_ID) {
       // The formation sign is generated on the fly
       return DrawStyle.getFormationSvg(signature);
+    } else if (signature.id === Signs.RESOURCE_PLACEHOLDER_SIGN_ID) {
+      // The resource sign is generated on the fly
+      return DrawStyle.getResourceSvg(signature);
     } else if (Signs.TRANSPORT_SIGN_IDS.includes(signature.id ?? 0)) {
       // The transport sign is generated on the fly
       return DrawStyle.getTransportSvg(signature);
@@ -333,6 +336,15 @@ export class DrawStyle {
     return 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
   }
 
+  private static escapeXml(value: string): string {
+    return value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&apos;');
+  }
+
   public static getHazardSignSvg(signature: Sign): string {
     const color = '#FF9100';
     const hazardCode = signature.hazardCode ?? '';
@@ -408,10 +420,10 @@ export class DrawStyle {
   <path d="${bodyPath}" fill="white" stroke="${color}" stroke-width="7"/>
   
   <!-- Organization text in body -->
-  <text x="${padding + 78}" y="${55 + padding}" fill="${color}" font-family="Arial" font-weight="700" font-size="${orgFontSize}" text-anchor="middle">${organization}</text>
-  
+  <text x="${padding + 78}" y="${55 + padding}" fill="${color}" font-family="Arial" font-weight="700" font-size="${orgFontSize}" text-anchor="middle">${DrawStyle.escapeXml(organization)}</text>
+
   <!-- Formation detail text above body -->
-  <text x="${padding + 78}" y="${padding - 5}" fill="${color}" font-family="Arial" font-weight="600" font-size="22" text-anchor="middle">${formationDetail}</text>
+  <text x="${padding + 78}" y="${padding - 5}" fill="${color}" font-family="Arial" font-weight="600" font-size="22" text-anchor="middle">${DrawStyle.escapeXml(formationDetail)}</text>
   
   <!-- Wheels -->
   ${wheelsHtml}
@@ -473,7 +485,7 @@ export class DrawStyle {
   <circle cx="${centerX}" cy="${circleY}" r="${circleRadius}" fill="white" stroke="${color}" stroke-width="9"/>
   
   <!-- Organization text inside circle -->
-  <text x="${centerX}" y="${circleY + 8}" fill="${color}" font-family="Arial" font-weight="700" font-size="${orgFontSize}" text-anchor="middle">${organization}</text>
+  <text x="${centerX}" y="${circleY + 8}" fill="${color}" font-family="Arial" font-weight="700" font-size="${orgFontSize}" text-anchor="middle">${DrawStyle.escapeXml(organization)}</text>
 </svg>`.trim();
 
     return this.asDataImageSvg(svg);
@@ -543,12 +555,12 @@ export class DrawStyle {
       const bottomY2 = 170 + padding;
       if (formationNumber && formationLocation) {
         bottomText = `
-          <text x="${circleCenter}" y="${bottomY1}" fill="${color}" font-family="Arial" font-weight="600" font-size="22" text-anchor="middle">${formationNumber}</text>
-          <text x="${circleCenter}" y="${bottomY2}" fill="${color}" font-family="Arial" font-weight="600" font-size="22" text-anchor="middle">${formationLocation}</text>`;
+          <text x="${circleCenter}" y="${bottomY1}" fill="${color}" font-family="Arial" font-weight="600" font-size="22" text-anchor="middle">${DrawStyle.escapeXml(formationNumber)}</text>
+          <text x="${circleCenter}" y="${bottomY2}" fill="${color}" font-family="Arial" font-weight="600" font-size="22" text-anchor="middle">${DrawStyle.escapeXml(formationLocation)}</text>`;
       } else if (formationNumber) {
-        bottomText = `<text x="${circleCenter}" y="${bottomY1}" fill="${color}" font-family="Arial" font-weight="600" font-size="22" text-anchor="middle">${formationNumber}</text>`;
+        bottomText = `<text x="${circleCenter}" y="${bottomY1}" fill="${color}" font-family="Arial" font-weight="600" font-size="22" text-anchor="middle">${DrawStyle.escapeXml(formationNumber)}</text>`;
       } else {
-        bottomText = `<text x="${circleCenter}" y="${bottomY1}" fill="${color}" font-family="Arial" font-weight="600" font-size="22" text-anchor="middle">${formationLocation}</text>`;
+        bottomText = `<text x="${circleCenter}" y="${bottomY1}" fill="${color}" font-family="Arial" font-weight="600" font-size="22" text-anchor="middle">${DrawStyle.escapeXml(formationLocation)}</text>`;
       }
     }
 
@@ -561,16 +573,65 @@ export class DrawStyle {
   <circle cx="${circleCenter}" cy="${78 + padding}" r="40" fill="white" stroke="${color}" stroke-width="8"/>
   
   <!-- Organization text inside circle -->
-  <text x="${circleCenter}" y="${85 + padding}" fill="${color}" font-family="Arial" font-weight="700" font-size="${orgFontSize}" text-anchor="middle">${organization}</text>
-  
+  <text x="${circleCenter}" y="${85 + padding}" fill="${color}" font-family="Arial" font-weight="700" font-size="${orgFontSize}" text-anchor="middle">${DrawStyle.escapeXml(organization)}</text>
+
   <!-- Left text (formation detail) -->
-  <text x="${25 + padding}" y="${85 + padding}" fill="${color}" font-family="Arial" font-weight="600" font-size="22" text-anchor="end">${formationDetail}</text>
-  
+  <text x="${25 + padding}" y="${85 + padding}" fill="${color}" font-family="Arial" font-weight="600" font-size="22" text-anchor="end">${DrawStyle.escapeXml(formationDetail)}</text>
+
   <!-- Right text (additional info) -->
-  <text x="${131 + padding}" y="${85 + padding}" fill="${color}" font-family="Arial" font-weight="600" font-size="22" text-anchor="start">${additionalInfo}</text>
+  <text x="${131 + padding}" y="${85 + padding}" fill="${color}" font-family="Arial" font-weight="600" font-size="22" text-anchor="start">${DrawStyle.escapeXml(additionalInfo)}</text>
   
   <!-- Bottom text -->
   ${bottomText}
+</svg>`.trim();
+
+    return this.asDataImageSvg(svg);
+  }
+
+  private static truncateForSvg(value: string, maxLength = 16): string {
+    return value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
+  }
+
+  public static getResourceSvg(signature: Sign): string {
+    const color = signature.color ?? '#0000FF';
+    const resourceItems = signature.resourceItems ?? [];
+
+    // Use larger viewBox with padding to prevent clipping
+    const padding = 20;
+    const boxWidth = 156;
+    const boxHeight = 100;
+    const viewBoxWidth = boxWidth + padding * 2;
+    const viewBoxHeight = boxHeight + padding * 2;
+    const centerX = viewBoxWidth / 2;
+
+    const distinctArticleNumbers = new Set(resourceItems.map((item) => item.articleNumber));
+    const totalQuantity = resourceItems.reduce((sum, item) => sum + item.quantity, 0);
+
+    let titleLine: string;
+    let quantityLine = '';
+    if (distinctArticleNumbers.size <= 1) {
+      const articleName = resourceItems[0]?.name ?? signature.label ?? '';
+      titleLine = DrawStyle.truncateForSvg(articleName);
+      if (totalQuantity > 1) {
+        quantityLine = `×${totalQuantity}`;
+      }
+    } else {
+      titleLine = DrawStyle.truncateForSvg(signature.label || 'Mittel');
+      quantityLine = `${distinctArticleNumbers.size} Artikel`;
+    }
+
+    const titleY = quantityLine ? viewBoxHeight / 2 - 6 : viewBoxHeight / 2 + 7;
+
+    const svg = `
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${viewBoxWidth} ${viewBoxHeight}" width="${viewBoxWidth}px" height="${viewBoxHeight}px">
+  <!-- Rounded resource box -->
+  <rect x="${padding}" y="${padding}" width="${boxWidth}" height="${boxHeight}" rx="14" ry="14" fill="white" stroke="${color}" stroke-width="7"/>
+
+  <!-- Article name -->
+  <text x="${centerX}" y="${titleY}" fill="${color}" font-family="Arial" font-weight="700" font-size="22" text-anchor="middle">${DrawStyle.escapeXml(titleLine)}</text>
+
+  <!-- Quantity / article count -->
+  ${quantityLine ? `<text x="${centerX}" y="${viewBoxHeight / 2 + 20}" fill="${color}" font-family="Arial" font-weight="600" font-size="20" text-anchor="middle">${DrawStyle.escapeXml(quantityLine)}</text>` : ''}
 </svg>`.trim();
 
     return this.asDataImageSvg(svg);
@@ -613,6 +674,7 @@ export class DrawStyle {
         additionalInfo: signature.additionalInfo,
         formationNumber: signature.formationNumber,
         formationLocation: signature.formationLocation,
+        resourceItems: signature.resourceItems,
       }),
     ).toString();
   }

--- a/packages/app/src/app/map-renderer/elements/base/base-draw-element.ts
+++ b/packages/app/src/app/map-renderer/elements/base/base-draw-element.ts
@@ -79,6 +79,7 @@ export abstract class ZsMapBaseDrawElement<
       additionalInfo: state.additionalInfo,
       formationNumber: state.formationNumber,
       formationLocation: state.formationLocation,
+      resourceItems: state.resourceItems,
     });
   }
 

--- a/packages/app/src/app/map-renderer/signs.ts
+++ b/packages/app/src/app/map-renderer/signs.ts
@@ -3,6 +3,7 @@ import { Sign } from '@zskarte/types';
 export class Signs {
   public static HAZARD_SIGN_ID = 57;
   public static FORMATION_SIGN_ID = 210;
+  public static RESOURCE_PLACEHOLDER_SIGN_ID = 211;
   public static TRUCK_SIGN_ID = 190;
   public static MOTOR_VEHICLE_SIGN_ID = 192;
   public static TRANSPORT_VEHICLE_SIGN_ID = 201;
@@ -1994,6 +1995,16 @@ export class Signs {
       de: 'Formation (Trupp, Gruppe, Zug, Kompanie, Bataillon)',
       en: 'Formation (Squad, Group, Platoon, Company, Battalion)',
       fr: 'Formation (Équipe, Groupe, Section, Compagnie, Bataillon)',
+    },
+    {
+      id: Signs.RESOURCE_PLACEHOLDER_SIGN_ID,
+      kat: 'action',
+      type: 'Point',
+      color: '#0000FF',
+      src: 'resource-placeholder.svg',
+      de: 'Mittel (aus Mittelübersicht)',
+      en: 'Resource (from resource overview)',
+      fr: 'Moyen (aperçu des ressources)',
     },
   ];
 

--- a/packages/app/src/app/resource-overview/resource-overview.component.html
+++ b/packages/app/src/app/resource-overview/resource-overview.component.html
@@ -1,61 +1,65 @@
 <app-dialog-header>
-  <h2>{{ i18n.get('resourceOverview') }}</h2>
+  <div class="header-content">
+    <div class="header-row">
+      <h2>{{ i18n.get('resourceOverview') }}</h2>
+      <div class="header-meta">
+        @if (resourceService.importMeta(); as meta) {
+          <span class="meta-info"
+            >{{ i18n.get('resourceLastImport') }} {{ meta.importedAt | date: 'dd.MM.yyyy HH:mm' }}</span
+          >
+        }
+        @if (resourceService.cachedOnly()) {
+          <span class="chip">{{ i18n.get('resourceCachedOnly') }}</span>
+        }
+        @if (canImport) {
+          <button
+            mat-stroked-button
+            [disabled]="!isOnline()"
+            [matTooltip]="!isOnline() ? i18n.get('resourceImportOnlineOnly') : ''"
+            (click)="openImportDialog()"
+          >
+            <mat-icon>upload_file</mat-icon>
+            {{ i18n.get('resourceImportCsv') }}
+          </button>
+          @if (hasCatalogue) {
+            <button
+              mat-stroked-button
+              [disabled]="!isOnline()"
+              [matTooltip]="!isOnline() ? i18n.get('resourceImportOnlineOnly') : ''"
+              (click)="clearCatalogue()"
+            >
+              <mat-icon>delete_sweep</mat-icon>
+              {{ i18n.get('resourceClear') }}
+            </button>
+          }
+        }
+      </div>
+    </div>
+    <p class="header-hint">
+      {{ i18n.get('resourceOverviewIntro') }}
+      <a
+        class="example-csv"
+        [href]="exampleCsvUrl"
+        [attr.download]="exampleCsvFileName"
+        [matTooltip]="i18n.get('resourceExampleCsvHint')"
+      >
+        <mat-icon>download</mat-icon>
+        {{ i18n.get('resourceExampleCsv') }}
+      </a>
+    </p>
+  </div>
 </app-dialog-header>
 
-<app-dialog-body>  
-  <mat-card>
-  @if (resources$ | async; as resources) {
-    @if (resources.length > 0) {
-      <table mat-table [dataSource]="resources" class="resource-table">
-        <!-- Organization Column -->
-        <ng-container matColumnDef="organization">
-          <th mat-header-cell *matHeaderCellDef>{{ i18n.get('organization') }}</th>
-          <td mat-cell *matCellDef="let row">{{ row.organization }}</td>
-        </ng-container>
-
-        <!-- Formation Location Column -->
-        <ng-container matColumnDef="formationLocation">
-          <th mat-header-cell *matHeaderCellDef>{{ i18n.get('formationLocation') }}</th>
-          <td mat-cell *matCellDef="let row">{{ row.formationLocation }}</td>
-        </ng-container>
-
-        <!-- Hierarchy Level Column -->
-        <ng-container matColumnDef="hierarchyLevel">
-          <th mat-header-cell *matHeaderCellDef>{{ i18n.get('hierarchyLevel') }}</th>
-          <td mat-cell *matCellDef="let row">{{ row.hierarchyLevel }}</td>
-        </ng-container>
-
-        <!-- Formation Number Column -->
-        <ng-container matColumnDef="formationNumber">
-          <th mat-header-cell *matHeaderCellDef>{{ i18n.get('formationNumber') }}</th>
-          <td mat-cell *matCellDef="let row">{{ row.formationNumber }}</td>
-        </ng-container>
-
-        <!-- Formation Detail Column -->
-        <ng-container matColumnDef="formationDetail">
-          <th mat-header-cell *matHeaderCellDef>{{ i18n.get('formationDetail') }}</th>
-          <td mat-cell *matCellDef="let row">{{ row.formationDetail }}</td>
-        </ng-container>
-
-        <!-- Additional Info Column -->
-        <ng-container matColumnDef="additionalInfo">
-          <th mat-header-cell *matHeaderCellDef>{{ i18n.get('additionalInfo') }}</th>
-          <td mat-cell *matCellDef="let row">{{ row.additionalInfo }}</td>
-        </ng-container>
-
-        <!-- Location Column -->
-        <ng-container matColumnDef="location">
-          <th mat-header-cell *matHeaderCellDef>{{ i18n.get('csvLocation') }}</th>
-          <td mat-cell *matCellDef="let row" class="location" (click)="navigateTo(row)">{{ row.location }}</td>
-        </ng-container>
-
-        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-        <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-      </table>
-    } @else {
-      <p class="no-resources">{{ i18n.get('noResources') }}</p>
-    }
-  }
-  </mat-card>
+<app-dialog-body>
+  <mat-tab-group animationDuration="0ms">
+    <mat-tab [label]="i18n.get('resourceTabCatalogue')">
+      <app-resource-catalogue />
+    </mat-tab>
+    <mat-tab [label]="i18n.get('resourceTabDeployed')">
+      <app-resource-deployed />
+    </mat-tab>
+    <mat-tab [label]="i18n.get('resourceTabFormations')">
+      <app-resource-formation-table />
+    </mat-tab>
+  </mat-tab-group>
 </app-dialog-body>
-

--- a/packages/app/src/app/resource-overview/resource-overview.component.scss
+++ b/packages/app/src/app/resource-overview/resource-overview.component.scss
@@ -1,7 +1,76 @@
-mat-card {
-    width: fit-content;
+:host {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
-.location {
-  cursor: pointer;
+.header-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex: 1;
+}
+
+.header-hint {
+  margin: 0;
+  color: #666;
+  font-size: 0.8rem;
+  line-height: 1.35;
+  max-width: 90ch;
+}
+
+// Inline with the sentence it belongs to, so the download reads as part of the explanation.
+.example-csv {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  margin-left: 0.35rem;
+  color: #1a56db;
+  text-decoration: underline;
+  white-space: nowrap;
+
+  mat-icon {
+    font-size: 1rem;
+    width: 1rem;
+    height: 1rem;
+  }
+}
+
+.header-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+}
+
+.meta-info {
+  color: #666;
+}
+
+.chip {
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  background: #fff4e5;
+  color: #7a4a00;
+  font-size: 0.75rem;
+  white-space: nowrap;
+}
+
+app-dialog-body {
+  display: block;
+  flex: 1;
+  overflow: hidden;
+}
+
+mat-tab-group {
+  height: 100%;
 }

--- a/packages/app/src/app/resource-overview/resource-overview.component.ts
+++ b/packages/app/src/app/resource-overview/resource-overview.component.ts
@@ -1,101 +1,102 @@
-import { Component, DestroyRef, inject } from '@angular/core';
-import { ZsMapStateService } from '../state/state.service';
-import { I18NService } from '../state/i18n.service';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { HierarchyLevel, Sign, ZsMapDrawElementState } from '@zskarte/types';
-import { map } from 'rxjs';
-import { MatTableModule } from '@angular/material/table';
-import { AsyncPipe } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { DatePipe } from '@angular/common';
+import { MatDialog } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { DialogHeaderComponent, DialogBodyComponent } from '../ui/dialog-layout';
-import { MatCard } from '@angular/material/card';
-import { convertTo, projection_LV95 } from '../helper/projections';
-import { ZsMapBaseDrawElement } from '../map-renderer/elements/base/base-draw-element';
-import { SimpleGeometry } from 'ol/geom';
-import { getCenter } from 'ol/extent';
-
-interface ResourceRow {
-  id: string;
-  organization: string;
-  formationLocation: string;
-  hierarchyLevel: string;
-  formationNumber: string;
-  formationDetail: string;
-  additionalInfo: string;
-  location: string;
-}
+import { I18NService } from '../state/i18n.service';
+import { SessionService } from '../session/session.service';
+import { ResourceService } from '../resource/resource.service';
+import { ResourceCatalogueComponent } from '../resource/catalogue/resource-catalogue.component';
+import { ResourceDeployedComponent } from '../resource/deployed/resource-deployed.component';
+import { ResourceFormationTableComponent } from '../resource/formations/resource-formation-table.component';
+import { ResourceImportDialogComponent } from '../resource/import/resource-import-dialog.component';
+import { ConfirmationDialogComponent } from '../confirmation-dialog/confirmation-dialog.component';
+import { v4 as uuidv4 } from 'uuid';
 
 @Component({
   selector: 'app-resource-overview',
-  imports: [MatTableModule, AsyncPipe, DialogHeaderComponent, DialogBodyComponent, MatCard],
+  imports: [
+    DatePipe,
+    MatButtonModule,
+    MatIconModule,
+    MatTabsModule,
+    MatTooltipModule,
+    DialogHeaderComponent,
+    DialogBodyComponent,
+    ResourceCatalogueComponent,
+    ResourceDeployedComponent,
+    ResourceFormationTableComponent,
+  ],
   templateUrl: './resource-overview.component.html',
   styleUrl: './resource-overview.component.scss',
 })
 export class ResourceOverviewComponent {
-  private state = inject(ZsMapStateService);
-  private destroyRef = inject(DestroyRef);
+  private dialog = inject(MatDialog);
+  private session = inject(SessionService);
+  resourceService = inject(ResourceService);
   i18n = inject(I18NService);
 
-  readonly RESOURCE_SIGN_ID = [210];
+  /**
+   * Downloadable, self-documenting template: its rows above the CSV header explain the format
+   * and are skipped by the parser, so it doubles as the documentation of the import. Kept in
+   * sync with the parser by `resource-csv.parser.spec.ts`, which imports this very file.
+   */
+  readonly exampleCsvUrl = 'assets/doc/resource/mittel-beispiel.csv';
+  readonly exampleCsvFileName = 'mittel-beispiel.csv';
 
-  displayedColumns: string[] = [
-    'organization',
-    'formationLocation',
-    'hierarchyLevel',
-    'formationNumber',
-    'formationDetail',
-    'additionalInfo',
-    'location',
-  ];
+  readonly canImport = this.session.hasWritePermission() && !this.session.isArchived();
+  readonly isOnline = toSignal(this.session.observeIsOnline(), { initialValue: this.session.isOnline() });
 
-  resources$ = this.state.observeDrawElements().pipe(
-    takeUntilDestroyed(this.destroyRef),
-    map((elements) =>
-      elements
-        .filter((e) => this.RESOURCE_SIGN_ID.includes(e.elementState?.symbolId as number))
-        .map((e) => this.mapToResourceRow(e)),
-    ),
-  );
-
-  private mapToResourceRow(element: ZsMapBaseDrawElement): ResourceRow {
-    const state = element.elementState as ZsMapDrawElementState;
-    const geometry = element.getOlFeature().getGeometry() as SimpleGeometry;
-    return {
-      id: state.id ?? '',
-      organization: state.organization ?? '',
-      formationLocation: state.formationLocation ?? String(state.coordinates) ?? '',
-      hierarchyLevel: this.getHierarchyLabel(state.hierarchyLevel),
-      formationNumber: state.formationNumber ?? '',
-      formationDetail: state.formationDetail ?? '',
-      additionalInfo: state.additionalInfo ?? '',
-      location: convertTo(geometry.getCoordinates() || [], projection_LV95!, false) as string
-    };
+  /** True once a catalogue exists, i.e. there is something that could be cleared. */
+  get hasCatalogue(): boolean {
+    return this.resourceService.articles().length > 0;
   }
 
-  private getHierarchyLabel(level?: HierarchyLevel): string {
-    if (!level) return '';
-    switch (level) {
-      case HierarchyLevel.TRUPP:
-        return this.i18n.get('hierarchyTrupp');
-      case HierarchyLevel.GRUPPE:
-        return this.i18n.get('hierarchyGruppe');
-      case HierarchyLevel.ZUG:
-        return this.i18n.get('hierarchyZug');
-      case HierarchyLevel.KOMPANIE:
-        return this.i18n.get('hierarchyKompanie');
-      case HierarchyLevel.BATAILLON:
-        return this.i18n.get('hierarchyBataillon');
-      default:
-        return '';
+  openImportDialog(): void {
+    if (!this.canImport || !this.isOnline()) {
+      return;
     }
+    this.dialog.open(ResourceImportDialogComponent, { width: '700px', maxWidth: '95vw' });
   }
 
-  navigateTo(element: ZsMapDrawElementState) {
-    if (element.id) {
-      this.state.setSelectedFeature(element.id);
-      const extent = this.state.getDrawElement(element.id)?.getOlFeature()?.getGeometry()?.getExtent();
-      if (extent) {
-        this.state.setMapCenter(getCenter(extent));
+  /**
+   * Clears the whole catalogue of this operation, e.g. before re-importing a corrected export.
+   * An import with an empty article list is exactly the "replace" the endpoint already performs,
+   * so no dedicated delete endpoint is needed.
+   *
+   * Markers already placed on the map are deliberately kept - they then show up as
+   * "Nicht im Katalog", consistent with the re-import behaviour. The confirmation says so.
+   */
+  clearCatalogue(): void {
+    if (!this.canImport || !this.isOnline() || !this.hasCatalogue) {
+      return;
+    }
+    const confirmation = this.dialog.open(ConfirmationDialogComponent, {
+      data: {
+        title: this.i18n.get('resourceClearTitle'),
+        message: this.i18n.get('resourceClearConfirm'),
+        confirmLabel: this.i18n.get('resourceClear'),
+      },
+    });
+    confirmation.afterClosed().subscribe(async (confirmed) => {
+      if (!confirmed) {
+        return;
       }
-    }
+      const operationId = this.session.getOperationId();
+      const organizationId = this.session.getOrganization()?.documentId;
+      if (!operationId || !organizationId) {
+        return;
+      }
+      await this.resourceService.commitImport({
+        operation: operationId,
+        organization: organizationId,
+        importId: uuidv4(),
+        articles: [],
+      });
+    });
   }
 }

--- a/packages/app/src/app/resource/catalogue/resource-catalogue-filter.component.html
+++ b/packages/app/src/app/resource/catalogue/resource-catalogue-filter.component.html
@@ -1,0 +1,92 @@
+<div class="filter-bar">
+  <mat-form-field appearance="outline" class="search-field">
+    <mat-label>{{ i18n.get('resourceSearch') }}</mat-label>
+    <input
+      matInput
+      name="resourceCatalogueSearch"
+      [ngModel]="search()"
+      (ngModelChange)="search.set($event)"
+      [placeholder]="i18n.get('resourceSearchHint')"
+    />
+    @if (search()) {
+      <button
+        matSuffix
+        mat-icon-button
+        type="button"
+        [attr.aria-label]="i18n.get('resourceFilterClear')"
+        (click)="clearSearch()"
+      >
+        <mat-icon>close</mat-icon>
+      </button>
+    }
+  </mat-form-field>
+
+  <mat-form-field appearance="outline" class="filter-select">
+    <mat-label>{{ i18n.get('resourceArticleGroup') }}</mat-label>
+    <mat-select
+      multiple
+      name="resourceCatalogueGroupFilter"
+      [ngModel]="selectedGroups()"
+      (ngModelChange)="selectedGroups.set($event)"
+    >
+      @for (group of articleGroups(); track group) {
+        <mat-option [value]="group">{{ group }}</mat-option>
+      }
+    </mat-select>
+  </mat-form-field>
+
+  <mat-form-field appearance="outline" class="filter-select">
+    <mat-label>{{ i18n.get('resourceArticleType') }}</mat-label>
+    <mat-select
+      multiple
+      name="resourceCatalogueTypeFilter"
+      [ngModel]="selectedTypes()"
+      (ngModelChange)="selectedTypes.set($event)"
+    >
+      @for (type of articleTypes(); track type) {
+        <mat-option [value]="type">{{ type }}</mat-option>
+      }
+    </mat-select>
+  </mat-form-field>
+
+  <mat-form-field appearance="outline" class="filter-select">
+    <mat-label>{{ i18n.get('resourceStorageLocation') }}</mat-label>
+    <mat-select
+      multiple
+      name="resourceCatalogueStorageFilter"
+      [ngModel]="selectedStorageSites()"
+      (ngModelChange)="selectedStorageSites.set($event)"
+    >
+      @for (site of storageSites(); track site) {
+        <mat-option [value]="site">{{ site }}</mat-option>
+      }
+    </mat-select>
+  </mat-form-field>
+
+  @if (showAvailability()) {
+    <mat-form-field appearance="outline" class="filter-select">
+      <mat-label>{{ i18n.get('resourceFilterAvailability') }}</mat-label>
+      <mat-select
+        multiple
+        name="resourceCatalogueAvailabilityFilter"
+        [ngModel]="selectedAvailability()"
+        (ngModelChange)="selectedAvailability.set($event)"
+      >
+        @for (option of availabilityOptions; track option.value) {
+          <mat-option [value]="option.value">{{ i18n.get(option.labelKey) }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+  }
+
+  <button
+    mat-stroked-button
+    type="button"
+    class="clear-button"
+    [disabled]="!hasActiveFilters()"
+    (click)="clearFilters()"
+  >
+    <mat-icon>filter_alt_off</mat-icon>
+    {{ i18n.get('resourceFilterClear') }}
+  </button>
+</div>

--- a/packages/app/src/app/resource/catalogue/resource-catalogue-filter.component.scss
+++ b/packages/app/src/app/resource/catalogue/resource-catalogue-filter.component.scss
@@ -1,0 +1,28 @@
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem 0;
+}
+
+.search-field {
+  flex: 1 1 220px;
+  min-width: 200px;
+}
+
+.filter-select {
+  flex: 1 1 160px;
+  min-width: 150px;
+  max-width: 240px;
+}
+
+.clear-button {
+  flex: 0 0 auto;
+  align-self: center;
+  margin-top: 4px;
+
+  mat-icon {
+    margin-right: 4px;
+  }
+}

--- a/packages/app/src/app/resource/catalogue/resource-catalogue-filter.component.ts
+++ b/packages/app/src/app/resource/catalogue/resource-catalogue-filter.component.ts
@@ -1,0 +1,72 @@
+import { Component, computed, inject, input, model } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { ResourceAvailability } from '@zskarte/types';
+import { I18NService } from '../../state/i18n.service';
+
+interface AvailabilityOption {
+  value: ResourceAvailability;
+  labelKey: string;
+}
+
+/**
+ * Filter bar for the resource catalogue: free-text search plus multi-select filters for
+ * article group, article type, storage site and availability bucket. All filter state is
+ * owned by the parent (`ResourceCatalogueComponent`) via two-way `model()` bindings so the
+ * parent can combine them (AND) with the catalogue rows.
+ */
+@Component({
+  selector: 'app-resource-catalogue-filter',
+  imports: [FormsModule, MatButtonModule, MatFormFieldModule, MatIconModule, MatInputModule, MatSelectModule],
+  templateUrl: './resource-catalogue-filter.component.html',
+  styleUrl: './resource-catalogue-filter.component.scss',
+})
+export class ResourceCatalogueFilterComponent {
+  i18n = inject(I18NService);
+
+  articleGroups = input<string[]>([]);
+  /**
+   * The availability buckets only make sense where stock can still be free. On the
+   * "Im Einsatz" tab every row is assigned by definition, so that select is hidden there.
+   */
+  showAvailability = input<boolean>(true);
+  articleTypes = input<string[]>([]);
+  storageSites = input<string[]>([]);
+
+  search = model<string>('');
+  selectedGroups = model<string[]>([]);
+  selectedTypes = model<string[]>([]);
+  selectedStorageSites = model<string[]>([]);
+  selectedAvailability = model<ResourceAvailability[]>([]);
+
+  readonly availabilityOptions: AvailabilityOption[] = [
+    { value: 'available', labelKey: 'resourceAvailable' },
+    { value: 'assigned', labelKey: 'resourceAssigned' },
+    { value: 'unavailable', labelKey: 'resourceUnavailable' },
+  ];
+
+  readonly hasActiveFilters = computed(
+    () =>
+      this.search().trim().length > 0 ||
+      this.selectedGroups().length > 0 ||
+      this.selectedTypes().length > 0 ||
+      this.selectedStorageSites().length > 0 ||
+      (this.showAvailability() && this.selectedAvailability().length > 0),
+  );
+
+  clearSearch(): void {
+    this.search.set('');
+  }
+
+  clearFilters(): void {
+    this.search.set('');
+    this.selectedGroups.set([]);
+    this.selectedTypes.set([]);
+    this.selectedStorageSites.set([]);
+    this.selectedAvailability.set([]);
+  }
+}

--- a/packages/app/src/app/resource/catalogue/resource-catalogue.component.html
+++ b/packages/app/src/app/resource/catalogue/resource-catalogue.component.html
@@ -1,0 +1,175 @@
+@if (resourceService.loading()) {
+  <div class="state-container">
+    <mat-spinner diameter="40"></mat-spinner>
+  </div>
+} @else if (resourceService.error()) {
+  <app-empty>
+    <app-empty-header>
+      <app-empty-media variant="icon">
+        <mat-icon>error_outline</mat-icon>
+      </app-empty-media>
+      <app-empty-title>{{ i18n.get('resourceLoadError') }}</app-empty-title>
+    </app-empty-header>
+  </app-empty>
+} @else if (resourceService.articles().length === 0) {
+  <app-empty>
+    <app-empty-header>
+      <app-empty-media variant="icon">
+        <mat-icon>inventory_2</mat-icon>
+      </app-empty-media>
+      <app-empty-title>{{ i18n.get('resourceNoCatalogue') }}</app-empty-title>
+      <app-empty-description>{{ i18n.get('resourceNoCatalogueHint') }}</app-empty-description>
+    </app-empty-header>
+  </app-empty>
+} @else {
+  <div class="catalogue-container">
+    <app-resource-catalogue-filter
+      [articleGroups]="resourceService.articleGroups()"
+      [articleTypes]="resourceService.articleTypes()"
+      [storageSites]="resourceService.storageSites()"
+      [(search)]="search"
+      [(selectedGroups)]="selectedGroups"
+      [(selectedTypes)]="selectedTypes"
+      [(selectedStorageSites)]="selectedStorageSites"
+      [(selectedAvailability)]="selectedAvailability"
+    ></app-resource-catalogue-filter>
+
+    <div class="count-line">
+      {{ filteredArticleCount() }} {{ i18n.get('resourceCountOf') }} {{ totalArticleCount() }}
+      {{ i18n.get('resourceImportArticles') }} · {{ filteredPieceCount() }} {{ i18n.get('resourceImportItems') }}
+    </div>
+
+    <div class="table-container">
+      <table mat-table [dataSource]="dataSource" matSort multiTemplateDataRows class="catalogue-table">
+        <ng-container matColumnDef="select">
+          <th mat-header-cell *matHeaderCellDef>
+            <mat-checkbox
+              [checked]="allFilteredSelected()"
+              [indeterminate]="someFilteredSelected()"
+              [attr.aria-label]="i18n.get('resourceSelectAllArticles')"
+              (change)="toggleAllFiltered($event)"
+            ></mat-checkbox>
+          </th>
+          <td mat-cell *matCellDef="let row">
+            <mat-checkbox
+              [checked]="isRowFullySelected(row)"
+              [indeterminate]="isRowPartiallySelected(row)"
+              [disabled]="row.availableCount <= 0"
+              [attr.aria-label]="i18n.get('resourceSelectArticle')"
+              (click)="$event.stopPropagation()"
+              (change)="toggleRow(row)"
+            ></mat-checkbox>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="signature">
+          <th mat-header-cell *matHeaderCellDef>{{ i18n.get('resourceDeploySignature') }}</th>
+          <td mat-cell *matCellDef="let row">
+            @let signature = signaturePreview(row.article);
+            <img
+              [src]="signature.url"
+              [alt]="signature.label"
+              [matTooltip]="signature.label"
+              class="signature-icon"
+              [class.placeholder]="signature.isPlaceholder"
+            />
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="articleNumber">
+          <th mat-header-cell mat-sort-header *matHeaderCellDef sortActionDescription="Sort by article number">
+            {{ i18n.get('resourceArticleNumber') }}
+          </th>
+          <td mat-cell *matCellDef="let row">{{ row.article.articleNumber }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="name">
+          <th mat-header-cell mat-sort-header *matHeaderCellDef sortActionDescription="Sort by name">
+            {{ i18n.get('resourceArticleName') }}
+          </th>
+          <td mat-cell *matCellDef="let row">{{ row.article.name }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="articleGroup">
+          <th mat-header-cell mat-sort-header *matHeaderCellDef sortActionDescription="Sort by article group">
+            {{ i18n.get('resourceArticleGroup') }}
+          </th>
+          <td mat-cell *matCellDef="let row">{{ row.article.articleGroup }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="totalCount">
+          <th mat-header-cell mat-sort-header *matHeaderCellDef sortActionDescription="Sort by total count">
+            {{ i18n.get('resourceTotalCount') }}
+          </th>
+          <td mat-cell *matCellDef="let row">{{ row.article.totalCount }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="availableCount">
+          <th mat-header-cell mat-sort-header *matHeaderCellDef sortActionDescription="Sort by available count">
+            {{ i18n.get('resourceFreeCount') }}
+          </th>
+          <td mat-cell *matCellDef="let row">{{ row.availableCount }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="expand">
+          <th mat-header-cell *matHeaderCellDef></th>
+          <td mat-cell *matCellDef="let row">
+            <button
+              mat-icon-button
+              type="button"
+              [attr.aria-label]="i18n.get('resourceItemsToggle')"
+              (click)="toggleExpand(row)"
+            >
+              <mat-icon>{{ isExpanded(row) ? 'expand_less' : 'expand_more' }}</mat-icon>
+            </button>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="expandedDetail">
+          <td mat-cell *matCellDef="let row" [attr.colspan]="displayedColumns.length">
+            @if (isExpanded(row)) {
+              <app-resource-item-table
+                [article]="row.article"
+                [row]="row"
+                [selection]="selectionFor(row)"
+                (selectionChange)="updateSelection(row.article.articleNumber, $event)"
+              ></app-resource-item-table>
+            }
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns" class="element-row"></tr>
+        <tr
+          mat-row
+          *matRowDef="let row; columns: ['expandedDetail']"
+          class="detail-row"
+          [class.expanded]="isExpanded(row)"
+        ></tr>
+      </table>
+
+      @if (filteredArticleCount() === 0) {
+        <app-empty class="no-results">
+          <app-empty-header>
+            <app-empty-media variant="icon">
+              <mat-icon>search_off</mat-icon>
+            </app-empty-media>
+            <app-empty-title>{{ i18n.get('resourceNoFilterResults') }}</app-empty-title>
+          </app-empty-header>
+        </app-empty>
+      }
+
+      <mat-paginator [pageSize]="50" [pageSizeOptions]="[25, 50, 100]" showFirstLastButtons></mat-paginator>
+    </div>
+
+    @if (hasSelection()) {
+      <div class="selection-footer">
+        <span class="selection-count">{{ totalSelectedQuantity() }} {{ i18n.get('resourceSelected') }}</span>
+        <button mat-button type="button" (click)="clearSelection()">{{ i18n.get('resourceSelectionClear') }}</button>
+        <button mat-flat-button color="primary" type="button" (click)="deploy()">
+          {{ i18n.get('resourceDeploy') }}
+        </button>
+      </div>
+    }
+  </div>
+}

--- a/packages/app/src/app/resource/catalogue/resource-catalogue.component.scss
+++ b/packages/app/src/app/resource/catalogue/resource-catalogue.component.scss
@@ -1,0 +1,93 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.state-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 0;
+}
+
+.catalogue-container {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
+}
+
+.count-line {
+  padding: 0 0 0.5rem;
+  color: var(--mat-sys-on-surface-variant, #666);
+  font-size: 0.8125rem;
+}
+
+.table-container {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  position: relative;
+}
+
+.catalogue-table {
+  width: 100%;
+}
+
+.catalogue-table th,
+.catalogue-table td {
+  padding-right: 8px;
+}
+
+.element-row {
+  cursor: default;
+}
+
+.signature-icon {
+  width: 28px;
+  height: 28px;
+  object-fit: contain;
+}
+
+.signature-icon.placeholder {
+  opacity: 0.45;
+  filter: grayscale(1);
+}
+
+.detail-row {
+  height: 0;
+}
+
+.detail-row:not(.expanded) td {
+  padding: 0;
+  border: none;
+  overflow: hidden;
+  height: 0;
+}
+
+.detail-row.expanded td {
+  padding: 0.5rem 0;
+  border-bottom-width: 1px;
+}
+
+.no-results {
+  padding: 1rem 0;
+}
+
+.selection-footer {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--mat-sys-outline-variant, #dedede);
+  background: var(--mat-sys-surface, #fff);
+  position: sticky;
+  bottom: 0;
+}
+
+.selection-count {
+  flex: 1;
+  font-weight: 500;
+}

--- a/packages/app/src/app/resource/catalogue/resource-catalogue.component.ts
+++ b/packages/app/src/app/resource/catalogue/resource-catalogue.component.ts
@@ -1,0 +1,302 @@
+import { AfterViewInit, Component, computed, effect, inject, signal, viewChild } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxChange, MatCheckboxModule } from '@angular/material/checkbox';
+import { MatDialog } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSort, MatSortModule } from '@angular/material/sort';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { RESOURCE_STATUS_IN_STOCK, ResourceArticle, ResourceAvailability } from '@zskarte/types';
+import { DrawStyle } from '../../map-renderer/draw-style';
+import { Signs } from '../../map-renderer/signs';
+import { I18NService } from '../../state/i18n.service';
+import { EmptyComponent, EmptyDescriptionComponent, EmptyHeaderComponent, EmptyMediaComponent, EmptyTitleComponent } from '../../ui/empty';
+import { ResourceDeployDialogComponent } from '../placement/resource-deploy-dialog.component';
+import { ResourceCatalogueRow } from '../resource-assignments';
+import { ResourceService } from '../resource.service';
+import { resolveResourceSignId } from '../resource-signature.mapping';
+import { ResourceCatalogueFilterComponent } from './resource-catalogue-filter.component';
+import { ResourceItemTableComponent } from './resource-item-table.component';
+
+/** Pending selection for one article: how many pieces, and which specific ones for a serialised article. */
+export interface ResourceSelectionEntry {
+  quantity: number;
+  itemKeys: string[];
+}
+
+/** Rendered signature (pictogram) preview for one catalogue row. */
+interface SignaturePreview {
+  url: string;
+  label: string;
+  isPlaceholder: boolean;
+}
+
+/**
+ * The resource catalogue: filter bar, grouped/expandable article table, multi-select
+ * across pages/filters, and the hand-off to the placement dialog.
+ *
+ * Selection is kept independently of the table's row objects - in `selection`, a
+ * `Map<articleNumber, ResourceSelectionEntry>` - so it survives filtering, sorting and
+ * pagination instead of living on rows that get replaced whenever the filtered set changes.
+ */
+@Component({
+  selector: 'app-resource-catalogue',
+  imports: [
+    MatButtonModule,
+    MatCheckboxModule,
+    MatIconModule,
+    MatPaginatorModule,
+    MatProgressSpinnerModule,
+    MatSortModule,
+    MatTableModule,
+    MatTooltipModule,
+    EmptyComponent,
+    EmptyHeaderComponent,
+    EmptyMediaComponent,
+    EmptyTitleComponent,
+    EmptyDescriptionComponent,
+    ResourceCatalogueFilterComponent,
+    ResourceItemTableComponent,
+  ],
+  templateUrl: './resource-catalogue.component.html',
+  styleUrl: './resource-catalogue.component.scss',
+})
+export class ResourceCatalogueComponent implements AfterViewInit {
+  resourceService = inject(ResourceService);
+  i18n = inject(I18NService);
+  private dialog = inject(MatDialog);
+
+  readonly sort = viewChild(MatSort);
+  readonly paginator = viewChild(MatPaginator);
+
+  readonly displayedColumns = [
+    'select',
+    'signature',
+    'articleNumber',
+    'name',
+    'articleGroup',
+    'totalCount',
+    'availableCount',
+    'expand',
+  ];
+
+  readonly dataSource = new MatTableDataSource<ResourceCatalogueRow>([]);
+
+  // Filter state, two-way bound to <app-resource-catalogue-filter>.
+  readonly search = signal('');
+  readonly selectedGroups = signal<string[]>([]);
+  readonly selectedTypes = signal<string[]>([]);
+  readonly selectedStorageSites = signal<string[]>([]);
+  readonly selectedAvailability = signal<ResourceAvailability[]>([]);
+
+  readonly expandedArticleNumbers = signal<ReadonlySet<string>>(new Set());
+
+  /** Pending selection, independent of the (filtered/sorted/paginated) table rows. */
+  readonly selection = signal<ReadonlyMap<string, ResourceSelectionEntry>>(new Map());
+
+  readonly filteredRows = computed<ResourceCatalogueRow[]>(() => {
+    const rows = this.resourceService.catalogueRows();
+    const search = this.search().trim().toLowerCase();
+    const groups = new Set(this.selectedGroups());
+    const types = new Set(this.selectedTypes());
+    const sites = new Set(this.selectedStorageSites());
+    const availability = new Set(this.selectedAvailability());
+
+    return rows.filter((row) => {
+      const article = row.article;
+      if (groups.size > 0 && !groups.has(article.articleGroup)) {
+        return false;
+      }
+      if (types.size > 0 && !types.has(article.articleType)) {
+        return false;
+      }
+      if (sites.size > 0 && !article.items.some((item) => item.storageLocation && sites.has(item.storageLocation))) {
+        return false;
+      }
+      if (availability.size > 0 && !row.availability.some((bucket) => availability.has(bucket))) {
+        return false;
+      }
+      if (search) {
+        const haystack = [article.articleNumber, article.name, article.manufacturer ?? '']
+          .concat(article.items.map((item) => item.serialNumber ?? ''))
+          .join(' ')
+          .toLowerCase();
+        if (!haystack.includes(search)) {
+          return false;
+        }
+      }
+      return true;
+    });
+  });
+
+  readonly totalArticleCount = computed(() => this.resourceService.catalogueRows().length);
+  readonly filteredArticleCount = computed(() => this.filteredRows().length);
+  readonly filteredPieceCount = computed(() => this.filteredRows().reduce((sum, row) => sum + row.article.totalCount, 0));
+
+  readonly selectionEntries = computed(() => [...this.selection().entries()]);
+  readonly totalSelectedQuantity = computed(() =>
+    this.selectionEntries().reduce((sum, [, entry]) => sum + entry.quantity, 0),
+  );
+  readonly hasSelection = computed(() => this.totalSelectedQuantity() > 0);
+
+  private readonly selectableFilteredRows = computed(() => this.filteredRows().filter((row) => row.availableCount > 0));
+
+  readonly allFilteredSelected = computed(() => {
+    const rows = this.selectableFilteredRows();
+    return rows.length > 0 && rows.every((row) => this.isRowFullySelected(row));
+  });
+
+  readonly someFilteredSelected = computed(() => {
+    if (this.allFilteredSelected()) {
+      return false;
+    }
+    return this.selectableFilteredRows().some((row) => (this.selection().get(row.article.articleNumber)?.quantity ?? 0) > 0);
+  });
+
+  constructor() {
+    effect(() => {
+      this.dataSource.data = this.filteredRows();
+      // A new filtered set can leave the paginator on a now out-of-range page - go back to page 1.
+      const paginator = this.paginator();
+      if (paginator) {
+        paginator.firstPage();
+      }
+    });
+  }
+
+  ngAfterViewInit(): void {
+    const sort = this.sort();
+    const paginator = this.paginator();
+    if (sort) {
+      this.dataSource.sort = sort;
+    }
+    if (paginator) {
+      this.dataSource.paginator = paginator;
+    }
+    this.dataSource.sortingDataAccessor = (row: ResourceCatalogueRow, property: string) => {
+      switch (property) {
+        case 'articleNumber':
+          return row.article.articleNumber.toLowerCase();
+        case 'name':
+          return row.article.name.toLowerCase();
+        case 'articleGroup':
+          return row.article.articleGroup.toLowerCase();
+        case 'totalCount':
+          return row.article.totalCount;
+        case 'availableCount':
+          return row.availableCount;
+        default:
+          return '';
+      }
+    };
+  }
+
+  signaturePreview(article: ResourceArticle): SignaturePreview {
+    const signId = resolveResourceSignId(article);
+    const sign = Signs.getSignById(signId);
+    return {
+      url: sign ? DrawStyle.getImageUrl(sign.src) : '',
+      label: sign ? this.i18n.getLabelForSign(sign) : '',
+      isPlaceholder: signId === Signs.RESOURCE_PLACEHOLDER_SIGN_ID,
+    };
+  }
+
+  isExpanded(row: ResourceCatalogueRow): boolean {
+    return this.expandedArticleNumbers().has(row.article.articleNumber);
+  }
+
+  toggleExpand(row: ResourceCatalogueRow): void {
+    const next = new Set(this.expandedArticleNumbers());
+    if (next.has(row.article.articleNumber)) {
+      next.delete(row.article.articleNumber);
+    } else {
+      next.add(row.article.articleNumber);
+    }
+    this.expandedArticleNumbers.set(next);
+  }
+
+  selectionFor(row: ResourceCatalogueRow): ResourceSelectionEntry | undefined {
+    return this.selection().get(row.article.articleNumber);
+  }
+
+  isRowFullySelected(row: ResourceCatalogueRow): boolean {
+    if (row.availableCount <= 0) {
+      return false;
+    }
+    const entry = this.selectionFor(row);
+    return !!entry && entry.quantity >= row.availableCount;
+  }
+
+  isRowPartiallySelected(row: ResourceCatalogueRow): boolean {
+    const entry = this.selectionFor(row);
+    return !!entry && entry.quantity > 0 && entry.quantity < row.availableCount;
+  }
+
+  /** Row-level checkbox: selects every currently available piece of the article, or clears it. */
+  toggleRow(row: ResourceCatalogueRow): void {
+    if (this.isRowFullySelected(row)) {
+      this.updateSelection(row.article.articleNumber, { quantity: 0, itemKeys: [] });
+      return;
+    }
+    this.updateSelection(row.article.articleNumber, this.fullSelectionFor(row));
+  }
+
+  /** Header checkbox: selects every available piece of every filtered article, or clears them all. */
+  toggleAllFiltered(event: MatCheckboxChange): void {
+    const next = new Map(this.selection());
+    for (const row of this.selectableFilteredRows()) {
+      if (event.checked) {
+        next.set(row.article.articleNumber, this.fullSelectionFor(row));
+      } else {
+        next.delete(row.article.articleNumber);
+      }
+    }
+    this.selection.set(next);
+  }
+
+  updateSelection(articleNumber: string, entry: ResourceSelectionEntry): void {
+    const next = new Map(this.selection());
+    if (entry.quantity <= 0 && entry.itemKeys.length === 0) {
+      next.delete(articleNumber);
+    } else {
+      next.set(articleNumber, entry);
+    }
+    this.selection.set(next);
+  }
+
+  clearSelection(): void {
+    this.selection.set(new Map());
+  }
+
+  private fullSelectionFor(row: ResourceCatalogueRow): ResourceSelectionEntry {
+    if (!row.article.serialized) {
+      return { quantity: row.availableCount, itemKeys: [] };
+    }
+    const assignedItemKeys = this.resourceService.assignmentIndex().byItemKey;
+    const itemKeys = row.article.items
+      .filter((item) => item.itemKey && item.status === RESOURCE_STATUS_IN_STOCK && !assignedItemKeys.has(item.itemKey))
+      .map((item) => item.itemKey as string);
+    return { quantity: itemKeys.length, itemKeys };
+  }
+
+  deploy(): void {
+    const articlesByNumber = new Map(this.resourceService.articles().map((article) => [article.articleNumber, article]));
+    const selections = this.selectionEntries()
+      .map(([articleNumber, entry]) => {
+        const article = articlesByNumber.get(articleNumber);
+        return article ? { article, quantity: entry.quantity, itemKeys: entry.itemKeys } : undefined;
+      })
+      .filter((selection): selection is { article: ResourceArticle; quantity: number; itemKeys: string[] } => !!selection);
+
+    if (selections.length === 0) {
+      return;
+    }
+
+    this.dialog.open(ResourceDeployDialogComponent, {
+      data: { selections },
+      width: '560px',
+    });
+  }
+}

--- a/packages/app/src/app/resource/catalogue/resource-item-table.component.html
+++ b/packages/app/src/app/resource/catalogue/resource-item-table.component.html
@@ -1,0 +1,75 @@
+@if (article().serialized) {
+  <div class="item-table-container">
+    <table mat-table [dataSource]="itemsDataSource" class="item-table">
+      <ng-container matColumnDef="select">
+        <th mat-header-cell *matHeaderCellDef></th>
+        <td mat-cell *matCellDef="let item">
+          <mat-checkbox
+            [checked]="isItemSelected(item)"
+            [disabled]="isItemDisabled(item)"
+            [attr.aria-label]="i18n.get('resourceSelectItem')"
+            (change)="toggleItem(item)"
+          ></mat-checkbox>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="serialNumber">
+        <th mat-header-cell *matHeaderCellDef>{{ i18n.get('resourceSerialNumber') }}</th>
+        <td mat-cell *matCellDef="let item">{{ item.serialNumber || '–' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="serialNumberInternal">
+        <th mat-header-cell *matHeaderCellDef>{{ i18n.get('resourceSerialNumberInternal') }}</th>
+        <td mat-cell *matCellDef="let item">{{ item.serialNumberInternal || '–' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="storageLocation">
+        <th mat-header-cell *matHeaderCellDef>{{ i18n.get('resourceStorageLocation') }}</th>
+        <td mat-cell *matCellDef="let item">{{ item.storageLocation || '–' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="status">
+        <th mat-header-cell *matHeaderCellDef>{{ i18n.get('resourceFilterAvailability') }}</th>
+        <td mat-cell *matCellDef="let item">
+          <span
+            class="status-chip"
+            [class.status-available]="statusLabelKey(item) === 'resourceAvailable'"
+            [class.status-assigned]="statusLabelKey(item) === 'resourceAssigned'"
+            [class.status-unavailable]="statusLabelKey(item) === 'resourceUnavailable'"
+          >
+            {{ i18n.get(statusLabelKey(item)) }}
+          </span>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="itemColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: itemColumns"></tr>
+    </table>
+
+    <mat-paginator [pageSize]="100" [pageSizeOptions]="[50, 100, 200]" showFirstLastButtons></mat-paginator>
+  </div>
+} @else {
+  <div class="quantity-stepper">
+    <span class="quantity-label">{{ i18n.get('resourceQuantity') }}</span>
+    <button
+      mat-icon-button
+      type="button"
+      [attr.aria-label]="i18n.get('resourceQuantityDecrease')"
+      [disabled]="quantity() <= 0"
+      (click)="decreaseQuantity()"
+    >
+      <mat-icon>remove</mat-icon>
+    </button>
+    <span class="quantity-value">{{ quantity() }}</span>
+    <button
+      mat-icon-button
+      type="button"
+      [attr.aria-label]="i18n.get('resourceQuantityIncrease')"
+      [disabled]="quantity() >= row().availableCount"
+      (click)="increaseQuantity()"
+    >
+      <mat-icon>add</mat-icon>
+    </button>
+    <span class="quantity-hint">{{ i18n.get('resourceFreeCount') }}: {{ row().availableCount }}</span>
+  </div>
+}

--- a/packages/app/src/app/resource/catalogue/resource-item-table.component.scss
+++ b/packages/app/src/app/resource/catalogue/resource-item-table.component.scss
@@ -1,0 +1,60 @@
+.item-table-container {
+  padding: 0.5rem 1rem 1rem;
+  background: var(--mat-sys-surface-variant, #f5f5f5);
+  border-radius: 0.5rem;
+}
+
+.item-table {
+  width: 100%;
+  background: transparent;
+}
+
+.status-chip {
+  display: inline-block;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  padding: 2px 10px;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.status-available {
+  background-color: var(--mat-sys-tertiary-container, #d7f7dc);
+  color: var(--mat-sys-on-tertiary-container, #0d3d16);
+}
+
+.status-assigned {
+  background-color: var(--mat-sys-secondary-container, #dfe4ff);
+  color: var(--mat-sys-on-secondary-container, #1a2266);
+}
+
+.status-unavailable {
+  background-color: var(--mat-sys-error-container, #fdd8d8);
+  color: var(--mat-sys-on-error-container, #5b0e0e);
+}
+
+.quantity-stepper {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: var(--mat-sys-surface-variant, #f5f5f5);
+  border-radius: 0.5rem;
+}
+
+.quantity-label {
+  font-weight: 500;
+  margin-right: 0.5rem;
+}
+
+.quantity-value {
+  min-width: 2ch;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.quantity-hint {
+  margin-left: 0.75rem;
+  color: var(--mat-sys-on-surface-variant, #666);
+  font-size: 0.8125rem;
+}

--- a/packages/app/src/app/resource/catalogue/resource-item-table.component.ts
+++ b/packages/app/src/app/resource/catalogue/resource-item-table.component.ts
@@ -1,0 +1,105 @@
+import { AfterViewInit, Component, computed, effect, inject, input, output, viewChild } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatIconModule } from '@angular/material/icon';
+import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { RESOURCE_STATUS_IN_STOCK, ResourceArticle, ResourceItem } from '@zskarte/types';
+import { I18NService } from '../../state/i18n.service';
+import { ResourceCatalogueRow } from '../resource-assignments';
+import { ResourceService } from '../resource.service';
+import { ResourceSelectionEntry } from './resource-catalogue.component';
+
+/**
+ * Expanded per-piece list for one article of the resource catalogue.
+ *
+ * A serialised article shows a paginated (100/page) table of individual pieces, each with
+ * its own checkbox - disabled once the piece is not `an Lager` or is already assigned to a
+ * draw element elsewhere on the map. A non-serialised article shows a single quantity
+ * stepper instead, since its pieces are fungible.
+ */
+@Component({
+  selector: 'app-resource-item-table',
+  imports: [MatButtonModule, MatCheckboxModule, MatIconModule, MatPaginatorModule, MatTableModule],
+  templateUrl: './resource-item-table.component.html',
+  styleUrl: './resource-item-table.component.scss',
+})
+export class ResourceItemTableComponent implements AfterViewInit {
+  private resourceService = inject(ResourceService);
+  i18n = inject(I18NService);
+
+  article = input.required<ResourceArticle>();
+  row = input.required<ResourceCatalogueRow>();
+  selection = input<ResourceSelectionEntry | undefined>(undefined);
+  selectionChange = output<ResourceSelectionEntry>();
+
+  readonly paginator = viewChild(MatPaginator);
+
+  readonly itemColumns = ['select', 'serialNumber', 'serialNumberInternal', 'storageLocation', 'status'];
+  readonly itemsDataSource = new MatTableDataSource<ResourceItem>([]);
+
+  /** itemKeys already assigned to a draw element elsewhere on the map. */
+  private readonly assignedItemKeys = computed(() => new Set(this.resourceService.assignmentIndex().byItemKey.keys()));
+  private readonly selectedItemKeys = computed(() => new Set(this.selection()?.itemKeys ?? []));
+
+  readonly quantity = computed(() => this.selection()?.quantity ?? 0);
+
+  constructor() {
+    effect(() => {
+      this.itemsDataSource.data = this.article().items;
+    });
+  }
+
+  ngAfterViewInit(): void {
+    const paginator = this.paginator();
+    if (paginator) {
+      this.itemsDataSource.paginator = paginator;
+    }
+  }
+
+  isItemSelected(item: ResourceItem): boolean {
+    return !!item.itemKey && this.selectedItemKeys().has(item.itemKey);
+  }
+
+  isItemDisabled(item: ResourceItem): boolean {
+    return (
+      item.status !== RESOURCE_STATUS_IN_STOCK ||
+      !item.itemKey ||
+      (this.assignedItemKeys().has(item.itemKey) && !this.isItemSelected(item))
+    );
+  }
+
+  toggleItem(item: ResourceItem): void {
+    if (!item.itemKey || this.isItemDisabled(item)) {
+      return;
+    }
+    const keys = new Set(this.selectedItemKeys());
+    if (keys.has(item.itemKey)) {
+      keys.delete(item.itemKey);
+    } else {
+      keys.add(item.itemKey);
+    }
+    const itemKeys = [...keys];
+    this.selectionChange.emit({ quantity: itemKeys.length, itemKeys });
+  }
+
+  statusLabelKey(item: ResourceItem): string {
+    if (item.status !== RESOURCE_STATUS_IN_STOCK) {
+      return 'resourceUnavailable';
+    }
+    if (item.itemKey && this.assignedItemKeys().has(item.itemKey) && !this.isItemSelected(item)) {
+      return 'resourceAssigned';
+    }
+    return 'resourceAvailable';
+  }
+
+  decreaseQuantity(): void {
+    const next = Math.max(0, this.quantity() - 1);
+    this.selectionChange.emit({ quantity: next, itemKeys: [] });
+  }
+
+  increaseQuantity(): void {
+    const next = Math.min(this.row().availableCount, this.quantity() + 1);
+    this.selectionChange.emit({ quantity: next, itemKeys: [] });
+  }
+}

--- a/packages/app/src/app/resource/deployed/resource-deployed.component.html
+++ b/packages/app/src/app/resource/deployed/resource-deployed.component.html
@@ -1,0 +1,156 @@
+@if (allRowsCount() > 0) {
+  <app-resource-catalogue-filter
+    [articleGroups]="resourceService.articleGroups()"
+    [articleTypes]="resourceService.articleTypes()"
+    [storageSites]="resourceService.storageSites()"
+    [showAvailability]="false"
+    [(search)]="search"
+    [(selectedGroups)]="selectedGroups"
+    [(selectedTypes)]="selectedTypes"
+    [(selectedStorageSites)]="selectedStorageSites"
+    [(selectedAvailability)]="selectedAvailability"
+  />
+}
+
+@if (rows().length > 0) {
+  <mat-card>
+    <table mat-table [dataSource]="tableRows()" class="deployed-table">
+      <!-- Signature Column -->
+      <ng-container matColumnDef="signature">
+        <th mat-header-cell *matHeaderCellDef>{{ i18n.get('csvSignatur') }}</th>
+        <td mat-cell *matCellDef="let row">
+          @if (row.signatureSrc && !row.inGroup) {
+            <img [src]="row.signatureSrc" [alt]="row.signatureAlt" class="signature-preview" />
+          }
+        </td>
+      </ng-container>
+
+      <!-- Article Column -->
+      <ng-container matColumnDef="article">
+        <th mat-header-cell *matHeaderCellDef>{{ i18n.get('resourceArticleName') }}</th>
+        <td mat-cell *matCellDef="let row" [class.grouped-article]="row.inGroup">{{ row.articleLabel }}</td>
+      </ng-container>
+
+      <!-- Marker Name Column -->
+      <ng-container matColumnDef="markerName">
+        <th mat-header-cell *matHeaderCellDef>{{ i18n.get('csvLabel') }}</th>
+        <td mat-cell *matCellDef="let row">{{ row.inGroup ? '' : row.markerName }}</td>
+      </ng-container>
+
+      <!-- Report Number Column -->
+      <ng-container matColumnDef="reportNumber">
+        <th mat-header-cell *matHeaderCellDef>{{ i18n.get('csvReportNumber') }}</th>
+        <td mat-cell *matCellDef="let row">{{ row.inGroup ? '' : row.reportNumber }}</td>
+      </ng-container>
+
+      <!-- Location Column -->
+      <ng-container matColumnDef="location">
+        <th mat-header-cell *matHeaderCellDef>{{ i18n.get('csvLocation') }}</th>
+        <td mat-cell *matCellDef="let row" class="location" (click)="navigateToElement(row)">
+          {{ row.inGroup ? '' : row.location }}
+        </td>
+      </ng-container>
+
+      <!-- Actions Column -->
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef></th>
+        <td mat-cell *matCellDef="let row" class="actions">
+          <button
+            mat-icon-button
+            type="button"
+            [attr.aria-label]="i18n.get('resourceTakeBack')"
+            [matTooltip]="i18n.get('resourceTakeBack')"
+            (click)="takeBack(row)"
+          >
+            <mat-icon>undo</mat-icon>
+          </button>
+          <!-- for a grouped marker this action lives on the group header instead -->
+          @if (!row.inGroup && row.markerAssignmentCount > 1) {
+            <button
+              mat-icon-button
+              type="button"
+              [attr.aria-label]="i18n.get('resourceTakeBackAll')"
+              [matTooltip]="i18n.get('resourceTakeBackAll')"
+              (click)="takeBackAll(row.elementId)"
+            >
+              <mat-icon>playlist_remove</mat-icon>
+            </button>
+          }
+        </td>
+      </ng-container>
+
+      <!-- Group header: one marker carrying several resources, spanning the whole table width -->
+      <ng-container matColumnDef="group">
+        <td mat-cell *matCellDef="let row" [attr.colspan]="displayedColumns.length" class="group-cell">
+          <div class="group-header">
+            @if (row.signatureSrc) {
+              <img [src]="row.signatureSrc" [alt]="row.signatureAlt" class="signature-preview" />
+            }
+            <div class="group-text">
+              <span class="group-label">{{ row.markerLabel }}</span>
+              <span class="group-meta">
+                {{ row.count }} {{ i18n.get('resourceMarkerGroupCount') }}
+                @if (row.reportNumber) {
+                  · {{ i18n.get('csvReportNumber') }} {{ row.reportNumber }}
+                }
+              </span>
+            </div>
+            @if (row.location) {
+              <span class="group-location location" (click)="navigateToElement(row)">{{ row.location }}</span>
+            }
+            <button
+              mat-icon-button
+              type="button"
+              [attr.aria-label]="i18n.get('resourceTakeBackAll')"
+              [matTooltip]="i18n.get('resourceTakeBackAll')"
+              (click)="takeBackAll(row.elementId)"
+            >
+              <mat-icon>playlist_remove</mat-icon>
+            </button>
+          </div>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: ['group']; when: isGroupRow" class="group-row"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns" [class.grouped-row]="row.inGroup"></tr>
+    </table>
+  </mat-card>
+} @else if (allRowsCount() > 0) {
+  <!-- filters active but nothing matches - do not claim that nothing is deployed -->
+  <app-empty>
+    <app-empty-header>
+      <app-empty-media variant="icon">
+        <mat-icon>filter_alt_off</mat-icon>
+      </app-empty-media>
+      <app-empty-title>{{ i18n.get('resourceNoDeployedFilterResults') }}</app-empty-title>
+    </app-empty-header>
+  </app-empty>
+} @else {
+  <app-empty>
+    <app-empty-header>
+      <app-empty-media variant="icon">
+        <mat-icon>inventory_2</mat-icon>
+      </app-empty-media>
+      <app-empty-title>{{ i18n.get('resourceNoDeployed') }}</app-empty-title>
+      <app-empty-description>{{ i18n.get('resourceNoDeployedHint') }}</app-empty-description>
+    </app-empty-header>
+  </app-empty>
+}
+
+@if (resourceService.orphanedAssignments().length > 0) {
+  <h3 class="orphan-heading">{{ i18n.get('resourceOrphanAssignments') }}</h3>
+  <ul class="orphan-list">
+    @for (
+      orphan of resourceService.orphanedAssignments();
+      track orphan.assignment.itemKey || orphan.elementId + orphan.assignment.articleNumber
+    ) {
+      <li>
+        {{ orphan.assignment.quantity }}× {{ orphan.assignment.name }}
+        @if (orphan.assignment.serialNumber) {
+          ({{ i18n.get('resourceSerialNumber') }}: {{ orphan.assignment.serialNumber }})
+        }
+      </li>
+    }
+  </ul>
+}

--- a/packages/app/src/app/resource/deployed/resource-deployed.component.html
+++ b/packages/app/src/app/resource/deployed/resource-deployed.component.html
@@ -12,108 +12,130 @@
   />
 }
 
-@if (rows().length > 0) {
+@if (markerRows().length > 0) {
   <mat-card>
-    <table mat-table [dataSource]="tableRows()" class="deployed-table">
+    <table mat-table [dataSource]="markerRows()" multiTemplateDataRows class="deployed-table">
       <!-- Signature Column -->
       <ng-container matColumnDef="signature">
         <th mat-header-cell *matHeaderCellDef>{{ i18n.get('csvSignatur') }}</th>
-        <td mat-cell *matCellDef="let row">
-          @if (row.signatureSrc && !row.inGroup) {
-            <img [src]="row.signatureSrc" [alt]="row.signatureAlt" class="signature-preview" />
+        <td mat-cell *matCellDef="let marker">
+          @if (marker.signatureSrc) {
+            <img [src]="marker.signatureSrc" [alt]="marker.signatureAlt" class="signature-preview" />
           }
         </td>
-      </ng-container>
-
-      <!-- Article Column -->
-      <ng-container matColumnDef="article">
-        <th mat-header-cell *matHeaderCellDef>{{ i18n.get('resourceArticleName') }}</th>
-        <td mat-cell *matCellDef="let row" [class.grouped-article]="row.inGroup">{{ row.articleLabel }}</td>
       </ng-container>
 
       <!-- Marker Name Column -->
       <ng-container matColumnDef="markerName">
         <th mat-header-cell *matHeaderCellDef>{{ i18n.get('csvLabel') }}</th>
-        <td mat-cell *matCellDef="let row">{{ row.inGroup ? '' : row.markerName }}</td>
+        <td mat-cell *matCellDef="let marker">{{ marker.markerLabel }}</td>
+      </ng-container>
+
+      <!-- Number of resources on this marker -->
+      <ng-container matColumnDef="count">
+        <th mat-header-cell *matHeaderCellDef>{{ i18n.get('resourceMarkerResourceCount') }}</th>
+        <td mat-cell *matCellDef="let marker">{{ marker.assignments.length }}</td>
       </ng-container>
 
       <!-- Report Number Column -->
       <ng-container matColumnDef="reportNumber">
         <th mat-header-cell *matHeaderCellDef>{{ i18n.get('csvReportNumber') }}</th>
-        <td mat-cell *matCellDef="let row">{{ row.inGroup ? '' : row.reportNumber }}</td>
+        <td mat-cell *matCellDef="let marker">{{ marker.reportNumber }}</td>
       </ng-container>
 
       <!-- Location Column -->
       <ng-container matColumnDef="location">
         <th mat-header-cell *matHeaderCellDef>{{ i18n.get('csvLocation') }}</th>
-        <td mat-cell *matCellDef="let row" class="location" (click)="navigateToElement(row)">
-          {{ row.inGroup ? '' : row.location }}
+        <td mat-cell *matCellDef="let marker" class="location" (click)="navigateTo(marker.elementId)">
+          {{ marker.location }}
         </td>
       </ng-container>
 
       <!-- Actions Column -->
       <ng-container matColumnDef="actions">
         <th mat-header-cell *matHeaderCellDef></th>
-        <td mat-cell *matCellDef="let row" class="actions">
+        <td mat-cell *matCellDef="let marker" class="actions">
           <button
             mat-icon-button
             type="button"
-            [attr.aria-label]="i18n.get('resourceTakeBack')"
-            [matTooltip]="i18n.get('resourceTakeBack')"
-            (click)="takeBack(row)"
+            [attr.aria-label]="i18n.get('resourceTakeBackAll')"
+            [matTooltip]="i18n.get('resourceTakeBackAll')"
+            (click)="takeBackAll(marker.elementId)"
           >
-            <mat-icon>undo</mat-icon>
+            <mat-icon>playlist_remove</mat-icon>
           </button>
-          <!-- for a grouped marker this action lives on the group header instead -->
-          @if (!row.inGroup && row.markerAssignmentCount > 1) {
-            <button
-              mat-icon-button
-              type="button"
-              [attr.aria-label]="i18n.get('resourceTakeBackAll')"
-              [matTooltip]="i18n.get('resourceTakeBackAll')"
-              (click)="takeBackAll(row.elementId)"
-            >
-              <mat-icon>playlist_remove</mat-icon>
-            </button>
+        </td>
+      </ng-container>
+
+      <!-- Expand toggle, mirroring the catalogue's "show individual pieces" -->
+      <ng-container matColumnDef="expand">
+        <th mat-header-cell *matHeaderCellDef></th>
+        <td mat-cell *matCellDef="let marker">
+          <button
+            mat-icon-button
+            type="button"
+            [attr.aria-label]="i18n.get('resourceMarkerResourcesToggle')"
+            [matTooltip]="i18n.get('resourceMarkerResourcesToggle')"
+            (click)="toggleExpand(marker)"
+          >
+            <mat-icon>{{ isExpanded(marker) ? 'expand_less' : 'expand_more' }}</mat-icon>
+          </button>
+        </td>
+      </ng-container>
+
+      <!-- The resources of one marker, as the catalogue lists the pieces of an article -->
+      <ng-container matColumnDef="expandedDetail">
+        <td mat-cell *matCellDef="let marker" [attr.colspan]="displayedColumns.length">
+          @if (isExpanded(marker)) {
+            <div class="assignment-table-container">
+              <table mat-table [dataSource]="marker.assignments" class="assignment-table">
+                <ng-container matColumnDef="article">
+                  <th mat-header-cell *matHeaderCellDef>{{ i18n.get('resourceArticleName') }}</th>
+                  <!-- the serial has its own column right next to this one -->
+                  <td mat-cell *matCellDef="let row">{{ row.assignment.quantity }}× {{ row.assignment.name }}</td>
+                </ng-container>
+
+                <ng-container matColumnDef="serialNumber">
+                  <th mat-header-cell *matHeaderCellDef>{{ i18n.get('resourceSerialNumber') }}</th>
+                  <td mat-cell *matCellDef="let row">{{ row.assignment.serialNumber || '–' }}</td>
+                </ng-container>
+
+                <ng-container matColumnDef="storageLocation">
+                  <th mat-header-cell *matHeaderCellDef>{{ i18n.get('resourceStorageLocation') }}</th>
+                  <td mat-cell *matCellDef="let row">{{ row.storageSites.join(', ') || '–' }}</td>
+                </ng-container>
+
+                <ng-container matColumnDef="actions">
+                  <th mat-header-cell *matHeaderCellDef></th>
+                  <td mat-cell *matCellDef="let row" class="actions">
+                    <button
+                      mat-icon-button
+                      type="button"
+                      [attr.aria-label]="i18n.get('resourceTakeBack')"
+                      [matTooltip]="i18n.get('resourceTakeBack')"
+                      (click)="takeBack(row)"
+                    >
+                      <mat-icon>undo</mat-icon>
+                    </button>
+                  </td>
+                </ng-container>
+
+                <tr mat-header-row *matHeaderRowDef="assignmentColumns"></tr>
+                <tr mat-row *matRowDef="let row; columns: assignmentColumns"></tr>
+              </table>
+            </div>
           }
         </td>
       </ng-container>
 
-      <!-- Group header: one marker carrying several resources, spanning the whole table width -->
-      <ng-container matColumnDef="group">
-        <td mat-cell *matCellDef="let row" [attr.colspan]="displayedColumns.length" class="group-cell">
-          <div class="group-header">
-            @if (row.signatureSrc) {
-              <img [src]="row.signatureSrc" [alt]="row.signatureAlt" class="signature-preview" />
-            }
-            <div class="group-text">
-              <span class="group-label">{{ row.markerLabel }}</span>
-              <span class="group-meta">
-                {{ row.count }} {{ i18n.get('resourceMarkerGroupCount') }}
-                @if (row.reportNumber) {
-                  · {{ i18n.get('csvReportNumber') }} {{ row.reportNumber }}
-                }
-              </span>
-            </div>
-            @if (row.location) {
-              <span class="group-location location" (click)="navigateToElement(row)">{{ row.location }}</span>
-            }
-            <button
-              mat-icon-button
-              type="button"
-              [attr.aria-label]="i18n.get('resourceTakeBackAll')"
-              [matTooltip]="i18n.get('resourceTakeBackAll')"
-              (click)="takeBackAll(row.elementId)"
-            >
-              <mat-icon>playlist_remove</mat-icon>
-            </button>
-          </div>
-        </td>
-      </ng-container>
-
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: ['group']; when: isGroupRow" class="group-row"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns" [class.grouped-row]="row.inGroup"></tr>
+      <tr mat-row *matRowDef="let marker; columns: displayedColumns" class="element-row"></tr>
+      <tr
+        mat-row
+        *matRowDef="let marker; columns: ['expandedDetail']"
+        class="detail-row"
+        [class.expanded]="isExpanded(marker)"
+      ></tr>
     </table>
   </mat-card>
 } @else if (allRowsCount() > 0) {

--- a/packages/app/src/app/resource/deployed/resource-deployed.component.scss
+++ b/packages/app/src/app/resource/deployed/resource-deployed.component.scss
@@ -25,55 +25,35 @@ mat-card {
   padding-left: 1.25rem;
 }
 
-// One marker carrying several resources: its identity is stated once in a group header, and
-// its resources are indented under it instead of repeating the same marker data per row.
-.group-row td {
+// The resources of one marker, laid out exactly like the catalogue's individual pieces:
+// an expandable detail row holding a nested table on a tinted surface.
+.element-row {
+  cursor: default;
+}
+
+.detail-row {
+  height: 0;
+}
+
+.detail-row:not(.expanded) td {
   padding: 0;
-  border-bottom: none;
+  border: none;
+  overflow: hidden;
+  height: 0;
 }
 
-.group-cell {
-  padding: 0.5rem 0.75rem 0.25rem !important;
+.detail-row.expanded td {
+  padding: 0.5rem 0;
+  border-bottom-width: 1px;
 }
 
-.group-header {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
+.assignment-table-container {
+  padding: 0.5rem 1rem 1rem;
+  background: var(--mat-sys-surface-variant, #f5f5f5);
+  border-radius: 0.5rem;
 }
 
-.group-text {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  flex: 1;
-}
-
-.group-label {
-  font-weight: 600;
-}
-
-.group-meta {
-  color: #666;
-  font-size: 0.8rem;
-}
-
-.group-location {
-  color: #666;
-  font-size: 0.85rem;
-  white-space: nowrap;
-}
-
-.grouped-article {
-  padding-left: 1.75rem;
-  position: relative;
-
-  &::before {
-    content: '';
-    position: absolute;
-    left: 0.9rem;
-    top: 0;
-    bottom: 0;
-    border-left: 2px solid #e0e0e0;
-  }
+.assignment-table {
+  width: 100%;
+  background: transparent;
 }

--- a/packages/app/src/app/resource/deployed/resource-deployed.component.scss
+++ b/packages/app/src/app/resource/deployed/resource-deployed.component.scss
@@ -1,0 +1,79 @@
+mat-card {
+  width: 100%;
+  display: block;
+}
+
+.signature-preview {
+  height: 30px;
+  width: auto;
+}
+
+.location {
+  cursor: pointer;
+}
+
+.actions {
+  white-space: nowrap;
+}
+
+.orphan-heading {
+  margin: 1.5rem 0 0.5rem;
+}
+
+.orphan-list {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+// One marker carrying several resources: its identity is stated once in a group header, and
+// its resources are indented under it instead of repeating the same marker data per row.
+.group-row td {
+  padding: 0;
+  border-bottom: none;
+}
+
+.group-cell {
+  padding: 0.5rem 0.75rem 0.25rem !important;
+}
+
+.group-header {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.group-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+
+.group-label {
+  font-weight: 600;
+}
+
+.group-meta {
+  color: #666;
+  font-size: 0.8rem;
+}
+
+.group-location {
+  color: #666;
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.grouped-article {
+  padding-left: 1.75rem;
+  position: relative;
+
+  &::before {
+    content: '';
+    position: absolute;
+    left: 0.9rem;
+    top: 0;
+    bottom: 0;
+    border-left: 2px solid #e0e0e0;
+  }
+}

--- a/packages/app/src/app/resource/deployed/resource-deployed.component.ts
+++ b/packages/app/src/app/resource/deployed/resource-deployed.component.ts
@@ -1,0 +1,260 @@
+import { Component, Signal, computed, inject, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { map } from 'rxjs';
+import { IZsMapBaseDrawElementState, ResourceAssignment, ResourceAvailability } from '@zskarte/types';
+import { ZsMapStateService } from '../../state/state.service';
+import { I18NService } from '../../state/i18n.service';
+import { ResourceService } from '../resource.service';
+import { ResourceCatalogueFilterComponent } from '../catalogue/resource-catalogue-filter.component';
+import { ResourcePlacementService } from '../placement/resource-placement.service';
+import { Signs } from '../../map-renderer/signs';
+import { DrawStyle } from '../../map-renderer/draw-style';
+import { convertTo, projection_LV95 } from '../../helper/projections';
+import { getCenter } from 'ol/extent';
+import { MatTableModule } from '@angular/material/table';
+import { MatCard } from '@angular/material/card';
+import { MatDialog } from '@angular/material/dialog';
+import { ConfirmationDialogComponent } from '../../confirmation-dialog/confirmation-dialog.component';
+import { EmptyComponent, EmptyHeaderComponent, EmptyMediaComponent, EmptyTitleComponent, EmptyDescriptionComponent } from '../../ui/empty';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+
+interface DeployedRow {
+  kind: 'item';
+  /** True when this row is listed under a group header, i.e. its marker carries several resources. */
+  inGroup: boolean;
+  elementId: string;
+  assignment: ResourceAssignment;
+  /** Resolved from the catalogue for filtering; undefined when the article is no longer in it. */
+  articleGroup?: string;
+  articleType?: string;
+  storageSites: string[];
+  /** How many resource assignments the marker of this row carries in total. */
+  markerAssignmentCount: number;
+  signatureSrc?: string;
+  signatureAlt: string;
+  articleLabel: string;
+  markerName: string;
+  reportNumber: string;
+  location: string;
+}
+
+/**
+ * Header row standing for one marker that carries several resources: the marker's identity
+ * (pictogram, name, message, location) is shown once here instead of being repeated - and
+ * silently looking like unrelated rows - on every one of its resources.
+ */
+interface DeployedGroupRow {
+  kind: 'group';
+  elementId: string;
+  markerLabel: string;
+  signatureSrc?: string;
+  signatureAlt: string;
+  reportNumber: string;
+  location: string;
+  /** Resources of this marker currently listed (filters can hide some of them). */
+  count: number;
+  /** Total resources on the marker, which "take back all" acts on. */
+  totalCount: number;
+}
+
+type DeployedTableRow = DeployedRow | DeployedGroupRow;
+
+@Component({
+  selector: 'app-resource-deployed',
+  imports: [
+    MatTableModule,
+    MatCard,
+    MatIconModule,
+    MatTooltipModule,
+    ResourceCatalogueFilterComponent,
+    EmptyComponent,
+    EmptyHeaderComponent,
+    EmptyMediaComponent,
+    EmptyTitleComponent,
+    EmptyDescriptionComponent,
+  ],
+  templateUrl: './resource-deployed.component.html',
+  styleUrl: './resource-deployed.component.scss',
+})
+export class ResourceDeployedComponent {
+  private state = inject(ZsMapStateService);
+  private placement = inject(ResourcePlacementService);
+  private dialog = inject(MatDialog);
+  resourceService = inject(ResourceService);
+  i18n = inject(I18NService);
+
+  displayedColumns: string[] = ['signature', 'article', 'markerName', 'reportNumber', 'location', 'actions'];
+
+  private readonly drawElements: Signal<IZsMapBaseDrawElementState[]> = toSignal(
+    this.state.observeMapState().pipe(map((mapState) => Object.values(mapState?.drawElements ?? {}))),
+    { initialValue: [] },
+  );
+
+  /** Filter state, mirroring the catalogue's filter bar (availability is meaningless here). */
+  readonly search = signal('');
+  readonly selectedGroups = signal<string[]>([]);
+  readonly selectedTypes = signal<string[]>([]);
+  readonly selectedStorageSites = signal<string[]>([]);
+  readonly selectedAvailability = signal<ResourceAvailability[]>([]);
+
+  private readonly allRows: Signal<DeployedRow[]> = computed(() => this.buildRows());
+
+  /** Total deployed rows ignoring filters - decides whether the filter bar is shown at all. */
+  readonly allRowsCount = computed(() => this.allRows().length);
+
+  readonly rows: Signal<DeployedRow[]> = computed(() => {
+    const term = this.search().trim().toLowerCase();
+    const groups = this.selectedGroups();
+    const types = this.selectedTypes();
+    const sites = this.selectedStorageSites();
+    if (!term && !groups.length && !types.length && !sites.length) {
+      return this.allRows();
+    }
+    return this.allRows().filter((row) => {
+      if (groups.length && !groups.includes(row.articleGroup ?? '')) return false;
+      if (types.length && !types.includes(row.articleType ?? '')) return false;
+      if (sites.length && !row.storageSites.some((site) => sites.includes(site))) return false;
+      if (!term) return true;
+      return [
+        row.assignment.articleNumber,
+        row.assignment.name,
+        row.assignment.serialNumber,
+        row.markerName,
+        row.reportNumber,
+      ]
+        .filter(Boolean)
+        .some((value) => (value as string).toLowerCase().includes(term));
+    });
+  });
+
+  /**
+   * The rows as the table renders them: resources of the same marker are kept together under
+   * one group header. A marker with a single (visible) resource stays a plain row - a header
+   * for one item would be noise.
+   */
+  readonly tableRows: Signal<DeployedTableRow[]> = computed(() => {
+    const rows = this.rows();
+    const tableRows: DeployedTableRow[] = [];
+
+    for (let index = 0; index < rows.length; ) {
+      const start = index;
+      while (index < rows.length && rows[index].elementId === rows[start].elementId) {
+        index++;
+      }
+      const group = rows.slice(start, index);
+      const [head] = group;
+      if (group.length === 1) {
+        tableRows.push({ ...head, inGroup: false });
+        continue;
+      }
+      tableRows.push({
+        kind: 'group',
+        elementId: head.elementId,
+        // an unnamed marker is identified by what it depicts, e.g. "Materialdepot"
+        markerLabel: head.markerName || head.signatureAlt,
+        signatureSrc: head.signatureSrc,
+        signatureAlt: head.signatureAlt,
+        reportNumber: head.reportNumber,
+        location: head.location,
+        count: group.length,
+        totalCount: head.markerAssignmentCount,
+      });
+      tableRows.push(...group.map((row) => ({ ...row, inGroup: true })));
+    }
+
+    return tableRows;
+  });
+
+  // skipcq: JS-0105
+  isGroupRow(_index: number, row: DeployedTableRow): boolean {
+    return row.kind === 'group';
+  }
+
+  /** Centres the map on the marker of a group header or a plain row alike. */
+  navigateToElement(row: DeployedTableRow) {
+    this.navigateTo(row.elementId);
+  }
+
+  private buildRows(): DeployedRow[] {
+    const rows: DeployedRow[] = [];
+    for (const element of this.drawElements()) {
+      if (!element.id || !element.resourceItems?.length) continue;
+      const sign = Signs.getSignById(element.symbolId);
+      const signatureSrc = sign?.src ? DrawStyle.getImageUrl(sign.src) : undefined;
+      const signatureAlt = sign ? this.i18n.getLabelForSign(sign) : '';
+      const markerName = element.name ?? '';
+      const reportNumber = (Array.isArray(element.reportNumber) ? element.reportNumber : [element.reportNumber])
+        .filter((n) => n !== undefined && n !== null)
+        .join(', ');
+      const location = element.coordinates
+        ? (convertTo(element.coordinates as [number, number], projection_LV95!, false) as string)
+        : '';
+
+      for (const assignment of element.resourceItems) {
+        // group/type/storage are not stored on the assignment (it keeps only a name snapshot),
+        // so they are resolved from the catalogue; they stay undefined for orphaned entries.
+        const article = this.resourceService.findArticle(assignment.articleNumber);
+        const storageSites = article
+          ? [
+              ...new Set(
+                article.items
+                  .filter((item) => !assignment.itemKey || item.itemKey === assignment.itemKey)
+                  .map((item) => item.storageLocation2 ?? item.storageLocation)
+                  .filter((site): site is string => !!site),
+              ),
+            ]
+          : [];
+        rows.push({
+          kind: 'item',
+          inGroup: false,
+          elementId: element.id,
+          assignment,
+          articleGroup: article?.articleGroup,
+          articleType: article?.articleType,
+          storageSites,
+          markerAssignmentCount: element.resourceItems.length,
+          signatureSrc,
+          signatureAlt,
+          articleLabel: this.formatAssignment(assignment),
+          markerName,
+          reportNumber,
+          location,
+        });
+      }
+    }
+    return rows;
+  }
+
+  private formatAssignment(assignment: ResourceAssignment): string {
+    const base = `${assignment.quantity}× ${assignment.name}`;
+    return assignment.serialNumber ? `${base} (${this.i18n.get('resourceSerialNumber')}: ${assignment.serialNumber})` : base;
+  }
+
+  navigateTo(elementId: string) {
+    if (elementId) {
+      this.state.setSelectedFeature(elementId);
+      const extent = this.state.getDrawElement(elementId)?.getOlFeature()?.getGeometry()?.getExtent();
+      if (extent) {
+        this.state.setMapCenter(getCenter(extent));
+      }
+    }
+  }
+
+  /** Returns just this row's assignment to stock. */
+  takeBack(row: DeployedRow) {
+    this.placement.takeBack(row.elementId, row.assignment);
+  }
+
+  /** Returns every assignment of a marker to stock and deletes the marker - confirmed since it is destructive. */
+  takeBackAll(elementId: string) {
+    const confirm = this.dialog.open(ConfirmationDialogComponent, {
+      data: { message: this.i18n.get('resourceTakeBackConfirm') },
+    });
+    confirm.afterClosed().subscribe((result) => {
+      if (result) {
+        this.placement.takeBackAll(elementId);
+      }
+    });
+  }
+}

--- a/packages/app/src/app/resource/deployed/resource-deployed.component.ts
+++ b/packages/app/src/app/resource/deployed/resource-deployed.component.ts
@@ -19,10 +19,8 @@ import { EmptyComponent, EmptyHeaderComponent, EmptyMediaComponent, EmptyTitleCo
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 
+/** One resource on one marker - a row of the nested table inside an expanded marker. */
 interface DeployedRow {
-  kind: 'item';
-  /** True when this row is listed under a group header, i.e. its marker carries several resources. */
-  inGroup: boolean;
   elementId: string;
   assignment: ResourceAssignment;
   /** Resolved from the catalogue for filtering; undefined when the article is no longer in it. */
@@ -33,32 +31,27 @@ interface DeployedRow {
   markerAssignmentCount: number;
   signatureSrc?: string;
   signatureAlt: string;
-  articleLabel: string;
   markerName: string;
   reportNumber: string;
   location: string;
 }
 
 /**
- * Header row standing for one marker that carries several resources: the marker's identity
- * (pictogram, name, message, location) is shown once here instead of being repeated - and
- * silently looking like unrelated rows - on every one of its resources.
+ * One marker, grouping the resources it carries - the top-level row of this table, mirroring
+ * how the catalogue lists an article and expands to its individual pieces. The marker's
+ * identity (pictogram, name, message, location) is stated once here instead of being repeated
+ * on every resource, where identical rows looked like unrelated markers.
  */
-interface DeployedGroupRow {
-  kind: 'group';
+interface DeployedMarkerRow {
   elementId: string;
+  /** The marker's name, or what its pictogram depicts when it has none ("Materialdepot"). */
   markerLabel: string;
   signatureSrc?: string;
   signatureAlt: string;
   reportNumber: string;
   location: string;
-  /** Resources of this marker currently listed (filters can hide some of them). */
-  count: number;
-  /** Total resources on the marker, which "take back all" acts on. */
-  totalCount: number;
+  assignments: DeployedRow[];
 }
-
-type DeployedTableRow = DeployedRow | DeployedGroupRow;
 
 @Component({
   selector: 'app-resource-deployed',
@@ -84,7 +77,9 @@ export class ResourceDeployedComponent {
   resourceService = inject(ResourceService);
   i18n = inject(I18NService);
 
-  displayedColumns: string[] = ['signature', 'article', 'markerName', 'reportNumber', 'location', 'actions'];
+  displayedColumns: string[] = ['signature', 'markerName', 'count', 'reportNumber', 'location', 'actions', 'expand'];
+  /** Columns of the nested table listing the resources of one marker. */
+  assignmentColumns: string[] = ['article', 'serialNumber', 'storageLocation', 'actions'];
 
   private readonly drawElements: Signal<IZsMapBaseDrawElementState[]> = toSignal(
     this.state.observeMapState().pipe(map((mapState) => Object.values(mapState?.drawElements ?? {}))),
@@ -129,51 +124,59 @@ export class ResourceDeployedComponent {
   });
 
   /**
-   * The rows as the table renders them: resources of the same marker are kept together under
-   * one group header. A marker with a single (visible) resource stays a plain row - a header
-   * for one item would be noise.
+   * The markers the table lists, each carrying its own resources - built by grouping the
+   * filtered rows, which `buildRows()` already emits marker by marker.
    */
-  readonly tableRows: Signal<DeployedTableRow[]> = computed(() => {
-    const rows = this.rows();
-    const tableRows: DeployedTableRow[] = [];
+  readonly markerRows: Signal<DeployedMarkerRow[]> = computed(() => {
+    const byElement = new Map<string, DeployedMarkerRow>();
 
-    for (let index = 0; index < rows.length; ) {
-      const start = index;
-      while (index < rows.length && rows[index].elementId === rows[start].elementId) {
-        index++;
+    for (const row of this.rows()) {
+      let marker = byElement.get(row.elementId);
+      if (!marker) {
+        marker = {
+          elementId: row.elementId,
+          markerLabel: row.markerName || row.signatureAlt,
+          signatureSrc: row.signatureSrc,
+          signatureAlt: row.signatureAlt,
+          reportNumber: row.reportNumber,
+          location: row.location,
+          assignments: [],
+        };
+        byElement.set(row.elementId, marker);
       }
-      const group = rows.slice(start, index);
-      const [head] = group;
-      if (group.length === 1) {
-        tableRows.push({ ...head, inGroup: false });
-        continue;
-      }
-      tableRows.push({
-        kind: 'group',
-        elementId: head.elementId,
-        // an unnamed marker is identified by what it depicts, e.g. "Materialdepot"
-        markerLabel: head.markerName || head.signatureAlt,
-        signatureSrc: head.signatureSrc,
-        signatureAlt: head.signatureAlt,
-        reportNumber: head.reportNumber,
-        location: head.location,
-        count: group.length,
-        totalCount: head.markerAssignmentCount,
-      });
-      tableRows.push(...group.map((row) => ({ ...row, inGroup: true })));
+      marker.assignments.push(row);
     }
 
-    return tableRows;
+    return [...byElement.values()];
   });
 
-  // skipcq: JS-0105
-  isGroupRow(_index: number, row: DeployedTableRow): boolean {
-    return row.kind === 'group';
+  /** Markers the user expanded by hand; a filter expands everything on top of that (see `isExpanded`). */
+  private readonly expandedElementIds = signal<ReadonlySet<string>>(new Set());
+
+  private readonly hasActiveFilter = computed(
+    () =>
+      !!this.search().trim() ||
+      this.selectedGroups().length > 0 ||
+      this.selectedTypes().length > 0 ||
+      this.selectedStorageSites().length > 0,
+  );
+
+  /**
+   * Expanded while filtering: a marker is listed because one of its resources matched, so
+   * collapsing it would hide the very thing that was searched for.
+   */
+  isExpanded(marker: DeployedMarkerRow): boolean {
+    return this.hasActiveFilter() || this.expandedElementIds().has(marker.elementId);
   }
 
-  /** Centres the map on the marker of a group header or a plain row alike. */
-  navigateToElement(row: DeployedTableRow) {
-    this.navigateTo(row.elementId);
+  toggleExpand(marker: DeployedMarkerRow): void {
+    const next = new Set(this.expandedElementIds());
+    if (next.has(marker.elementId)) {
+      next.delete(marker.elementId);
+    } else {
+      next.add(marker.elementId);
+    }
+    this.expandedElementIds.set(next);
   }
 
   private buildRows(): DeployedRow[] {
@@ -206,8 +209,6 @@ export class ResourceDeployedComponent {
             ]
           : [];
         rows.push({
-          kind: 'item',
-          inGroup: false,
           elementId: element.id,
           assignment,
           articleGroup: article?.articleGroup,
@@ -216,7 +217,6 @@ export class ResourceDeployedComponent {
           markerAssignmentCount: element.resourceItems.length,
           signatureSrc,
           signatureAlt,
-          articleLabel: this.formatAssignment(assignment),
           markerName,
           reportNumber,
           location,
@@ -224,11 +224,6 @@ export class ResourceDeployedComponent {
       }
     }
     return rows;
-  }
-
-  private formatAssignment(assignment: ResourceAssignment): string {
-    const base = `${assignment.quantity}× ${assignment.name}`;
-    return assignment.serialNumber ? `${base} (${this.i18n.get('resourceSerialNumber')}: ${assignment.serialNumber})` : base;
   }
 
   navigateTo(elementId: string) {

--- a/packages/app/src/app/resource/formations/resource-formation-table.component.html
+++ b/packages/app/src/app/resource/formations/resource-formation-table.component.html
@@ -1,0 +1,62 @@
+@if (resources$ | async; as resources) {
+  @if (resources.length > 0) {
+    <mat-card>
+      <table mat-table [dataSource]="resources" class="resource-table">
+        <!-- Organization Column -->
+        <ng-container matColumnDef="organization">
+          <th mat-header-cell *matHeaderCellDef>{{ i18n.get('organization') }}</th>
+          <td mat-cell *matCellDef="let row">{{ row.organization }}</td>
+        </ng-container>
+
+        <!-- Formation Location Column -->
+        <ng-container matColumnDef="formationLocation">
+          <th mat-header-cell *matHeaderCellDef>{{ i18n.get('formationLocation') }}</th>
+          <td mat-cell *matCellDef="let row">{{ row.formationLocation }}</td>
+        </ng-container>
+
+        <!-- Hierarchy Level Column -->
+        <ng-container matColumnDef="hierarchyLevel">
+          <th mat-header-cell *matHeaderCellDef>{{ i18n.get('hierarchyLevel') }}</th>
+          <td mat-cell *matCellDef="let row">{{ row.hierarchyLevel }}</td>
+        </ng-container>
+
+        <!-- Formation Number Column -->
+        <ng-container matColumnDef="formationNumber">
+          <th mat-header-cell *matHeaderCellDef>{{ i18n.get('formationNumber') }}</th>
+          <td mat-cell *matCellDef="let row">{{ row.formationNumber }}</td>
+        </ng-container>
+
+        <!-- Formation Detail Column -->
+        <ng-container matColumnDef="formationDetail">
+          <th mat-header-cell *matHeaderCellDef>{{ i18n.get('formationDetail') }}</th>
+          <td mat-cell *matCellDef="let row">{{ row.formationDetail }}</td>
+        </ng-container>
+
+        <!-- Additional Info Column -->
+        <ng-container matColumnDef="additionalInfo">
+          <th mat-header-cell *matHeaderCellDef>{{ i18n.get('additionalInfo') }}</th>
+          <td mat-cell *matCellDef="let row">{{ row.additionalInfo }}</td>
+        </ng-container>
+
+        <!-- Location Column -->
+        <ng-container matColumnDef="location">
+          <th mat-header-cell *matHeaderCellDef>{{ i18n.get('csvLocation') }}</th>
+          <td mat-cell *matCellDef="let row" class="location" (click)="navigateTo(row)">{{ row.location }}</td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+      </table>
+    </mat-card>
+  } @else {
+    <app-empty>
+      <app-empty-header>
+        <app-empty-media variant="icon">
+          <mat-icon>groups</mat-icon>
+        </app-empty-media>
+        <app-empty-title>{{ i18n.get('resourceNoFormations') }}</app-empty-title>
+        <app-empty-description>{{ i18n.get('resourceNoFormationsHint') }}</app-empty-description>
+      </app-empty-header>
+    </app-empty>
+  }
+}

--- a/packages/app/src/app/resource/formations/resource-formation-table.component.scss
+++ b/packages/app/src/app/resource/formations/resource-formation-table.component.scss
@@ -1,0 +1,7 @@
+mat-card {
+  width: 100%;
+}
+
+.location {
+  cursor: pointer;
+}

--- a/packages/app/src/app/resource/formations/resource-formation-table.component.ts
+++ b/packages/app/src/app/resource/formations/resource-formation-table.component.ts
@@ -1,0 +1,119 @@
+import { Component, DestroyRef, inject } from '@angular/core';
+import { ZsMapStateService } from '../../state/state.service';
+import { I18NService } from '../../state/i18n.service';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { HierarchyLevel, ZsMapDrawElementState } from '@zskarte/types';
+import { map } from 'rxjs';
+import { MatTableModule } from '@angular/material/table';
+import { AsyncPipe } from '@angular/common';
+import { MatCard } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import {
+  EmptyComponent,
+  EmptyHeaderComponent,
+  EmptyMediaComponent,
+  EmptyTitleComponent,
+  EmptyDescriptionComponent,
+} from '../../ui/empty';
+import { convertTo, projection_LV95 } from '../../helper/projections';
+import { ZsMapBaseDrawElement } from '../../map-renderer/elements/base/base-draw-element';
+import { Signs } from '../../map-renderer/signs';
+import { SimpleGeometry } from 'ol/geom';
+import { getCenter } from 'ol/extent';
+
+interface FormationRow {
+  id: string;
+  organization: string;
+  formationLocation: string;
+  hierarchyLevel: string;
+  formationNumber: string;
+  formationDetail: string;
+  additionalInfo: string;
+  location: string;
+}
+
+@Component({
+  selector: 'app-resource-formation-table',
+  imports: [
+    MatTableModule,
+    AsyncPipe,
+    MatCard,
+    MatIconModule,
+    EmptyComponent,
+    EmptyHeaderComponent,
+    EmptyMediaComponent,
+    EmptyTitleComponent,
+    EmptyDescriptionComponent,
+  ],
+  templateUrl: './resource-formation-table.component.html',
+  styleUrl: './resource-formation-table.component.scss',
+})
+export class ResourceFormationTableComponent {
+  private state = inject(ZsMapStateService);
+  private destroyRef = inject(DestroyRef);
+  i18n = inject(I18NService);
+
+  readonly FORMATION_SIGN_ID = [Signs.FORMATION_SIGN_ID];
+
+  displayedColumns: string[] = [
+    'organization',
+    'formationLocation',
+    'hierarchyLevel',
+    'formationNumber',
+    'formationDetail',
+    'additionalInfo',
+    'location',
+  ];
+
+  resources$ = this.state.observeDrawElements().pipe(
+    takeUntilDestroyed(this.destroyRef),
+    map((elements) =>
+      elements
+        .filter((e) => this.FORMATION_SIGN_ID.includes(e.elementState?.symbolId as number))
+        .map((e) => this.mapToFormationRow(e)),
+    ),
+  );
+
+  private mapToFormationRow(element: ZsMapBaseDrawElement): FormationRow {
+    const state = element.elementState as ZsMapDrawElementState;
+    const geometry = element.getOlFeature().getGeometry() as SimpleGeometry;
+    return {
+      id: state.id ?? '',
+      organization: state.organization ?? '',
+      formationLocation: state.formationLocation ?? String(state.coordinates) ?? '',
+      hierarchyLevel: this.getHierarchyLabel(state.hierarchyLevel),
+      formationNumber: state.formationNumber ?? '',
+      formationDetail: state.formationDetail ?? '',
+      additionalInfo: state.additionalInfo ?? '',
+      location: convertTo(geometry.getCoordinates() || [], projection_LV95!, false) as string,
+    };
+  }
+
+  private getHierarchyLabel(level?: HierarchyLevel): string {
+    if (!level) return '';
+    switch (level) {
+      case HierarchyLevel.TRUPP:
+        return this.i18n.get('hierarchyTrupp');
+      case HierarchyLevel.GRUPPE:
+        return this.i18n.get('hierarchyGruppe');
+      case HierarchyLevel.ZUG:
+        return this.i18n.get('hierarchyZug');
+      case HierarchyLevel.KOMPANIE:
+        return this.i18n.get('hierarchyKompanie');
+      case HierarchyLevel.BATAILLON:
+        return this.i18n.get('hierarchyBataillon');
+      default:
+        return '';
+    }
+  }
+
+  navigateTo(row: FormationRow) {
+    if (row.id) {
+      this.state.setSelectedFeature(row.id);
+      const extent = this.state.getDrawElement(row.id)?.getOlFeature()?.getGeometry()?.getExtent();
+      if (extent) {
+        this.state.setMapCenter(getCenter(extent));
+      }
+    }
+  }
+}

--- a/packages/app/src/app/resource/import/resource-aggregate.spec.ts
+++ b/packages/app/src/app/resource/import/resource-aggregate.spec.ts
@@ -1,0 +1,178 @@
+// Pure module, no Angular TestBed involved — import the globals explicitly (vitest `globals` is not enabled repo-wide).
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+import { aggregateResourceArticles, slugifyArticleName } from './resource-aggregate';
+import { parseResourceCsv } from './resource-csv.parser';
+
+function loadFixtureBuffer(): ArrayBuffer {
+  const path = new URL('../testing/resource-fixture.csv', import.meta.url);
+  const nodeBuffer = readFileSync(path);
+  return nodeBuffer.buffer.slice(nodeBuffer.byteOffset, nodeBuffer.byteOffset + nodeBuffer.byteLength) as ArrayBuffer;
+}
+
+function aggregateFixture() {
+  const parsed = parseResourceCsv(loadFixtureBuffer());
+  expect(parsed.errors).toEqual([]);
+  return aggregateResourceArticles(parsed.rows);
+}
+
+function byNumber(articles: ReturnType<typeof aggregateFixture>['articles'], articleNumber: string) {
+  const article = articles.find((a) => a.articleNumber === articleNumber);
+  expect(article).toBeDefined();
+  return article!;
+}
+
+describe('slugifyArticleName', () => {
+  it('lowercases, trims and collapses whitespace to dashes while keeping umlauts', () => {
+    expect(slugifyArticleName('Beingummi pro Stück')).toBe('beingummi-pro-stück');
+  });
+
+  it('collapses multiple internal spaces', () => {
+    expect(slugifyArticleName('  Foo   Bar  ')).toBe('foo-bar');
+  });
+});
+
+describe('aggregateResourceArticles (fixture)', () => {
+  it('produces 7 articles and 15 items total', () => {
+    const { articles } = aggregateFixture();
+    expect(articles.length).toBe(7);
+    expect(articles.reduce((sum, a) => sum + a.totalCount, 0)).toBe(15);
+  });
+
+  it('emits one aggregated emptyName warning', () => {
+    const { warnings } = aggregateFixture();
+    const emptyName = warnings.find((w) => w.code === 'emptyName');
+    expect(emptyName).toBeDefined();
+    expect(emptyName!.count).toBe(1);
+  });
+
+  it('counts 2 rows as syntheticNumber', () => {
+    const { warnings } = aggregateFixture();
+    const synthetic = warnings.find((w) => w.code === 'syntheticNumber');
+    expect(synthetic).toBeDefined();
+    expect(synthetic!.count).toBe(2);
+  });
+
+  it('ZM-000680 "Stromaggregat Kirsch": 3 items, all in stock, serialized, deterministic itemKeys with #2 on the higher serialNumberInternal', () => {
+    const { articles } = aggregateFixture();
+    const article = byNumber(articles, 'ZM-000680');
+    expect(article.name).toBe('Stromaggregat "Kirsch"');
+    expect(article.totalCount).toBe(3);
+    expect(article.inStockCount).toBe(3);
+    expect(article.serialized).toBe(true);
+    expect(article.items.map((i) => i.itemKey)).toEqual(['ZM-000680|SN-1', 'ZM-000680|SN-2', 'ZM-000680|SN-2#2']);
+    const dup2 = article.items.find((i) => i.itemKey === 'ZM-000680|SN-2#2');
+    expect(dup2?.serialNumberInternal).toBe('14');
+  });
+
+  it('ZM-000057 "Anhänger ZS": 2 items, 1 in stock (one in Reparatur), comment keeps the newline', () => {
+    const { articles } = aggregateFixture();
+    const article = byNumber(articles, 'ZM-000057');
+    expect(article.totalCount).toBe(2);
+    expect(article.inStockCount).toBe(1);
+    expect(article.items[0].comment).toBe('AG 719 186\nWeisse Nummer');
+  });
+
+  it('ZM-001577: 3 items, not serialized, no itemKeys', () => {
+    const { articles } = aggregateFixture();
+    const article = byNumber(articles, 'ZM-001577');
+    expect(article.totalCount).toBe(3);
+    expect(article.serialized).toBe(false);
+    expect(article.items.every((i) => i.itemKey === undefined)).toBe(true);
+  });
+
+  it('~beingummi-pro-stück: 2 items, syntheticNumber true', () => {
+    const { articles } = aggregateFixture();
+    const article = byNumber(articles, '~beingummi-pro-stück');
+    expect(article.totalCount).toBe(2);
+    expect(article.syntheticNumber).toBe(true);
+  });
+
+  it('ZM-000552: name picks the most frequent spelling, other spelling becomes a nameVariant', () => {
+    const { articles } = aggregateFixture();
+    const article = byNumber(articles, 'ZM-000552');
+    expect(article.name).toBe('Regenjacke 52/56');
+    expect(article.nameVariants).toEqual(['Regenjacke52/56']);
+  });
+
+  it('ZM-000582: storageLocation2 is omitted (the "#VALUE!" normalisation)', () => {
+    const { articles } = aggregateFixture();
+    const article = byNumber(articles, 'ZM-000582');
+    expect(article.items[0].storageLocation2).toBeUndefined();
+  });
+
+  it('ZM-000015: sealed, purchaseDate, unit and coordinates are parsed correctly', () => {
+    const { articles } = aggregateFixture();
+    const article = byNumber(articles, 'ZM-000015');
+    const item = article.items[0];
+    expect(item.sealed).toBe(true);
+    expect(item.purchaseDate).toBe('2024-12-09');
+    expect(article.unit).toBe('Liter');
+    expect(item.coordinates?.[0]).toBeCloseTo(47.547959470582526, 9);
+    expect(item.coordinates?.[1]).toBeCloseTo(7.767585683309598, 9);
+  });
+
+  it('sorts the output by articleNumber ascending', () => {
+    const { articles } = aggregateFixture();
+    const numbers = articles.map((a) => a.articleNumber);
+    const sorted = [...numbers].sort((a, b) => a.localeCompare(b));
+    expect(numbers).toEqual(sorted);
+  });
+
+  it('is deterministic: aggregating the same parsed rows twice yields deeply equal results', () => {
+    const parsed = parseResourceCsv(loadFixtureBuffer());
+    const first = aggregateResourceArticles(parsed.rows);
+    const second = aggregateResourceArticles(parsed.rows);
+    expect(second).toEqual(first);
+  });
+
+  it('never stores empty-string optional fields on items — they are omitted instead', () => {
+    const { articles } = aggregateFixture();
+    for (const article of articles) {
+      for (const item of article.items) {
+        for (const [key, value] of Object.entries(item)) {
+          if (typeof value === 'string' && key !== 'status') {
+            expect(value).not.toBe('');
+          }
+        }
+      }
+    }
+  });
+});
+
+/**
+ * End-to-end over the downloadable template: what someone gets when they fill it in must
+ * aggregate into a usable catalogue - otherwise the example teaches the wrong thing.
+ */
+describe('shipped example template', () => {
+  function aggregateExample() {
+    const path = new URL('../../../assets/doc/resource/mittel-beispiel.csv', import.meta.url);
+    const nodeBuffer = readFileSync(path);
+    const buffer = nodeBuffer.buffer.slice(
+      nodeBuffer.byteOffset,
+      nodeBuffer.byteOffset + nodeBuffer.byteLength,
+    ) as ArrayBuffer;
+    const parsed = parseResourceCsv(buffer);
+    return aggregateResourceArticles(parsed.rows);
+  }
+
+  it('aggregates into four articles without warnings about unusable cells', () => {
+    const { articles, warnings } = aggregateExample();
+    expect(articles.map((a) => a.articleNumber)).toEqual(['ZM-000001', 'ZM-000002', 'ZM-000003', 'ZM-000004']);
+    expect(warnings.filter((warning) => warning.code !== 'syntheticNumber')).toEqual([]);
+  });
+
+  it('shows a serialised article, an interchangeable one and a piece that is not in stock', () => {
+    const { articles } = aggregateExample();
+    const byNumber = new Map(articles.map((article) => [article.articleNumber, article]));
+
+    // three generators, one of them "in Reparatur"
+    expect(byNumber.get('ZM-000001')).toMatchObject({ serialized: true, totalCount: 3, inStockCount: 2 });
+    // three warning vests without serial numbers - a pure quantity
+    expect(byNumber.get('ZM-000002')).toMatchObject({ serialized: false, totalCount: 3, inStockCount: 3 });
+    // the group that maps to its own pictogram
+    expect(byNumber.get('ZM-000003')?.articleGroup).toBe('Transport/Logistik');
+    expect(byNumber.get('ZM-000004')?.articleGroup).toBe('Sanitätsmaterial');
+  });
+});

--- a/packages/app/src/app/resource/import/resource-aggregate.ts
+++ b/packages/app/src/app/resource/import/resource-aggregate.ts
@@ -1,0 +1,311 @@
+import { RESOURCE_STATUS_IN_STOCK, ResourceArticle, ResourceItem } from '@zskarte/types';
+import { ResourceCsvIssue } from './resource-csv.parser';
+
+const internalOrderCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+
+/** Lowercase, trimmed, whitespace collapsed to '-'. Umlauts are kept as-is — the key only has to be deterministic. */
+export function slugifyArticleName(name: string): string {
+  return name.trim().toLowerCase().replace(/\s+/g, '-');
+}
+
+/** Trims a raw CSV cell; treats blank and the literal '#VALUE!' as absent. */
+function cell(value: string | undefined): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (trimmed === '' || trimmed === '#VALUE!') {
+    return undefined;
+  }
+  return trimmed;
+}
+
+/** Picks the most frequent value (ties won by first-seen order) and returns the other distinct values seen. */
+function mostFrequent(values: string[]): { value?: string; variants: string[] } {
+  const counts = new Map<string, number>();
+  const order: string[] = [];
+  for (const value of values) {
+    if (!counts.has(value)) {
+      counts.set(value, 0);
+      order.push(value);
+    }
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  if (order.length === 0) {
+    return { value: undefined, variants: [] };
+  }
+  let best = order[0];
+  let bestCount = counts.get(best) ?? 0;
+  for (const value of order) {
+    const count = counts.get(value) ?? 0;
+    if (count > bestCount) {
+      best = value;
+      bestCount = count;
+    }
+  }
+  return { value: best, variants: order.filter((value) => value !== best) };
+}
+
+function parsePurchaseDate(value: string): string | undefined {
+  const match = /^(\d{1,2})\.(\d{1,2})\.(\d{4})$/.exec(value);
+  if (!match) {
+    return undefined;
+  }
+  const day = Number(match[1]);
+  const month = Number(match[2]);
+  const year = Number(match[3]);
+  const date = new Date(year, month - 1, day);
+  if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
+    return undefined;
+  }
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${year}-${pad(month)}-${pad(day)}`;
+}
+
+function parseCoordinates(value: string): [number, number] | undefined {
+  const parts = value.split(',').map((part) => part.trim());
+  if (parts.length !== 2) {
+    return undefined;
+  }
+  const lat = Number(parts[0]);
+  const lon = Number(parts[1]);
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+    return undefined;
+  }
+  return [lat, lon];
+}
+
+interface ItemEntry {
+  item: ResourceItem;
+  index: number;
+}
+
+interface ArticleBucket {
+  articleNumber: string;
+  syntheticNumber: boolean;
+  names: string[];
+  articleGroups: string[];
+  articleTypes: string[];
+  manufacturers: string[];
+  units: string[];
+  sirenTypes: string[];
+  entries: ItemEntry[];
+}
+
+/**
+ * Assigns `itemKey` to every entry that has a serialNumber. Because (articleNumber,
+ * serialNumber) is not unique in the real data, duplicates within the same serialNumber
+ * are ordered deterministically (by serialNumberInternal, then storageCode, then original
+ * CSV row order) and get '#2', '#3', … appended.
+ */
+function assignItemKeys(articleNumber: string, entries: ItemEntry[]): void {
+  const groups = new Map<string, ItemEntry[]>();
+  for (const entry of entries) {
+    const serialNumber = entry.item.serialNumber;
+    if (!serialNumber) {
+      continue;
+    }
+    const group = groups.get(serialNumber);
+    if (group) {
+      group.push(entry);
+    } else {
+      groups.set(serialNumber, [entry]);
+    }
+  }
+
+  for (const [serialNumber, group] of groups) {
+    const baseKey = `${articleNumber}|${serialNumber}`;
+    if (group.length === 1) {
+      group[0].item.itemKey = baseKey;
+      continue;
+    }
+    const sorted = [...group].sort((a, b) => {
+      const byInternal = internalOrderCollator.compare(a.item.serialNumberInternal ?? '', b.item.serialNumberInternal ?? '');
+      if (byInternal !== 0) {
+        return byInternal;
+      }
+      const byStorage = internalOrderCollator.compare(a.item.storageCode ?? '', b.item.storageCode ?? '');
+      if (byStorage !== 0) {
+        return byStorage;
+      }
+      return a.index - b.index;
+    });
+    sorted.forEach((entry, position) => {
+      entry.item.itemKey = position === 0 ? baseKey : `${baseKey}#${position + 1}`;
+    });
+  }
+}
+
+export function aggregateResourceArticles(rows: Record<string, string>[]): {
+  articles: ResourceArticle[];
+  warnings: ResourceCsvIssue[];
+} {
+  const warnings: ResourceCsvIssue[] = [];
+  let emptyNameCount = 0;
+  let syntheticNumberCount = 0;
+  let badDateCount = 0;
+  let badCoordinatesCount = 0;
+
+  const buckets = new Map<string, ArticleBucket>();
+  const bucketOrder: string[] = [];
+
+  rows.forEach((row, index) => {
+    const name = cell(row['Artikel']);
+    if (!name) {
+      emptyNameCount++;
+      return;
+    }
+
+    const articleNumberRaw = cell(row['Artikelnummer']);
+    const syntheticNumber = !articleNumberRaw;
+    if (syntheticNumber) {
+      syntheticNumberCount++;
+    }
+    const key = articleNumberRaw ?? `~${slugifyArticleName(name)}`;
+
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = {
+        articleNumber: key,
+        syntheticNumber,
+        names: [],
+        articleGroups: [],
+        articleTypes: [],
+        manufacturers: [],
+        units: [],
+        sirenTypes: [],
+        entries: [],
+      };
+      buckets.set(key, bucket);
+      bucketOrder.push(key);
+    }
+
+    bucket.names.push(name);
+    const articleGroup = cell(row['Artikelgruppe']);
+    if (articleGroup) bucket.articleGroups.push(articleGroup);
+    const articleType = cell(row['Artikeltyp']);
+    if (articleType) bucket.articleTypes.push(articleType);
+    const manufacturer = cell(row['Hersteller']);
+    if (manufacturer) bucket.manufacturers.push(manufacturer);
+    const unit = cell(row['Einheit']);
+    if (unit) bucket.units.push(unit);
+    const sirenType = cell(row['Sirenentyp']);
+    if (sirenType) bucket.sirenTypes.push(sirenType);
+
+    const item: ResourceItem = { status: cell(row['Status']) ?? '' };
+
+    const serialNumber = cell(row['Seriennummer']);
+    if (serialNumber) item.serialNumber = serialNumber;
+    const serialNumberInternal = cell(row['Serien-Nr. intern']);
+    if (serialNumberInternal) item.serialNumberInternal = serialNumberInternal;
+    const batch = cell(row['Charge']);
+    if (batch) item.batch = batch;
+    const storageCode = cell(row['Lagerort-Code']);
+    if (storageCode) item.storageCode = storageCode;
+    const storageLocation = cell(row['Lagerort']);
+    if (storageLocation) item.storageLocation = storageLocation;
+    const storageLocation2 = cell(row['Lagerort 2']);
+    if (storageLocation2) item.storageLocation2 = storageLocation2;
+    const comment = cell(row['Kommentar']);
+    if (comment) item.comment = comment;
+
+    const sealedRaw = cell(row['Plombiert']);
+    if (sealedRaw === 'Ja') {
+      item.sealed = true;
+    } else if (sealedRaw === 'Nein') {
+      item.sealed = false;
+    }
+
+    const purchaseDateRaw = cell(row['Kaufdatum']);
+    if (purchaseDateRaw) {
+      const purchaseDate = parsePurchaseDate(purchaseDateRaw);
+      if (purchaseDate) {
+        item.purchaseDate = purchaseDate;
+      } else {
+        badDateCount++;
+      }
+    }
+
+    const coordinatesRaw = cell(row['Koordinaten']);
+    if (coordinatesRaw) {
+      const coordinates = parseCoordinates(coordinatesRaw);
+      if (coordinates) {
+        item.coordinates = coordinates;
+      } else {
+        badCoordinatesCount++;
+      }
+    }
+
+    bucket.entries.push({ item, index });
+  });
+
+  for (const key of bucketOrder) {
+    const bucket = buckets.get(key)!;
+    assignItemKeys(bucket.articleNumber, bucket.entries);
+  }
+
+  const articles: ResourceArticle[] = bucketOrder.map((key) => {
+    const bucket = buckets.get(key)!;
+    const items = bucket.entries.map((entry) => entry.item);
+    const { value: name, variants: nameVariants } = mostFrequent(bucket.names);
+
+    const article: ResourceArticle = {
+      articleNumber: bucket.articleNumber,
+      name: name ?? '',
+      articleGroup: mostFrequent(bucket.articleGroups).value ?? '',
+      articleType: mostFrequent(bucket.articleTypes).value ?? '',
+      serialized: items.some((item) => !!item.serialNumber),
+      totalCount: items.length,
+      inStockCount: items.filter((item) => item.status === RESOURCE_STATUS_IN_STOCK).length,
+      items,
+    };
+
+    if (bucket.syntheticNumber) {
+      article.syntheticNumber = true;
+    }
+    if (nameVariants.length > 0) {
+      article.nameVariants = nameVariants;
+    }
+    const manufacturer = mostFrequent(bucket.manufacturers).value;
+    if (manufacturer) article.manufacturer = manufacturer;
+    const unit = mostFrequent(bucket.units).value;
+    if (unit) article.unit = unit;
+    const sirenType = mostFrequent(bucket.sirenTypes).value;
+    if (sirenType) article.sirenType = sirenType;
+
+    return article;
+  });
+
+  articles.sort((a, b) => a.articleNumber.localeCompare(b.articleNumber));
+
+  if (emptyNameCount > 0) {
+    warnings.push({
+      code: 'emptyName',
+      message: `${emptyNameCount} row(s) were skipped because Artikel was empty.`,
+      count: emptyNameCount,
+    });
+  }
+  if (syntheticNumberCount > 0) {
+    warnings.push({
+      code: 'syntheticNumber',
+      message: `${syntheticNumberCount} row(s) had no Artikelnummer; a synthetic article key was generated.`,
+      count: syntheticNumberCount,
+    });
+  }
+  if (badDateCount > 0) {
+    warnings.push({
+      code: 'badDate',
+      message: `${badDateCount} row(s) had an unparseable Kaufdatum.`,
+      count: badDateCount,
+    });
+  }
+  if (badCoordinatesCount > 0) {
+    warnings.push({
+      code: 'badCoordinates',
+      message: `${badCoordinatesCount} row(s) had unparseable Koordinaten.`,
+      count: badCoordinatesCount,
+    });
+  }
+
+  return { articles, warnings };
+}

--- a/packages/app/src/app/resource/import/resource-csv.parser.spec.ts
+++ b/packages/app/src/app/resource/import/resource-csv.parser.spec.ts
@@ -1,0 +1,165 @@
+// Pure module, no Angular TestBed involved — import the globals explicitly (vitest `globals` is not enabled repo-wide).
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+import { decodeResourceCsv, findHeaderIndex, parseResourceCsv, parseResourceCsvMetadata } from './resource-csv.parser';
+
+function loadFixtureBuffer(): ArrayBuffer {
+  const path = new URL('../testing/resource-fixture.csv', import.meta.url);
+  const nodeBuffer = readFileSync(path);
+  return nodeBuffer.buffer.slice(nodeBuffer.byteOffset, nodeBuffer.byteOffset + nodeBuffer.byteLength) as ArrayBuffer;
+}
+
+describe('resource-csv.parser', () => {
+  describe('parseResourceCsv (fixture)', () => {
+    it('finds the header row at line index 7', () => {
+      const buffer = loadFixtureBuffer();
+      const text = decodeResourceCsv(buffer);
+      const lines = text.split('\n');
+      expect(findHeaderIndex(lines)).toBe(7);
+    });
+
+    it('parses 16 data rows with 38 columns and no fatal errors', () => {
+      const result = parseResourceCsv(loadFixtureBuffer());
+      expect(result.errors).toEqual([]);
+      expect(result.rows.length).toBe(16);
+      expect(Object.keys(result.rows[0]).length).toBe(38);
+    });
+
+    it('unescapes doubled quotes', () => {
+      const result = parseResourceCsv(loadFixtureBuffer());
+      expect(result.rows[0]['Artikel']).toBe('Stromaggregat "Kirsch"');
+    });
+
+    it('decodes windows-1252 umlauts', () => {
+      const result = parseResourceCsv(loadFixtureBuffer());
+      expect(result.rows[3]['Artikel']).toBe('Anhänger ZS');
+    });
+
+    it('preserves an embedded newline inside a quoted cell (critical regression test)', () => {
+      const result = parseResourceCsv(loadFixtureBuffer());
+      expect(result.rows[3]['Kommentar']).toBe('AG 719 186\nWeisse Nummer');
+    });
+
+    it('extracts the source organisation and export timestamp from the metadata rows', () => {
+      const result = parseResourceCsv(loadFixtureBuffer());
+      expect(result.meta.sourceOrganisation).toBe('ZSO Unteres Fricktal');
+      expect(result.meta.sourceExportedAt).toEqual(new Date(2026, 8, 7, 14, 15, 45));
+    });
+
+    it('is deterministic across repeated runs on the same buffer', () => {
+      const first = parseResourceCsv(loadFixtureBuffer());
+      const second = parseResourceCsv(loadFixtureBuffer());
+      expect(second).toEqual(first);
+    });
+  });
+
+  describe('findHeaderIndex', () => {
+    it('returns -1 when the header row is absent', () => {
+      expect(findHeaderIndex(['a;b;c', 'd;e;f'])).toBe(-1);
+    });
+
+    it('finds a header row that starts with Organisation;Status; and contains ;Artikelnummer;', () => {
+      const lines = ['noise', 'Organisation;Status;aktuelle Verwendung;Artikelnummer;Artikel', 'data'];
+      expect(findHeaderIndex(lines)).toBe(1);
+    });
+  });
+
+  describe('parseResourceCsvMetadata', () => {
+    it('never throws and returns an empty object when nothing matches', () => {
+      const lines = ['foo;bar', 'baz;qux'];
+      expect(() => parseResourceCsvMetadata(lines, 2)).not.toThrow();
+      expect(parseResourceCsvMetadata(lines, 2)).toEqual({});
+    });
+
+    it('parses Organisation and Exportiert am rows', () => {
+      const lines = ['Organisation;Acme Corp;;;', 'Exportiert am;01.02.2024;;09:30:00;;'];
+      const meta = parseResourceCsvMetadata(lines, 2);
+      expect(meta.sourceOrganisation).toBe('Acme Corp');
+      expect(meta.sourceExportedAt).toEqual(new Date(2024, 1, 1, 9, 30, 0));
+    });
+
+    it('does not throw on garbage export date/time', () => {
+      const lines = ['Exportiert am;not-a-date;;not-a-time;;'];
+      expect(() => parseResourceCsvMetadata(lines, 1)).not.toThrow();
+      expect(parseResourceCsvMetadata(lines, 1).sourceExportedAt).toBeUndefined();
+    });
+  });
+
+  describe('parseResourceCsv (fatal errors)', () => {
+    it('reports emptyFile for an empty buffer', () => {
+      const result = parseResourceCsv(new ArrayBuffer(0));
+      expect(result.errors.some((e) => e.code === 'emptyFile')).toBe(true);
+      expect(result.rows).toEqual([]);
+    });
+
+    it('reports headerNotFound when there is no matching header row', () => {
+      const buffer = new TextEncoder().encode('foo;bar\nbaz;qux\n').buffer;
+      const result = parseResourceCsv(buffer as ArrayBuffer);
+      expect(result.errors.some((e) => e.code === 'headerNotFound')).toBe(true);
+    });
+
+    it('reports missingColumns listing the missing required columns', () => {
+      const csv = 'Organisation;Status;aktuelle Verwendung;Artikelnummer;Artikel\nZSO;an Lager;;ZM-1;Foo\n';
+      const buffer = new TextEncoder().encode(csv).buffer;
+      const result = parseResourceCsv(buffer as ArrayBuffer);
+      const issue = result.errors.find((e) => e.code === 'missingColumns');
+      expect(issue).toBeDefined();
+      expect(issue!.message).toContain('Artikelgruppe');
+      expect(issue!.message).toContain('Artikeltyp');
+      expect(issue!.message).toContain('Seriennummer');
+      expect(issue!.message).toContain('Lagerort');
+    });
+  });
+});
+
+/**
+ * The template shipped for download (`assets/doc/resource/mittel-beispiel.csv`) is what people
+ * fill in with their own stock, so it has to survive the very same import path as a real
+ * export - including the encoding it happens to be saved in.
+ */
+describe('shipped example template', () => {
+  function loadExampleBuffer(): ArrayBuffer {
+    const path = new URL('../../../assets/doc/resource/mittel-beispiel.csv', import.meta.url);
+    const nodeBuffer = readFileSync(path);
+    return nodeBuffer.buffer.slice(nodeBuffer.byteOffset, nodeBuffer.byteOffset + nodeBuffer.byteLength) as ArrayBuffer;
+  }
+
+  it('parses without fatal errors and keeps its explanatory rows out of the data', () => {
+    const result = parseResourceCsv(loadExampleBuffer());
+    expect(result.errors).toEqual([]);
+    expect(result.rows.length).toBe(9);
+    expect(result.meta.sourceOrganisation).toBe('ZSO Musterstadt');
+  });
+
+  it('keeps umlauts intact - it is stored as utf-8, unlike the windows-1252 export', () => {
+    const result = parseResourceCsv(loadExampleBuffer());
+    const groups = result.rows.map((row) => row['Artikelgruppe']);
+    expect(groups).toContain('Sanitätsmaterial');
+    expect(groups).toContain('Ausrüstung AdZS');
+  });
+
+  it('demonstrates every state the catalogue can show', () => {
+    const result = parseResourceCsv(loadExampleBuffer());
+    const statuses = new Set(result.rows.map((row) => row['Status']));
+    expect(statuses).toEqual(new Set(['an Lager', 'in Reparatur', 'ausgeliehen']));
+    // serialised pieces and interchangeable ones side by side
+    expect(result.rows.some((row) => row['Seriennummer'])).toBe(true);
+    expect(result.rows.some((row) => !row['Seriennummer'])).toBe(true);
+  });
+});
+
+describe('decodeResourceCsv', () => {
+  const header =
+    'Organisation;Status;Artikelnummer;Artikel;Artikelgruppe;Artikeltyp;Seriennummer;Lagerort\nZSO;an Lager;ZM-1;Anhänger;Transport/Logistik;Kat. B;;Lager\n';
+
+  it('decodes a utf-8 file (a filled-in template) without mojibake', () => {
+    const bytes = new TextEncoder().encode(header);
+    expect(decodeResourceCsv(bytes.buffer as ArrayBuffer)).toContain('Anhänger');
+  });
+
+  it('still decodes the windows-1252 export, whose umlauts are single bytes', () => {
+    const bytes = Uint8Array.from(header, (character) => character.charCodeAt(0));
+    expect(decodeResourceCsv(bytes.buffer as ArrayBuffer)).toContain('Anhänger');
+  });
+});

--- a/packages/app/src/app/resource/import/resource-csv.parser.ts
+++ b/packages/app/src/app/resource/import/resource-csv.parser.ts
@@ -1,0 +1,174 @@
+import { inferSchema, initParser } from 'udsv';
+
+/**
+ * Pure, dependency-free CSV parsing for the "Material - Übersicht Bestand" export.
+ *
+ * The export is a windows-1252 encoded CSV with a handful of metadata rows above the
+ * actual header row, `;`-separated columns, `"`-enclosed values (escaped by doubling the
+ * quote) and, unfortunately, at least one column (`Kommentar`) that can contain a bare
+ * `\n` inside a quoted value while every row is otherwise terminated by `\r\n`.
+ */
+
+export interface ResourceCsvIssue {
+  code: string;
+  message: string;
+  line?: number;
+  count?: number;
+}
+
+export interface ResourceCsvParseResult {
+  rows: Record<string, string>[];
+  meta: { sourceOrganisation?: string; sourceExportedAt?: Date };
+  /** Fatal — caller must not import when this is non-empty. */
+  errors: ResourceCsvIssue[];
+  /** Informational. */
+  warnings: ResourceCsvIssue[];
+}
+
+/** Columns that must be present in the header row for the import to make sense. */
+export const RESOURCE_CSV_REQUIRED_COLUMNS = [
+  'Status',
+  'Artikelnummer',
+  'Artikel',
+  'Artikelgruppe',
+  'Artikeltyp',
+  'Seriennummer',
+  'Lagerort',
+];
+
+function normalizeLineEndings(text: string): string {
+  return text.replace(/\r\n?/g, '\n');
+}
+
+/**
+ * Decodes the raw CSV bytes, utf-8 first and windows-1252 (what the export itself uses)
+ * second. Line endings are always normalised to `\n`.
+ *
+ * Being valid utf-8 is the decisive signal, and it is a reliable one: the umlauts of a
+ * windows-1252 export are single bytes (`ü` = 0xFC) that are not legal utf-8, so strict
+ * decoding of a real export throws and the fallback takes over; a pure-ASCII file decodes
+ * identically either way. Sniffing windows-1252 first cannot work: utf-8 umlaut bytes
+ * (`ü` = 0xC3 0xBC) are perfectly valid windows-1252 characters, so a hand-made utf-8 file -
+ * a filled-in template, or an export opened and re-saved in a spreadsheet - was silently
+ * imported as mojibake ("Ausrüstung").
+ */
+export function decodeResourceCsv(buffer: ArrayBuffer): string {
+  try {
+    const utf8Text = normalizeLineEndings(new TextDecoder('utf-8', { fatal: true }).decode(buffer));
+    if (findHeaderIndex(utf8Text.split('\n')) !== -1) {
+      return utf8Text;
+    }
+  } catch {
+    // not valid utf-8 - the windows-1252 export case
+  }
+  return normalizeLineEndings(new TextDecoder('windows-1252').decode(buffer));
+}
+
+/** Finds the index of the actual data header row, or -1 when it cannot be found. */
+export function findHeaderIndex(lines: string[]): number {
+  return lines.findIndex((line) => line.startsWith('Organisation;Status;') && line.includes(';Artikelnummer;'));
+}
+
+function parseSwissDateTime(datePart: string, timePart: string): Date | undefined {
+  const dateMatch = /^(\d{1,2})\.(\d{1,2})\.(\d{4})$/.exec(datePart.trim());
+  if (!dateMatch) {
+    return undefined;
+  }
+  const day = Number(dateMatch[1]);
+  const month = Number(dateMatch[2]);
+  const year = Number(dateMatch[3]);
+
+  let hours = 0;
+  let minutes = 0;
+  let seconds = 0;
+  const timeMatch = /^(\d{1,2}):(\d{1,2}):(\d{1,2})$/.exec(timePart.trim());
+  if (timeMatch) {
+    hours = Number(timeMatch[1]);
+    minutes = Number(timeMatch[2]);
+    seconds = Number(timeMatch[3]);
+  }
+
+  const date = new Date(year, month - 1, day, hours, minutes, seconds);
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+  return date;
+}
+
+/**
+ * Extracts the metadata rows above the header row: `Organisation;<name>;…` and
+ * `Exportiert am;<dd.mm.yyyy>;;<hh:mm:ss>;…`. Never throws; both fields are optional.
+ */
+export function parseResourceCsvMetadata(
+  lines: string[],
+  headerIndex: number,
+): { sourceOrganisation?: string; sourceExportedAt?: Date } {
+  const meta: { sourceOrganisation?: string; sourceExportedAt?: Date } = {};
+  try {
+    for (const line of lines.slice(0, Math.max(headerIndex, 0))) {
+      const cells = line.split(';');
+      const label = (cells[0] ?? '').trim();
+      if (label === 'Organisation') {
+        const value = (cells[1] ?? '').trim();
+        if (value) {
+          meta.sourceOrganisation = value;
+        }
+      } else if (label === 'Exportiert am') {
+        const datePart = cells[1] ?? '';
+        const timePart = cells[3] ?? '';
+        const exportedAt = parseSwissDateTime(datePart, timePart);
+        if (exportedAt) {
+          meta.sourceExportedAt = exportedAt;
+        }
+      }
+    }
+  } catch {
+    // metadata is best-effort — never let it break the import
+  }
+  return meta;
+}
+
+export function parseResourceCsv(buffer: ArrayBuffer): ResourceCsvParseResult {
+  const errors: ResourceCsvIssue[] = [];
+  const warnings: ResourceCsvIssue[] = [];
+  const meta: { sourceOrganisation?: string; sourceExportedAt?: Date } = {};
+
+  if (!buffer || buffer.byteLength === 0) {
+    errors.push({ code: 'emptyFile', message: 'The CSV file is empty.' });
+    return { rows: [], meta, errors, warnings };
+  }
+
+  const text = decodeResourceCsv(buffer);
+  if (text.trim() === '') {
+    errors.push({ code: 'emptyFile', message: 'The CSV file is empty.' });
+    return { rows: [], meta, errors, warnings };
+  }
+
+  const lines = text.split('\n');
+  const headerIndex = findHeaderIndex(lines);
+  if (headerIndex === -1) {
+    errors.push({
+      code: 'headerNotFound',
+      message: 'Could not find the CSV header row (expected a row starting with "Organisation;Status;" containing "Artikelnummer").',
+    });
+    return { rows: [], meta, errors, warnings };
+  }
+
+  Object.assign(meta, parseResourceCsvMetadata(lines, headerIndex));
+
+  const headerColumns = lines[headerIndex].split(';').map((column) => column.trim());
+  const missingColumns = RESOURCE_CSV_REQUIRED_COLUMNS.filter((column) => !headerColumns.includes(column));
+  if (missingColumns.length > 0) {
+    errors.push({
+      code: 'missingColumns',
+      message: `The CSV is missing required column(s): ${missingColumns.join(', ')}.`,
+    });
+    return { rows: [], meta, errors, warnings };
+  }
+
+  const body = lines.slice(headerIndex).join('\n');
+  const schema = inferSchema(body, { col: ';', row: '\n', encl: '"', esc: '"' });
+  const rows = initParser(schema).stringObjs(body);
+
+  return { rows, meta, errors, warnings };
+}

--- a/packages/app/src/app/resource/import/resource-diff.spec.ts
+++ b/packages/app/src/app/resource/import/resource-diff.spec.ts
@@ -1,0 +1,134 @@
+// Pure module, no Angular TestBed involved — import the globals explicitly (vitest `globals` is not enabled repo-wide).
+import { describe, expect, it } from 'vitest';
+import { ResourceArticle, ResourceAssignment } from '@zskarte/types';
+
+import { computeResourceImportPreview } from './resource-diff';
+
+function article(overrides: Partial<ResourceArticle> = {}): ResourceArticle {
+  return {
+    articleNumber: 'ZM-1',
+    name: 'Test Article',
+    articleGroup: 'Group',
+    articleType: 'Type',
+    serialized: false,
+    totalCount: 1,
+    inStockCount: 1,
+    items: [{ status: 'an Lager' }],
+    ...overrides,
+  };
+}
+
+function assignment(overrides: Partial<ResourceAssignment> = {}): ResourceAssignment {
+  return {
+    articleNumber: 'ZM-1',
+    name: 'Test Article',
+    quantity: 1,
+    ...overrides,
+  };
+}
+
+describe('computeResourceImportPreview', () => {
+  it('treats everything as added when current is empty (first import), with no affected assignments', () => {
+    const next = [article({ articleNumber: 'ZM-1' }), article({ articleNumber: 'ZM-2' })];
+    const preview = computeResourceImportPreview([], next, []);
+
+    expect(preview.added).toEqual(next);
+    expect(preview.removed).toEqual([]);
+    expect(preview.changed).toEqual([]);
+    expect(preview.unchanged).toBe(0);
+    expect(preview.affectedAssignments).toEqual([]);
+    expect(preview.totals).toEqual({ articles: 2, items: 2, inStock: 2 });
+  });
+
+  it('detects added, removed, changed and unchanged articles', () => {
+    const current = [
+      article({ articleNumber: 'ZM-1', totalCount: 2, inStockCount: 2 }),
+      article({ articleNumber: 'ZM-2', totalCount: 1, inStockCount: 1 }),
+      article({ articleNumber: 'ZM-3', totalCount: 1, inStockCount: 1 }),
+    ];
+    const next = [
+      article({ articleNumber: 'ZM-1', totalCount: 3, inStockCount: 1 }), // changed
+      article({ articleNumber: 'ZM-3', totalCount: 1, inStockCount: 1 }), // unchanged
+      article({ articleNumber: 'ZM-4' }), // added
+    ];
+
+    const preview = computeResourceImportPreview(current, next, []);
+
+    expect(preview.added.map((a) => a.articleNumber)).toEqual(['ZM-4']);
+    expect(preview.removed.map((a) => a.articleNumber)).toEqual(['ZM-2']);
+    expect(preview.changed).toEqual([
+      { articleNumber: 'ZM-1', name: 'Test Article', oldTotal: 2, newTotal: 3, oldInStock: 2, newInStock: 1 },
+    ]);
+    expect(preview.unchanged).toBe(1);
+  });
+
+  it('flags an assignment as articleRemoved when its article is gone from the next catalogue', () => {
+    const current = [article({ articleNumber: 'ZM-1' })];
+    const next: ResourceArticle[] = [];
+    const assignments = [assignment({ articleNumber: 'ZM-1' })];
+
+    const preview = computeResourceImportPreview(current, next, assignments);
+
+    expect(preview.affectedAssignments).toEqual([{ assignment: assignments[0], reason: 'articleRemoved' }]);
+  });
+
+  it('flags an assignment as serialRemoved when the article survives but its itemKey is gone', () => {
+    const current = [
+      article({
+        articleNumber: 'ZM-1',
+        serialized: true,
+        items: [{ status: 'an Lager', serialNumber: 'SN-1', itemKey: 'ZM-1|SN-1' }],
+      }),
+    ];
+    const next = [
+      article({
+        articleNumber: 'ZM-1',
+        serialized: true,
+        items: [{ status: 'an Lager', serialNumber: 'SN-2', itemKey: 'ZM-1|SN-2' }],
+      }),
+    ];
+    const assignments = [assignment({ articleNumber: 'ZM-1', serialNumber: 'SN-1', itemKey: 'ZM-1|SN-1' })];
+
+    const preview = computeResourceImportPreview(current, next, assignments);
+
+    expect(preview.affectedAssignments).toEqual([{ assignment: assignments[0], reason: 'serialRemoved' }]);
+  });
+
+  it('flags an assignment as overbooked when total assigned quantity exceeds the new inStockCount', () => {
+    const current = [article({ articleNumber: 'ZM-1', totalCount: 5, inStockCount: 5 })];
+    const next = [article({ articleNumber: 'ZM-1', totalCount: 5, inStockCount: 1 })];
+    const assignments = [
+      assignment({ articleNumber: 'ZM-1', quantity: 2 }),
+      assignment({ articleNumber: 'ZM-1', quantity: 1 }),
+    ];
+
+    const preview = computeResourceImportPreview(current, next, assignments);
+
+    expect(preview.affectedAssignments).toEqual([
+      { assignment: assignments[0], reason: 'overbooked' },
+      { assignment: assignments[1], reason: 'overbooked' },
+    ]);
+  });
+
+  it('does not flag an assignment that is still valid within stock', () => {
+    const current = [article({ articleNumber: 'ZM-1', totalCount: 5, inStockCount: 5 })];
+    const next = [article({ articleNumber: 'ZM-1', totalCount: 5, inStockCount: 5 })];
+    const assignments = [assignment({ articleNumber: 'ZM-1', quantity: 2 })];
+
+    const preview = computeResourceImportPreview(current, next, assignments);
+
+    expect(preview.affectedAssignments).toEqual([]);
+  });
+
+  it('yields at most one entry per assignment, preferring articleRemoved over the other reasons', () => {
+    const current = [article({ articleNumber: 'ZM-1', totalCount: 5, inStockCount: 5 })];
+    const next: ResourceArticle[] = [];
+    // would also be "overbooked"-shaped if the article existed, but it does not: only articleRemoved should fire.
+    const assignments = [assignment({ articleNumber: 'ZM-1', quantity: 10 })];
+
+    const preview = computeResourceImportPreview(current, next, assignments);
+
+    expect(preview.affectedAssignments.length).toBe(1);
+    expect(preview.affectedAssignments[0].reason).toBe('articleRemoved');
+  });
+});

--- a/packages/app/src/app/resource/import/resource-diff.ts
+++ b/packages/app/src/app/resource/import/resource-diff.ts
@@ -1,0 +1,86 @@
+import { ResourceArticle, ResourceAssignment } from '@zskarte/types';
+
+export interface ResourceImportPreview {
+  added: ResourceArticle[];
+  removed: ResourceArticle[];
+  changed: { articleNumber: string; name: string; oldTotal: number; newTotal: number; oldInStock: number; newInStock: number }[];
+  unchanged: number;
+  affectedAssignments: { assignment: ResourceAssignment; reason: 'articleRemoved' | 'serialRemoved' | 'overbooked' }[];
+  totals: { articles: number; items: number; inStock: number };
+}
+
+/**
+ * Compares the currently stored catalogue against a freshly parsed one and reports what
+ * would change, plus which existing map assignments would be affected by applying it.
+ */
+export function computeResourceImportPreview(
+  current: ResourceArticle[],
+  next: ResourceArticle[],
+  assignments: ResourceAssignment[],
+): ResourceImportPreview {
+  const currentByNumber = new Map(current.map((article) => [article.articleNumber, article]));
+  const nextByNumber = new Map(next.map((article) => [article.articleNumber, article]));
+
+  const added: ResourceArticle[] = [];
+  const changed: ResourceImportPreview['changed'] = [];
+  let unchanged = 0;
+
+  for (const article of next) {
+    const previous = currentByNumber.get(article.articleNumber);
+    if (!previous) {
+      added.push(article);
+    } else if (previous.totalCount !== article.totalCount || previous.inStockCount !== article.inStockCount) {
+      changed.push({
+        articleNumber: article.articleNumber,
+        name: article.name,
+        oldTotal: previous.totalCount,
+        newTotal: article.totalCount,
+        oldInStock: previous.inStockCount,
+        newInStock: article.inStockCount,
+      });
+    } else {
+      unchanged++;
+    }
+  }
+
+  const removed: ResourceArticle[] = current.filter((article) => !nextByNumber.has(article.articleNumber));
+
+  const nextItemKeysByArticle = new Map<string, Set<string>>();
+  for (const article of next) {
+    const keys = new Set<string>();
+    for (const item of article.items) {
+      if (item.itemKey) keys.add(item.itemKey);
+    }
+    nextItemKeysByArticle.set(article.articleNumber, keys);
+  }
+
+  const assignedQtyByArticle = new Map<string, number>();
+  for (const assignment of assignments) {
+    assignedQtyByArticle.set(assignment.articleNumber, (assignedQtyByArticle.get(assignment.articleNumber) ?? 0) + assignment.quantity);
+  }
+
+  const affectedAssignments: ResourceImportPreview['affectedAssignments'] = [];
+  for (const assignment of assignments) {
+    const nextArticle = nextByNumber.get(assignment.articleNumber);
+    if (!nextArticle) {
+      affectedAssignments.push({ assignment, reason: 'articleRemoved' });
+      continue;
+    }
+    if (assignment.itemKey && !nextItemKeysByArticle.get(assignment.articleNumber)?.has(assignment.itemKey)) {
+      affectedAssignments.push({ assignment, reason: 'serialRemoved' });
+      continue;
+    }
+    const totalAssigned = assignedQtyByArticle.get(assignment.articleNumber) ?? 0;
+    if (totalAssigned > nextArticle.inStockCount) {
+      affectedAssignments.push({ assignment, reason: 'overbooked' });
+    }
+  }
+
+  const totals = {
+    articles: next.length,
+    items: next.reduce((sum, article) => sum + article.totalCount, 0),
+    inStock: next.reduce((sum, article) => sum + article.inStockCount, 0),
+  };
+
+  return { added, removed, changed, unchanged, affectedAssignments, totals };
+}

--- a/packages/app/src/app/resource/import/resource-import-dialog.component.html
+++ b/packages/app/src/app/resource/import/resource-import-dialog.component.html
@@ -1,0 +1,70 @@
+<app-dialog-header>
+  <h2>{{ step() === 'file' ? i18n.get('resourceImportTitle') : i18n.get('resourceImportPreviewTitle') }}</h2>
+</app-dialog-header>
+
+<app-dialog-body>
+  @if (step() === 'file') {
+    <div class="file-step">
+      <p class="hint">
+        {{ i18n.get('resourceImportHint') }}
+        <a class="example-csv" [href]="exampleCsvUrl" [attr.download]="exampleCsvFileName">
+          <mat-icon>download</mat-icon>
+          {{ i18n.get('resourceExampleCsv') }}
+        </a>
+      </p>
+      <p class="hint">{{ i18n.get('resourceExampleCsvHint') }}</p>
+      <input type="file" accept=".csv" #fileInput (change)="onFileSelected()" />
+      @if (parsing()) {
+        <mat-spinner diameter="24"></mat-spinner>
+      }
+    </div>
+  }
+
+  @if (step() === 'preview') {
+    <div class="preview-step">
+      <div class="file-summary">
+        <strong>{{ fileName() }}</strong>
+        <span>
+          {{ i18n.get('resourceImportReadSummary') }}: {{ parseResult()?.rows?.length ?? 0 }}
+          {{ i18n.get('resourceImportRows') }} · {{ aggregateResult()?.articles?.length ?? 0 }}
+          {{ i18n.get('resourceImportArticles') }}
+        </span>
+      </div>
+
+      <!-- Only blocking problems are shown: without them the disabled commit button would be
+           unexplained. Everything else (diff, per-row notices) was noise and is gone. -->
+      @if ((parseResult()?.errors?.length ?? 0) > 0) {
+        <div class="notice error-block">
+          <h3>{{ i18n.get('resourceImportErrors') }}</h3>
+          <ul>
+            @for (issue of parseResult()?.errors; track issue.code + (issue.line ?? '')) {
+              <li>{{ issue.message }}</li>
+            }
+          </ul>
+        </div>
+      }
+
+      @if (commitError()) {
+        <p class="notice error-block">{{ commitError() }}</p>
+      }
+    </div>
+  }
+</app-dialog-body>
+
+<app-dialog-footer>
+  @if (step() === 'file') {
+    <button mat-button (click)="cancel()">{{ i18n.get('cancel') }}</button>
+    <button mat-flat-button color="primary" [disabled]="!fileName() || parsing()" (click)="readFile()">
+      {{ i18n.get('resourceImportRead') }}
+    </button>
+  } @else {
+    <button mat-button (click)="backToFileStep()">{{ i18n.get('resourceImportSelectFile') }}</button>
+    <button mat-flat-button color="primary" [disabled]="!canCommit()" (click)="commitImport()">
+      @if (committing()) {
+        <mat-spinner diameter="18"></mat-spinner>
+      } @else {
+        {{ i18n.get('resourceImportCommit') }}
+      }
+    </button>
+  }
+</app-dialog-footer>

--- a/packages/app/src/app/resource/import/resource-import-dialog.component.scss
+++ b/packages/app/src/app/resource/import/resource-import-dialog.component.scss
@@ -1,0 +1,79 @@
+.file-step {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.hint {
+  color: #666;
+  margin: 0;
+}
+
+.preview-step {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.file-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.diff-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.unchanged-count {
+  color: #666;
+  margin: 0;
+}
+
+.notice {
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+  background: #f5f5f5;
+
+  h3 {
+    margin: 0 0 0.5rem;
+  }
+
+  ul {
+    margin: 0;
+    padding-left: 1.25rem;
+  }
+}
+
+.notice.warning {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  background: #fff4e5;
+  color: #7a4a00;
+}
+
+.notice.error-block {
+  background: #fdecea;
+  color: #a11c1c;
+}
+
+// Reads as part of the sentence explaining the format, not as a separate action.
+.example-csv {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  margin-left: 0.35rem;
+  color: #1a56db;
+  text-decoration: underline;
+  white-space: nowrap;
+
+  mat-icon {
+    font-size: 1rem;
+    width: 1rem;
+    height: 1rem;
+  }
+}

--- a/packages/app/src/app/resource/import/resource-import-dialog.component.ts
+++ b/packages/app/src/app/resource/import/resource-import-dialog.component.ts
@@ -1,0 +1,142 @@
+import { Component, ElementRef, computed, inject, signal, viewChild } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { v4 as uuidv4 } from 'uuid';
+import { ResourceArticle, ResourceImportRequestApi } from '@zskarte/types';
+import { MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { DialogHeaderComponent, DialogBodyComponent, DialogFooterComponent } from '../../ui/dialog-layout';
+import { I18NService } from '../../state/i18n.service';
+import { SessionService } from '../../session/session.service';
+import { ResourceService } from '../resource.service';
+import { parseResourceCsv, ResourceCsvIssue, ResourceCsvParseResult } from './resource-csv.parser';
+import { aggregateResourceArticles } from './resource-aggregate';
+
+type ImportStep = 'file' | 'preview';
+
+interface AggregateResult {
+  articles: ResourceArticle[];
+  warnings: ResourceCsvIssue[];
+}
+
+@Component({
+  selector: 'app-resource-import-dialog',
+  imports: [
+    MatButtonModule,
+    MatIconModule,
+    MatProgressSpinnerModule,
+    DialogHeaderComponent,
+    DialogBodyComponent,
+    DialogFooterComponent,
+  ],
+  templateUrl: './resource-import-dialog.component.html',
+  styleUrl: './resource-import-dialog.component.scss',
+})
+export class ResourceImportDialogComponent {
+  /** Self-documenting template offered next to the file picker; see `ResourceOverviewComponent`. */
+  readonly exampleCsvUrl = 'assets/doc/resource/mittel-beispiel.csv';
+  readonly exampleCsvFileName = 'mittel-beispiel.csv';
+
+  private dialogRef = inject<MatDialogRef<ResourceImportDialogComponent, boolean>>(MatDialogRef);
+  private session = inject(SessionService);
+  private snackBar = inject(MatSnackBar);
+  resourceService = inject(ResourceService);
+  i18n = inject(I18NService);
+
+  readonly fileInput = viewChild.required<ElementRef<HTMLInputElement>>('fileInput');
+
+  readonly step = signal<ImportStep>('file');
+  readonly fileName = signal<string | undefined>(undefined);
+  readonly parsing = signal(false);
+  readonly committing = signal(false);
+  readonly commitError = signal<string | undefined>(undefined);
+
+  readonly parseResult = signal<ResourceCsvParseResult | undefined>(undefined);
+  readonly aggregateResult = signal<AggregateResult | undefined>(undefined);
+
+  readonly canCommit = computed(
+    () => !!this.aggregateResult() && (this.parseResult()?.errors.length ?? 0) === 0 && !this.committing(),
+  );
+
+  onFileSelected(): void {
+    const file = this.fileInput().nativeElement.files?.[0];
+    this.fileName.set(file?.name);
+  }
+
+  async readFile(): Promise<void> {
+    const file = this.fileInput().nativeElement.files?.[0];
+    if (!file) {
+      return;
+    }
+    this.parsing.set(true);
+    this.commitError.set(undefined);
+    try {
+      const buffer = await file.arrayBuffer();
+      const parseResult = parseResourceCsv(buffer);
+      this.parseResult.set(parseResult);
+      this.aggregateResult.set(parseResult.errors.length === 0 ? aggregateResourceArticles(parseResult.rows) : undefined);
+      this.step.set('preview');
+    } finally {
+      this.parsing.set(false);
+    }
+  }
+
+  backToFileStep(): void {
+    this.step.set('file');
+    this.parseResult.set(undefined);
+    this.aggregateResult.set(undefined);
+    this.commitError.set(undefined);
+  }
+
+  async commitImport(): Promise<void> {
+    const articles = this.aggregateResult()?.articles;
+    if (!articles) {
+      return;
+    }
+    const operation = this.session.getOperationId();
+    const organization = this.session.getOrganization()?.documentId;
+    if (!operation || !organization) {
+      this.commitError.set(this.i18n.get('resourceImportOnlineOnly'));
+      return;
+    }
+
+    this.committing.set(true);
+    this.commitError.set(undefined);
+    const meta = this.parseResult()?.meta;
+    const request: ResourceImportRequestApi = {
+      importId: uuidv4(),
+      sourceExportedAt: meta?.sourceExportedAt,
+      sourceOrganisation: meta?.sourceOrganisation,
+      operation,
+      organization,
+      articles,
+    };
+    try {
+      const { error } = await this.resourceService.commitImport(request);
+      if (error) {
+        this.commitError.set(this.describeError(error));
+        return;
+      }
+      this.snackBar.open(this.i18n.get('resourceImportSuccess'), 'OK', { duration: 3000 });
+      this.dialogRef.close(true);
+    } finally {
+      this.committing.set(false);
+    }
+  }
+
+  cancel(): void {
+    this.dialogRef.close(false);
+  }
+
+  private describeError(error: unknown): string {
+    if (error instanceof HttpErrorResponse) {
+      return (error.error?.error?.message as string | undefined) || error.message;
+    }
+    if (error instanceof Error) {
+      return error.message;
+    }
+    return String(error);
+  }
+}

--- a/packages/app/src/app/resource/placement/resource-deploy-dialog.component.html
+++ b/packages/app/src/app/resource/placement/resource-deploy-dialog.component.html
@@ -1,0 +1,166 @@
+<app-dialog-header>
+  <h2>{{ i18n.get('resourceDeployTitle') }}</h2>
+</app-dialog-header>
+
+<app-dialog-body>
+  <section class="section">
+    <h3>{{ i18n.get('resourceDeploySelection') }}</h3>
+    <ul class="selection-list">
+      @for (selection of selections; track selection.article.articleNumber) {
+        <li class="selection-row">
+          @let signature = selectionSignature(selection);
+          <img
+            [src]="signature.url"
+            [alt]="signature.label"
+            [matTooltip]="signature.label"
+            class="signature-icon"
+            [class.placeholder]="signature.isPlaceholder"
+          />
+          <span class="selection-label">{{ selectionLabel(selection) }}</span>
+          @if (signature.isPlaceholder) {
+            <mat-icon class="placeholder-hint" [matTooltip]="i18n.get('resourcePlaceholderSign')">info</mat-icon>
+          }
+        </li>
+      }
+    </ul>
+  </section>
+
+  <section class="section">
+    <h3>{{ i18n.get('resourceDeployMessage') }}</h3>
+    <mat-form-field appearance="outline" subscriptSizing="dynamic">
+      <mat-select [ngModel]="messageNumber()" (ngModelChange)="messageNumber.set($event)">
+        <mat-option [value]="undefined">{{ i18n.get('resourceDeployMessageNone') }}</mat-option>
+        @for (entry of journalEntries(); track entry.messageNumber) {
+          <mat-option [value]="entry.messageNumber">{{ journalEntryLabel(entry) }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+    @if (fromJournalHint()) {
+      <div class="hint">{{ i18n.get('resourceDeployFromJournal') }}</div>
+    }
+  </section>
+
+  <section class="section location-section">
+    <h3>{{ i18n.get('resourceDeployLocation') }}</h3>
+
+    @if (pickedLocationLabel(); as label) {
+      <div class="location-chosen">
+        <mat-icon>place</mat-icon>
+        <div class="location-chosen-text">
+          <span class="location-chosen-caption">{{ i18n.get('resourceDeployLocationChosen') }}</span>
+          <span class="location-label">{{ label }}</span>
+        </div>
+      </div>
+    }
+
+    <!--
+      The input and <app-search-autocomplete> must stay together in the SAME, unconditional
+      view - exactly as geocoder.component.html and text-area-with-address-search do it.
+      `autocompleteRef` is a @ViewChild inside the child component, so it is only resolved
+      after that child's view init; if the [matAutocomplete] binding sits in a conditional
+      branch it is evaluated in a different pass and flips undefined -> object, which trips
+      NG0100. Keeping the field always visible also lets the user simply search again.
+    -->
+    <mat-form-field appearance="outline" subscriptSizing="dynamic" class="location-search-field">
+      <input
+        matInput
+        [placeholder]="i18n.get('resourceDeployLocationSearch')"
+        [matAutocomplete]="locationAutocomplete.autocompleteRef"
+        [ngModel]="locationSearchTerm()"
+        (ngModelChange)="locationSearchTerm.set($event)"
+      />
+      <mat-icon class="search" matSuffix>search</mat-icon>
+    </mat-form-field>
+    <app-search-autocomplete
+      #locationAutocomplete
+      [searchTerm]="locationSearchTerm()"
+      [foundLocations]="locationResults()"
+      (selected)="locationSelected($event)"
+    ></app-search-autocomplete>
+
+    @if (!pickedLocationLabel()) {
+      <div class="hint">{{ i18n.get('resourceDeployLocationRequired') }}</div>
+    }
+
+    <div class="location-alternatives">
+      <span class="hint">{{ i18n.get('resourceDeployLocationAlternatives') }}</span>
+      <button mat-stroked-button type="button" (click)="placeAtCenter()">
+        <mat-icon>my_location</mat-icon>
+        {{ i18n.get('resourceDeployAtCenter') }}
+      </button>
+      <button mat-stroked-button type="button" (click)="placeOnMap()">
+        <mat-icon>touch_app</mat-icon>
+        {{ i18n.get('resourceDeploy') }}
+      </button>
+    </div>
+  </section>
+
+  <section class="section">
+    <h3>{{ i18n.get('resourceDeployMode') }}</h3>
+    <mat-radio-group [ngModel]="mode()" (ngModelChange)="mode.set($event)" class="mode-group">
+      <mat-radio-button value="collection">
+        {{ i18n.get('resourceDeployCollection') }}
+        <span class="hint">{{ i18n.get('resourceDeployCollectionHint') }}</span>
+      </mat-radio-button>
+      <mat-radio-button value="single">
+        {{ i18n.get('resourceDeploySingle') }}
+        <span class="hint">{{ i18n.get('resourceDeploySingleHint') }}</span>
+      </mat-radio-button>
+    </mat-radio-group>
+    @if (manyMarkersWarning()) {
+      <div class="warning">
+        <mat-icon>warning</mat-icon>
+        {{ i18n.get('resourceDeployManyMarkersWarning') }}
+      </div>
+    }
+
+    <div class="subsection">
+      <span class="subheading">{{ i18n.get('resourceDeploySignature') }}</span>
+      @if (mode() === 'collection') {
+        @let signature = collectionSignature();
+        <div class="signature-row">
+          <img
+            [src]="signature.url"
+            [alt]="signature.label"
+            class="signature-icon large"
+            [class.placeholder]="signature.isPlaceholder"
+          />
+          <span class="selection-label">{{ signature.label }}</span>
+          <button mat-stroked-button type="button" (click)="changeSignature()">
+            <mat-icon>cached</mat-icon>
+            {{ i18n.get('resourceDeployChangeSignature') }}
+          </button>
+        </div>
+      } @else {
+        <ul class="selection-list">
+          @for (signature of singleSignatures(); track signature.url + signature.label) {
+            <li class="selection-row">
+              <img
+                [src]="signature.url"
+                [alt]="signature.label"
+                class="signature-icon"
+                [class.placeholder]="signature.isPlaceholder"
+              />
+              <span class="selection-label">{{ signature.label }}</span>
+            </li>
+          }
+        </ul>
+      }
+    </div>
+
+    @if (mode() === 'collection') {
+      <mat-form-field appearance="outline" subscriptSizing="dynamic" class="name-field">
+        <mat-label>{{ i18n.get('resourceDeployName') }}</mat-label>
+        <input matInput type="text" [ngModel]="name()" (ngModelChange)="name.set($event)" />
+      </mat-form-field>
+    }
+  </section>
+</app-dialog-body>
+
+<app-dialog-footer>
+  <button mat-stroked-button type="button" (click)="cancel()">{{ i18n.get('cancel') }}</button>
+  <button mat-flat-button color="primary" type="button" [disabled]="!pickedCoordinates()" (click)="placeAtLocation()">
+    <mat-icon>place</mat-icon>
+    {{ i18n.get('resourceDeployAtLocation') }}
+  </button>
+</app-dialog-footer>

--- a/packages/app/src/app/resource/placement/resource-deploy-dialog.component.scss
+++ b/packages/app/src/app/resource/placement/resource-deploy-dialog.component.scss
@@ -1,0 +1,154 @@
+.section {
+  margin-bottom: 1.5rem;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  h3 {
+    margin: 0 0 0.5rem;
+    font-size: 0.9rem;
+    font-weight: bold;
+  }
+
+  mat-form-field {
+    width: 100%;
+  }
+}
+
+.selection-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.selection-row,
+.signature-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.selection-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.signature-icon {
+  width: 28px;
+  height: 28px;
+  object-fit: contain;
+  flex-shrink: 0;
+
+  &.large {
+    width: 36px;
+    height: 36px;
+  }
+
+  &.placeholder {
+    opacity: 0.45;
+    filter: grayscale(1);
+  }
+}
+
+.placeholder-hint {
+  color: #787878;
+  font-size: 1.1rem;
+  height: 1.1rem;
+  width: 1.1rem;
+  flex-shrink: 0;
+}
+
+.mode-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.hint {
+  display: block;
+  color: #787878;
+  font-size: 0.8rem;
+}
+
+.warning {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  color: var(--mat-form-field-error-text-color, #b00020);
+  font-size: 0.85rem;
+}
+
+.subsection {
+  margin-top: 1rem;
+}
+
+.subheading {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-size: 0.8rem;
+  font-weight: bold;
+  color: #787878;
+}
+
+.name-field {
+  margin-top: 1rem;
+}
+
+.location-section {
+  .location-search-field {
+    width: 100%;
+  }
+
+  .hint {
+    margin-bottom: 0.5rem;
+  }
+}
+
+.location-chosen {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.04);
+
+  .location-chosen-text {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .location-chosen-caption {
+    font-size: 0.75rem;
+    color: #787878;
+  }
+
+  .location-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-weight: 500;
+  }
+}
+
+.location-alternatives {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+
+  .hint {
+    flex-basis: 100%;
+  }
+}

--- a/packages/app/src/app/resource/placement/resource-deploy-dialog.component.ts
+++ b/packages/app/src/app/resource/placement/resource-deploy-dialog.component.ts
@@ -1,0 +1,290 @@
+import { AfterViewInit, ChangeDetectorRef, Component, computed, inject, signal, viewChild, effect } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { MatAutocompleteModule, MatAutocompleteTrigger } from '@angular/material/autocomplete';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatSelectModule } from '@angular/material/select';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { getCenter } from 'ol/extent';
+import { fromLonLat } from 'ol/proj';
+import { IResultSet, IZsMapSearchResult, Sign } from '@zskarte/types';
+import { DrawStyle } from '../../map-renderer/draw-style';
+import { Signs } from '../../map-renderer/signs';
+import { JournalEntry } from '../../journal/journal.types';
+import { JournalService } from '../../journal/journal.service';
+import { I18NService } from '../../state/i18n.service';
+import { ZsMapStateService } from '../../state/state.service';
+import { SearchService } from '../../search/search.service';
+import { SearchAutocompleteComponent } from '../../search/search-autocomplete/search-autocomplete.component';
+import { SelectSignDialog } from '../../select-sign-dialog/select-sign-dialog.component';
+import { DialogHeaderComponent, DialogBodyComponent, DialogFooterComponent } from '../../ui/dialog-layout';
+import { resolveCollectionSignId, resolveResourceSignId } from '../resource-signature.mapping';
+import {
+  ResourceDeployRequest,
+  ResourceDeploySelection,
+  ResourcePlacementService,
+  countSingleModeMarkers,
+} from './resource-placement.service';
+
+export interface ResourceDeployDialogData {
+  selections: ResourceDeploySelection[];
+}
+
+/** Rendered signature (pictogram) preview - reused for the selection list and the signature section. */
+interface SignaturePreview {
+  url: string;
+  label: string;
+  isPlaceholder: boolean;
+}
+
+const MANY_MARKERS_THRESHOLD = 50;
+
+/**
+ * Dialog for placing catalogue resources on the map: pick the resources (done before this
+ * dialog opens), link them to a journal message, search an address/coordinate (or use the map
+ * centre / a map click as alternatives) to place them, and optionally override how they're
+ * drawn. Placing itself is delegated entirely to `ResourcePlacementService` - this component
+ * never mutates map state directly.
+ */
+@Component({
+  selector: 'app-resource-deploy-dialog',
+  imports: [
+    FormsModule,
+    MatAutocompleteModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatRadioModule,
+    MatSelectModule,
+    MatTooltipModule,
+    SearchAutocompleteComponent,
+    DialogHeaderComponent,
+    DialogBodyComponent,
+    DialogFooterComponent,
+  ],
+  templateUrl: './resource-deploy-dialog.component.html',
+  styleUrl: './resource-deploy-dialog.component.scss',
+})
+export class ResourceDeployDialogComponent implements AfterViewInit {
+  private readonly data = inject<ResourceDeployDialogData>(MAT_DIALOG_DATA);
+  private readonly dialogRef = inject<MatDialogRef<ResourceDeployDialogComponent>>(MatDialogRef);
+  private readonly dialog = inject(MatDialog);
+  private readonly state = inject(ZsMapStateService);
+  private readonly journal = inject(JournalService);
+  private readonly search = inject(SearchService);
+  private readonly placement = inject(ResourcePlacementService);
+  private readonly cdr = inject(ChangeDetectorRef);
+  i18n = inject(I18NService);
+
+  readonly selections = this.data.selections;
+
+  readonly mode = signal<'collection' | 'single'>('collection');
+  readonly name = signal('');
+  readonly symbolOverride = signal<number | undefined>(undefined);
+  readonly messageNumber = signal<number | undefined>(undefined);
+
+  // Address/coordinate search for the "Ort" step - wired to the very same
+  // `SearchService.createGlobalSearchInstance(...)` the main map's `app-geocoder` uses, so
+  // free-text addresses and raw coordinates both work here exactly as they do there.
+  readonly locationSearchTerm = signal('');
+  readonly locationResults = signal<IResultSet[]>([]);
+  readonly pickedLocation = signal<IZsMapSearchResult | null>(null);
+  private readonly locationAutocompleteTrigger = viewChild(MatAutocompleteTrigger);
+
+  /**
+   * The picked result's map (Web-Mercator) coordinate - `deploy()`'s placement point.
+   *
+   * Resolved asynchronously because not every search result carries a coordinate directly:
+   * street results (e.g. "Pappelnweg, 4310 Rheinfelden") only come with a geometry `feature`,
+   * and some results only reference one via `internal.origin`/`featureId` and must be fetched.
+   * This mirrors the precedence in `SearchService.highlightResult()`.
+   */
+  readonly pickedCoordinates = signal<number[] | undefined>(undefined);
+
+  readonly pickedLocationLabel = computed(() => this.pickedLocation()?.label.replace(/<[^>]*>/g, ''));
+
+  readonly journalEntries = computed(() =>
+    [...this.journal.data()].sort((a, b) => b.messageNumber - a.messageNumber),
+  );
+  readonly fromJournalHint = computed(() => {
+    const activeEntry = this.journal.drawingEntry;
+    return !!activeEntry && activeEntry.messageNumber === this.messageNumber();
+  });
+
+  readonly defaultCollectionSymbolId = computed(() =>
+    resolveCollectionSignId(this.selections.map((selection) => selection.article)),
+  );
+  readonly effectiveSymbolId = computed(() => this.symbolOverride() ?? this.defaultCollectionSymbolId());
+  readonly collectionSignature = computed(() => this.toPreview(this.effectiveSymbolId()));
+
+  readonly singleSignatures = computed<SignaturePreview[]>(() => {
+    const seen = new Set<number>();
+    const previews: SignaturePreview[] = [];
+    for (const selection of this.selections) {
+      const symbolId = resolveResourceSignId(selection.article);
+      if (seen.has(symbolId)) {
+        continue;
+      }
+      seen.add(symbolId);
+      previews.push(this.toPreview(symbolId));
+    }
+    return previews;
+  });
+
+  readonly markerCount = computed(() => (this.mode() === 'single' ? countSingleModeMarkers(this.selections) : 1));
+  readonly manyMarkersWarning = computed(() => this.markerCount() > MANY_MARKERS_THRESHOLD);
+
+  constructor() {
+    const activeEntry = this.journal.drawingEntry;
+    if (activeEntry) {
+      this.messageNumber.set(activeEntry.messageNumber);
+    }
+
+    const searchConfig = this.state.getSearchConfig();
+    const { searchResults$, updateSearchTerm } = this.search.createGlobalSearchInstance(
+      searchConfig,
+      this.locationSearchTerm,
+    );
+
+    searchResults$.pipe(takeUntilDestroyed()).subscribe((newResultSets) => {
+      if (newResultSets === null) {
+        // request aborted by a newer search
+        return;
+      }
+      this.locationResults.set(newResultSets);
+      if (this.locationSearchTerm().length > 1) {
+        this.locationAutocompleteTrigger()?.openPanel();
+      }
+    });
+
+    effect(() => updateSearchTerm(this.locationSearchTerm()));
+  }
+
+  /**
+   * `<app-search-autocomplete>` exposes its MatAutocomplete via its own @ViewChild, resolved only
+   * after that child's view init - i.e. after this dialog's first change-detection pass already
+   * read `[matAutocomplete]`. Inside a MatDialog that ordering trips NG0100, so run one extra
+   * pass once the view exists. (geocoder.component.ts does not hit this: it is not rendered
+   * through a dialog portal.)
+   */
+  ngAfterViewInit(): void {
+    this.cdr.detectChanges();
+  }
+
+  selectionLabel(selection: ResourceDeploySelection): string {
+    return `${selection.quantity} × ${selection.article.name}`;
+  }
+
+  selectionSignature(selection: ResourceDeploySelection): SignaturePreview {
+    return this.toPreview(resolveResourceSignId(selection.article));
+  }
+
+  journalEntryLabel(entry: JournalEntry): string {
+    return `#${entry.messageNumber} · ${entry.messageSubject}`;
+  }
+
+  changeSignature(): void {
+    const ref = this.dialog.open(SelectSignDialog);
+    ref.afterClosed().subscribe((sign: Sign | undefined) => {
+      if (sign?.id !== undefined) {
+        this.symbolOverride.set(sign.id as number);
+      }
+    });
+  }
+
+  async locationSelected(value: IZsMapSearchResult): Promise<void> {
+    this.pickedLocation.set(value);
+    this.locationSearchTerm.set('');
+    this.pickedCoordinates.set(undefined);
+    this.pickedCoordinates.set(await this.resolveCoordinate(value));
+  }
+
+  /** Same precedence as `SearchService.highlightResult()`: coordinate, lonLat, geometry, centre. */
+  private async resolveCoordinate(result: IZsMapSearchResult): Promise<number[] | undefined> {
+    if (result.mercatorCoordinates) {
+      return result.mercatorCoordinates;
+    }
+    if (result.lonLat) {
+      return fromLonLat(result.lonLat);
+    }
+    let feature = result.feature;
+    if (!feature && result.internal?.origin && result.internal?.featureId) {
+      feature =
+        (await this.search.geoAdminGeometryByOriginAndId(
+          result.internal.origin,
+          result.internal.featureId,
+          result.internal.layer,
+        )) ?? undefined;
+    }
+    const extent = feature?.getGeometry()?.getExtent();
+    if (extent) {
+      return getCenter(extent);
+    }
+    return result.internal?.center;
+  }
+
+  placeAtLocation(): void {
+    const coordinates = this.pickedCoordinates();
+    if (!coordinates) {
+      return;
+    }
+    const request = this.buildRequest();
+    this.placement.deploy(request, coordinates);
+    this.closeForPlacement();
+  }
+
+  placeOnMap(): void {
+    const request = this.buildRequest();
+    this.placement.startClickPlacement(request);
+    this.closeForPlacement();
+  }
+
+  placeAtCenter(): void {
+    const request = this.buildRequest();
+    this.placement.deploy(request, this.state.getMapCenter());
+    this.closeForPlacement();
+  }
+
+  cancel(): void {
+    this.dialogRef.close();
+  }
+
+  private buildRequest(): ResourceDeployRequest {
+    const mode = this.mode();
+    return {
+      mode,
+      selections: this.selections,
+      name: mode === 'collection' ? this.name().trim() || undefined : undefined,
+      symbolId: mode === 'collection' ? this.symbolOverride() : undefined,
+      messageNumber: this.messageNumber(),
+    };
+  }
+
+  /**
+   * Closes this dialog and, with it, every other open dialog - so the map behind them is
+   * actually visible once resources are placed. The catalogue table that opens this dialog
+   * (`ResourceCatalogueComponent.deploy()`) is itself shown inside `ResourceOverviewComponent`,
+   * opened as its own full-size MatDialog by `sidebar-menu.component.ts`; neither hands this
+   * component their `MatDialogRef`, so closing every open dialog from here is the only way to
+   * guarantee that overview dialog doesn't keep covering the map after placement. Nothing reads
+   * this dialog's close result, so dropping it is safe.
+   */
+  private closeForPlacement(): void {
+    this.dialog.closeAll();
+  }
+
+  private toPreview(symbolId: number): SignaturePreview {
+    const sign = Signs.getSignById(symbolId);
+    return {
+      url: sign ? DrawStyle.getSignatureURI(sign) : '',
+      label: sign ? this.i18n.getLabelForSign(sign) : '',
+      isPlaceholder: symbolId === Signs.RESOURCE_PLACEHOLDER_SIGN_ID,
+    };
+  }
+}

--- a/packages/app/src/app/resource/placement/resource-placement-overlay.component.html
+++ b/packages/app/src/app/resource/placement/resource-placement-overlay.component.html
@@ -1,0 +1,12 @@
+@if (placement.pendingLabel(); as label) {
+  <div class="placement-infos mat-elevation-z3">
+    <mat-icon>touch_app</mat-icon>
+    <div class="placement-text">
+      <span class="hint">{{ i18n.get('resourceDeployOnMap') }}</span>
+      <span class="label">{{ label }}</span>
+    </div>
+    <button mat-icon-button [attr.aria-label]="i18n.get('cancel')" (click)="cancel()">
+      <mat-icon>close</mat-icon>
+    </button>
+  </div>
+}

--- a/packages/app/src/app/resource/placement/resource-placement-overlay.component.scss
+++ b/packages/app/src/app/resource/placement/resource-placement-overlay.component.scss
@@ -1,0 +1,30 @@
+.placement-infos {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  box-sizing: border-box;
+  border-radius: 2rem;
+  background-color: white;
+  padding: 0.75rem 0.75rem 0.75rem 1rem;
+  pointer-events: auto;
+  width: 100%;
+}
+
+.placement-text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+
+  .hint {
+    color: #666;
+    font-size: 0.8rem;
+  }
+
+  .label {
+    font-weight: bold;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}

--- a/packages/app/src/app/resource/placement/resource-placement-overlay.component.ts
+++ b/packages/app/src/app/resource/placement/resource-placement-overlay.component.ts
@@ -1,0 +1,24 @@
+import { Component, inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { I18NService } from '../../state/i18n.service';
+import { ResourcePlacementService } from './resource-placement.service';
+
+/**
+ * Floating banner shown while a resource placement is waiting for a map click, started by
+ * `ResourcePlacementService.startClickPlacement(...)`. Modelled on `journal-draw-overlay`.
+ */
+@Component({
+  selector: 'app-resource-placement-overlay',
+  imports: [MatButtonModule, MatIconModule],
+  templateUrl: './resource-placement-overlay.component.html',
+  styleUrl: './resource-placement-overlay.component.scss',
+})
+export class ResourcePlacementOverlayComponent {
+  placement = inject(ResourcePlacementService);
+  i18n = inject(I18NService);
+
+  cancel(): void {
+    this.placement.cancelClickPlacement();
+  }
+}

--- a/packages/app/src/app/resource/placement/resource-placement.service.ts
+++ b/packages/app/src/app/resource/placement/resource-placement.service.ts
@@ -1,0 +1,438 @@
+import { Injectable, inject, signal } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { Subscription } from 'rxjs';
+import { filter, map, take } from 'rxjs/operators';
+import {
+  ResourceArticle,
+  ResourceAssignment,
+  ZsMapDrawElementState,
+  ZsMapDrawElementStateType,
+  ZsMapLayerState,
+  ZsMapLayerStateType,
+} from '@zskarte/types';
+import { ZsMapStateService } from '../../state/state.service';
+import { I18NService } from '../../state/i18n.service';
+import { JournalService } from '../../journal/journal.service';
+import { GuestLimitDialogComponent } from '../../guest-limit-dialog/guest-limit-dialog.component';
+import { resolveCollectionSignId, resolveResourceSignId } from '../resource-signature.mapping';
+import { ResourceAddOption, appendResourceAssignment } from '../resource-assignment-picker';
+
+/**
+ * Name of the shared draw layer that collects every deployed resource. Kept as a plain
+ * constant, NOT an i18n lookup: this name is written into the shared operation data, so every
+ * team member must see and match the very same layer name regardless of their own UI language.
+ */
+export const RESOURCE_LAYER_NAME = 'Mittel im Einsatz';
+
+/** Pending selection for one article, as produced by the resource catalogue's multi-select. */
+export interface ResourceDeploySelection {
+  article: ResourceArticle;
+  quantity: number;
+  itemKeys: string[];
+}
+
+/** Everything the placement dialog gathered from the user; deploying does not mutate it. */
+export interface ResourceDeployRequest {
+  mode: 'collection' | 'single';
+  selections: ResourceDeploySelection[];
+  /** Collection mode only. */
+  name?: string;
+  /** Collection mode only - overrides `resolveCollectionSignId(...)`. */
+  symbolId?: number;
+  messageNumber?: number;
+}
+
+/** One marker to be placed on the map: its pictogram, optional label and the resources it carries. */
+interface ResourceMarkerPlan {
+  symbolId: number;
+  name?: string;
+  resourceItems: ResourceAssignment[];
+}
+
+/**
+ * Spacing/angle for the fan-out of markers that share one placement point (single mode with
+ * several pieces, or several markers dropped at the same map-centre click). Map units here are
+ * metres (the map's Web-Mercator projection), so `SPACING` is ~15m between neighbouring rings.
+ * A golden-angle spiral is used so successive markers don't line up radially.
+ */
+const SPACING = 15;
+const GOLDEN_ANGLE = 137.5 * (Math.PI / 180);
+
+function spiralOffset(index: number): [number, number] {
+  if (index <= 0) {
+    return [0, 0];
+  }
+  const angle = index * GOLDEN_ANGLE;
+  const radius = SPACING * Math.sqrt(index);
+  return [radius * Math.cos(angle), radius * Math.sin(angle)];
+}
+
+/**
+ * Splits one catalogue selection into `ResourceAssignment` records: one per serialised piece
+ * (quantity 1, carrying that piece's `itemKey` and `serialNumber`), plus - when the selected
+ * quantity exceeds the number of specific pieces picked - one aggregated record for the
+ * fungible remainder. `ResourceAssignment` only carries a single optional `itemKey`, so a
+ * serialised piece and a generic quantity can never share one record.
+ */
+function buildAssignments(selection: ResourceDeploySelection): ResourceAssignment[] {
+  const { article, quantity, itemKeys } = selection;
+  const assignments: ResourceAssignment[] = itemKeys.map((itemKey) => {
+    const item = article.items.find((candidate) => candidate.itemKey === itemKey);
+    return {
+      articleNumber: article.articleNumber,
+      name: article.name,
+      quantity: 1,
+      serialNumber: item?.serialNumber,
+      itemKey,
+    };
+  });
+
+  const remainder = quantity - itemKeys.length;
+  if (remainder > 0) {
+    assignments.push({ articleNumber: article.articleNumber, name: article.name, quantity: remainder });
+  }
+
+  return assignments;
+}
+
+/** How many individual markers `single` mode would create for this selection set. */
+export function countSingleModeMarkers(selections: ResourceDeploySelection[]): number {
+  return selections.reduce((sum, selection) => sum + buildAssignments(selection).length, 0);
+}
+
+function buildMarkerPlans(request: ResourceDeployRequest): ResourceMarkerPlan[] {
+  if (request.mode === 'collection') {
+    const resourceItems = request.selections.flatMap((selection) => buildAssignments(selection));
+    const symbolId =
+      request.symbolId ?? resolveCollectionSignId(request.selections.map((selection) => selection.article));
+    return [{ symbolId, name: request.name, resourceItems }];
+  }
+
+  return request.selections.flatMap((selection) =>
+    buildAssignments(selection).map((assignment) => ({
+      symbolId: resolveResourceSignId(selection.article),
+      name: assignment.quantity > 1 ? `${assignment.quantity}× ${assignment.name}` : assignment.name,
+      resourceItems: [assignment],
+    })),
+  );
+}
+
+/**
+ * Places selected catalogue resources on the map, either as one collection marker or as one
+ * marker per resource - either at a given coordinate (map centre) or by letting the user click
+ * the map to pick the point (`startClickPlacement`).
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class ResourcePlacementService {
+  private readonly state = inject(ZsMapStateService);
+  private readonly journal = inject(JournalService);
+  private readonly i18n = inject(I18NService);
+  private readonly dialog = inject(MatDialog);
+
+  /** Label of the placement currently waiting for a map click; undefined when none is pending. */
+  readonly pendingLabel = signal<string | undefined>(undefined);
+
+  private clickSubscription?: Subscription;
+
+  /** Places every marker of `request` at `coordinates` (further markers fan out from it). Returns the created element ids. */
+  deploy(request: ResourceDeployRequest, coordinates: number[]): string[] {
+    const layer = this.requireResourceLayer();
+    if (!layer) {
+      return [];
+    }
+
+    const ids = this.placePlans(buildMarkerPlans(request), layer, coordinates, request);
+    if (ids.length > 0) {
+      this.state.setSelectedFeature(ids[0]);
+      this.state.setMapCenter(coordinates);
+    }
+    return ids;
+  }
+
+  /**
+   * Arms click-to-place: reuses the app's existing symbol-drawing interaction
+   * (`state.drawElement(...)`, consumed by `map-renderer.service.ts` / `ZsMapSymbolDrawElement`,
+   * the same path `copySymbol` uses) to let the user pick a point on the map with a single
+   * click. That interaction only creates a bare `{symbolId, layer, coordinates}` element, so
+   * once it fires (surfaced via `observeSelectedFeature$()`, which `ZsMapSymbolDrawElement`
+   * updates right after creation) this stamps the remaining fields - name, resourceItems,
+   * message - onto it, then places any further markers (single mode) fanning out from the
+   * clicked point.
+   */
+  startClickPlacement(request: ResourceDeployRequest): void {
+    const layer = this.requireResourceLayer();
+    if (!layer) {
+      return;
+    }
+
+    const [first, ...rest] = buildMarkerPlans(request);
+
+    // Wait for the element the draw interaction actually creates, identified by diffing the
+    // draw elements against the ones that existed when we armed.
+    //
+    // Do NOT key this off observeSelectedFeature$: that emits on *any* selection change, so
+    // clicking an existing feature - or a stale/removed selection - made us stamp
+    // `resourceItems` onto the wrong (or a no longer existing) element. The resulting patch
+    // `drawElements/<id>/resourceItems` then fails to resolve, which breaks changeset sync for
+    // everyone in the operation and makes the server reject the changeset.
+    const knownIds = new Set(Object.keys(this.currentDrawElements()));
+    this.clickSubscription?.unsubscribe();
+
+    let matched = false;
+    const subscription = new Subscription();
+
+    subscription.add(
+      this.state
+        .observeMapState()
+        .pipe(
+          map((mapState) =>
+            Object.values(mapState?.drawElements ?? {}).find(
+              (element) =>
+                element.id &&
+                !knownIds.has(element.id) &&
+                element.layer === layer &&
+                element.symbolId === first.symbolId &&
+                // never hijack an element that already carries assignments
+                !element.resourceItems?.length,
+            ),
+          ),
+          filter((element): element is ZsMapDrawElementState => !!element?.id),
+          take(1),
+        )
+        .subscribe((element) => {
+          matched = true;
+          this.finishClickPlacement(element.id as string, layer, first, rest, request);
+        }),
+    );
+
+    this.clickSubscription = subscription;
+    this.pendingLabel.set(this.labelFor(request));
+
+    this.state.drawElement({ type: ZsMapDrawElementStateType.SYMBOL, layer, symbolId: first.symbolId });
+
+    // Disarm as soon as the draw interaction ends without having produced our element (Esc,
+    // switching tool, ...). Without this the subscription stayed armed indefinitely and the
+    // next element appearing on the shared layer - including one synced from another user -
+    // would get this placement's resourceItems stamped onto it.
+    subscription.add(
+      this.state
+        .observeElementToDraw()
+        .pipe(
+          filter((element) => !element),
+          take(1),
+        )
+        .subscribe(() => {
+          if (!matched) {
+            this.cancelClickPlacement();
+          }
+        }),
+    );
+  }
+
+  /** Cancels a pending click-to-place, if any. */
+  cancelClickPlacement(): void {
+    if (!this.clickSubscription) {
+      return;
+    }
+    this.clickSubscription.unsubscribe();
+    this.clickSubscription = undefined;
+    this.state.cancelDrawing();
+    this.pendingLabel.set(undefined);
+  }
+
+  private finishClickPlacement(
+    id: string,
+    layer: string,
+    first: ResourceMarkerPlan,
+    rest: ResourceMarkerPlan[],
+    request: ResourceDeployRequest,
+  ): void {
+    this.clickSubscription = undefined;
+
+    // The element must still exist: patching a removed element produces an unresolvable patch
+    // path, which the server rejects and which breaks every other client's changeset replay.
+    if (!this.state.getDrawElementState(id)) {
+      this.pendingLabel.set(undefined);
+      return;
+    }
+
+    if (first.name) {
+      this.state.updateDrawElementState(id, 'name', first.name);
+    }
+    if (first.resourceItems.length > 0) {
+      this.state.updateDrawElementState(id, 'resourceItems', first.resourceItems);
+    }
+    this.stampMessage(id, request);
+
+    const origin = (this.state.getDrawElementState(id)?.coordinates as number[] | undefined) ?? this.state.getMapCenter();
+    const restIds = this.placePlans(rest, layer, origin, request, 1);
+
+    this.state.setSelectedFeature(id);
+    this.state.setMapCenter(origin);
+    this.pendingLabel.set(undefined);
+    void restIds;
+  }
+
+  private placePlans(
+    plans: ResourceMarkerPlan[],
+    layer: string,
+    origin: number[],
+    request: ResourceDeployRequest,
+    startIndex = 0,
+  ): string[] {
+    const ids: string[] = [];
+    plans.forEach((plan, planIndex) => {
+      const [dx, dy] = spiralOffset(startIndex + planIndex);
+      const created = this.state.addDrawElement({
+        type: ZsMapDrawElementStateType.SYMBOL,
+        layer,
+        coordinates: [origin[0] + dx, origin[1] + dy],
+        symbolId: plan.symbolId,
+        name: plan.name,
+        resourceItems: plan.resourceItems,
+      });
+      if (created?.id) {
+        ids.push(created.id);
+        this.stampMessage(created.id, request);
+      }
+    });
+    return ids;
+  }
+
+  private stampMessage(id: string, request: ResourceDeployRequest): void {
+    // addDrawElement() already stamps reportNumber from journal.drawingEntry when one is
+    // active; only an explicitly picked message with no active drawing entry needs this.
+    if (request.messageNumber && !this.journal.drawingEntry) {
+      this.state.updateDrawElementState(id, 'reportNumber', [request.messageNumber]);
+    }
+  }
+
+  /**
+   * Guards against the genuinely broken case (`state.canAddElements()` false, e.g. a guest who
+   * hit the draw-element limit) and otherwise hands back the shared resource layer's id - there
+   * is no "no active draw layer" case any more since `ensureResourceLayer()` always creates or
+   * finds one.
+   */
+  private requireResourceLayer(): string | undefined {
+    if (!this.state.canAddElements()) {
+      this.dialog.open(GuestLimitDialogComponent);
+      return undefined;
+    }
+    return this.ensureResourceLayer();
+  }
+
+  /** Finds the shared layer, creating it when absent; activates it and returns its id. */
+  public ensureResourceLayer(): string {
+    const existing = this.findResourceLayer();
+    const layerId = existing?.id ?? this.createResourceLayer();
+    this.state.activateDrawLayer(layerId);
+    return layerId;
+  }
+
+  private createResourceLayer(): string {
+    this.state.addDrawLayer(RESOURCE_LAYER_NAME);
+    // addDrawLayer() returns nothing - re-read the layers to find the one it just created.
+    const created = this.findResourceLayer();
+    if (!created) {
+      throw new Error(`Failed to create draw layer "${RESOURCE_LAYER_NAME}"`);
+    }
+    return created.id;
+  }
+
+  private findResourceLayer(): ZsMapLayerState | undefined {
+    return Object.values(this.currentLayers()).find(
+      (candidate) => candidate.type === ZsMapLayerStateType.DRAW && candidate.name === RESOURCE_LAYER_NAME,
+    );
+  }
+
+  /** Synchronous read of the current layers - `observeMapState()` is backed by a `BehaviorSubject`, so `take(1)` resolves immediately. */
+  /** Snapshot of the operation's draw elements (observeMapState is a BehaviorSubject). */
+  private currentDrawElements(): Record<string, ZsMapDrawElementState> {
+    let elements: Record<string, ZsMapDrawElementState> = {};
+    this.state
+      .observeMapState()
+      .pipe(take(1))
+      .subscribe((mapState) => {
+        elements = mapState?.drawElements ?? {};
+      });
+    return elements;
+  }
+
+  private currentLayers(): Record<string, ZsMapLayerState> {
+    let layers: Record<string, ZsMapLayerState> = {};
+    this.state
+      .observeMapState()
+      .pipe(take(1))
+      .subscribe((mapState) => {
+        layers = mapState.layers ?? {};
+      });
+    return layers;
+  }
+
+  /**
+   * Assigns one more resource to an existing marker - the counterpart of `takeBack`, used by
+   * the selected-feature panel's resource search. Writing `resourceItems` is all it takes for
+   * the piece to count as deployed: `ResourceService.assignmentIndex` derives availability from
+   * the map state, so the catalogue drops it from the free stock as soon as this lands.
+   */
+  public assign(elementId: string, option: ResourceAddOption): void {
+    const element = this.state.getDrawElementState(elementId);
+    if (!element) {
+      return;
+    }
+    const items = element.resourceItems ?? [];
+    if (option.itemKey && items.some((item) => item.itemKey === option.itemKey)) {
+      //the same physical piece is already on this marker
+      return;
+    }
+    this.state.updateDrawElementState(elementId, 'resourceItems', appendResourceAssignment(items, option));
+  }
+
+  /** Returns one assignment to stock; deletes the marker when it has no assignments left. */
+  public takeBack(elementId: string, assignment: ResourceAssignment): void {
+    const element = this.state.getDrawElementState(elementId);
+    if (!element) {
+      return;
+    }
+    const items = element.resourceItems ?? [];
+    const index = items.findIndex((candidate) => this.matchesAssignment(candidate, assignment));
+    if (index === -1) {
+      return;
+    }
+    const next = [...items.slice(0, index), ...items.slice(index + 1)];
+    this.applyRemainingAssignments(elementId, next);
+  }
+
+  /** Returns every assignment of a marker to stock and deletes the marker. */
+  public takeBackAll(elementId: string): void {
+    this.applyRemainingAssignments(elementId, []);
+  }
+
+  private applyRemainingAssignments(elementId: string, next: ResourceAssignment[]): void {
+    if (next.length === 0) {
+      this.state.removeDrawElement(elementId);
+      return;
+    }
+    this.state.updateDrawElementState(elementId, 'resourceItems', next);
+  }
+
+  private matchesAssignment(candidate: ResourceAssignment, assignment: ResourceAssignment): boolean {
+    if (assignment.itemKey) {
+      return candidate.itemKey === assignment.itemKey;
+    }
+    return (
+      !candidate.itemKey &&
+      candidate.articleNumber === assignment.articleNumber &&
+      candidate.quantity === assignment.quantity
+    );
+  }
+
+  private labelFor(request: ResourceDeployRequest): string {
+    if (request.mode === 'collection' && request.name?.trim()) {
+      return request.name.trim();
+    }
+    return this.i18n.get(request.mode === 'collection' ? 'resourceDeployCollection' : 'resourceDeploySingle');
+  }
+}

--- a/packages/app/src/app/resource/resource-assignment-picker.spec.ts
+++ b/packages/app/src/app/resource/resource-assignment-picker.spec.ts
@@ -1,0 +1,178 @@
+import { ResourceArticle, ResourceAssignment, ResourceItem } from '@zskarte/types';
+import { describe, expect, it } from 'vitest';
+import { ResourceAssignmentIndex } from './resource-assignments';
+import { appendResourceAssignment, buildResourceAddOptions, canAssignOption } from './resource-assignment-picker';
+
+function article(overrides: Partial<ResourceArticle> = {}): ResourceArticle {
+  return {
+    articleNumber: 'ZM-0001',
+    name: 'Stromaggregat',
+    articleGroup: 'Energie',
+    articleType: 'ZSO Material',
+    serialized: false,
+    totalCount: 3,
+    inStockCount: 3,
+    items: [item(), item(), item()],
+    ...overrides,
+  };
+}
+
+function item(overrides: Partial<ResourceItem> = {}): ResourceItem {
+  return {
+    status: 'an Lager',
+    ...overrides,
+  };
+}
+
+function emptyIndex(): ResourceAssignmentIndex {
+  return { byArticle: new Map(), byItemKey: new Map() };
+}
+
+function index(quantity: number, itemKeys: string[] = [], articleNumber = 'ZM-0001'): ResourceAssignmentIndex {
+  return {
+    byArticle: new Map([[articleNumber, { quantity, elementIds: ['el-1'] }]]),
+    byItemKey: new Map(itemKeys.map((itemKey) => [itemKey, 'el-1'])),
+  };
+}
+
+describe('buildResourceAddOptions', () => {
+  it('pools the interchangeable pieces of an article into one free option', () => {
+    const options = buildResourceAddOptions([article()], emptyIndex(), '');
+    expect(options).toHaveLength(1);
+    expect(options[0]).toMatchObject({ articleNumber: 'ZM-0001', state: 'free', count: 3 });
+    expect(options[0].itemKey).toBeUndefined();
+  });
+
+  it('splits a pool into what is deployed and what is still free', () => {
+    const options = buildResourceAddOptions([article()], index(2), '');
+    expect(options.map((option) => [option.state, option.count])).toEqual([
+      ['free', 1],
+      ['deployed', 2],
+    ]);
+  });
+
+  it('still offers a piece the inventory does not list as in stock, with its status', () => {
+    const damaged = article({
+      serialized: true,
+      totalCount: 1,
+      inStockCount: 0,
+      items: [item({ status: 'in Reparatur', serialNumber: 'AG-7', itemKey: 'ZM-0001|AG-7' })],
+    });
+
+    const options = buildResourceAddOptions([damaged], emptyIndex(), '');
+    expect(options).toHaveLength(1);
+    expect(options[0]).toMatchObject({ state: 'notInStock', status: 'in Reparatur', serialNumber: 'AG-7' });
+    expect(canAssignOption(options[0])).toBe(true);
+  });
+
+  it('lists serialised pieces individually and marks the assigned ones as deployed', () => {
+    const serialised = article({
+      serialized: true,
+      totalCount: 2,
+      inStockCount: 2,
+      items: [
+        item({ serialNumber: 'A1', itemKey: 'ZM-0001|A1' }),
+        item({ serialNumber: 'A2', itemKey: 'ZM-0001|A2' }),
+      ],
+    });
+
+    const options = buildResourceAddOptions([serialised], index(1, ['ZM-0001|A1']), '');
+    expect(options.map((option) => [option.serialNumber, option.state])).toEqual([
+      ['A2', 'free'],
+      ['A1', 'deployed'],
+    ]);
+    expect(canAssignOption(options[1])).toBe(false);
+  });
+
+  it('does not double-count a deployed serialised piece against the pool', () => {
+    const mixed = article({
+      serialized: true,
+      totalCount: 3,
+      inStockCount: 3,
+      items: [item({ serialNumber: 'A1', itemKey: 'ZM-0001|A1' }), item(), item()],
+    });
+
+    const options = buildResourceAddOptions([mixed], index(1, ['ZM-0001|A1']), '');
+    expect(options.map((option) => [option.serialNumber, option.state, option.count])).toEqual([
+      [undefined, 'free', 2],
+      ['A1', 'deployed', 1],
+    ]);
+  });
+
+  it('matches the search term against article number, name, manufacturer, serial number and status', () => {
+    const articles = [
+      article({ articleNumber: 'ZM-0001', name: 'Stromaggregat', manufacturer: 'Honda' }),
+      article({
+        articleNumber: 'ZM-0002',
+        name: 'Anhänger ZS',
+        serialized: true,
+        totalCount: 1,
+        inStockCount: 0,
+        items: [item({ status: 'in Reparatur', serialNumber: 'AG-7', itemKey: 'ZM-0002|AG-7' })],
+      }),
+    ];
+
+    expect(buildResourceAddOptions(articles, emptyIndex(), 'strom').map((o) => o.articleNumber)).toEqual(['ZM-0001']);
+    expect(buildResourceAddOptions(articles, emptyIndex(), 'honda').map((o) => o.articleNumber)).toEqual(['ZM-0001']);
+    expect(buildResourceAddOptions(articles, emptyIndex(), 'anhänger').map((o) => o.articleNumber)).toEqual(['ZM-0002']);
+    expect(buildResourceAddOptions(articles, emptyIndex(), 'ag-7').map((o) => o.serialNumber)).toEqual(['AG-7']);
+    expect(buildResourceAddOptions(articles, emptyIndex(), 'reparatur').map((o) => o.articleNumber)).toEqual(['ZM-0002']);
+    expect(buildResourceAddOptions(articles, emptyIndex(), 'nothing')).toHaveLength(0);
+  });
+
+  it('sorts free before unavailable before deployed, then by name, and caps at the limit', () => {
+    const articles = [
+      article({ articleNumber: 'ZM-0003', name: 'Zelt' }),
+      article({ articleNumber: 'ZM-0002', name: 'Absperrband', inStockCount: 0, items: [item({ status: 'ausgeliehen' })] }),
+      article({ articleNumber: 'ZM-0001', name: 'Motorsäge' }),
+    ];
+
+    expect(buildResourceAddOptions(articles, emptyIndex(), '').map((o) => o.name)).toEqual([
+      'Motorsäge',
+      'Zelt',
+      'Absperrband',
+    ]);
+    expect(buildResourceAddOptions(articles, emptyIndex(), '', 2)).toHaveLength(2);
+  });
+});
+
+describe('appendResourceAssignment', () => {
+  const fungible = { article: article(), articleNumber: 'ZM-0001', name: 'Stromaggregat', state: 'free' as const, count: 2 };
+  const serialised = {
+    article: article(),
+    articleNumber: 'ZM-0001',
+    name: 'Stromaggregat',
+    itemKey: 'ZM-0001|A1',
+    serialNumber: 'A1',
+    state: 'free' as const,
+    count: 1,
+  };
+
+  it('appends a first assignment without mutating the input', () => {
+    const items: ResourceAssignment[] = [];
+    const next = appendResourceAssignment(items, fungible);
+    expect(next).toEqual([{ articleNumber: 'ZM-0001', name: 'Stromaggregat', quantity: 1 }]);
+    expect(items).toHaveLength(0);
+  });
+
+  it('bumps the quantity of an existing fungible record instead of appending a second one', () => {
+    const items: ResourceAssignment[] = [{ articleNumber: 'ZM-0001', name: 'Stromaggregat', quantity: 2 }];
+    expect(appendResourceAssignment(items, fungible)).toEqual([
+      { articleNumber: 'ZM-0001', name: 'Stromaggregat', quantity: 3 },
+    ]);
+    expect(items[0].quantity).toBe(2);
+  });
+
+  it('keeps a serialised piece separate from the article s fungible record', () => {
+    const items: ResourceAssignment[] = [{ articleNumber: 'ZM-0001', name: 'Stromaggregat', quantity: 1 }];
+    expect(appendResourceAssignment(items, serialised)).toEqual([
+      { articleNumber: 'ZM-0001', name: 'Stromaggregat', quantity: 1 },
+      { articleNumber: 'ZM-0001', name: 'Stromaggregat', quantity: 1, serialNumber: 'A1', itemKey: 'ZM-0001|A1' },
+    ]);
+  });
+
+  it('never assigns the same serialised piece twice', () => {
+    const items = appendResourceAssignment([], serialised);
+    expect(appendResourceAssignment(items, serialised)).toEqual(items);
+  });
+});

--- a/packages/app/src/app/resource/resource-assignment-picker.ts
+++ b/packages/app/src/app/resource/resource-assignment-picker.ts
@@ -1,0 +1,189 @@
+import { RESOURCE_STATUS_IN_STOCK, ResourceArticle, ResourceAssignment, ResourceItem } from '@zskarte/types';
+import { ResourceAssignmentIndex } from './resource-assignments';
+
+/**
+ * Why a piece is or isn't ready to be assigned:
+ * - `free`: in stock (`an Lager`) and on no marker - the normal case.
+ * - `notInStock`: the inventory export says something else (in Reparatur, ausgeliehen, ...).
+ *   Still offered: the export is a snapshot, and the person on the map knows better than it
+ *   does what is actually on site.
+ * - `deployed`: already carried by a marker. Offered so the search can explain where a piece
+ *   went instead of silently finding nothing, but not selectable - one physical piece cannot
+ *   be in two places, and a duplicate `itemKey` corrupts the availability accounting.
+ */
+export type ResourceAddOptionState = 'free' | 'notInStock' | 'deployed';
+
+/**
+ * One pickable unit offered by the "add resource" search on a marker.
+ *
+ * A serialised option refers to one specific physical piece (`itemKey`/`serialNumber`, always
+ * quantity 1); a fungible option stands for `count` interchangeable pieces that share a state.
+ * Mirrors the split `ResourcePlacementService.buildAssignments` makes when deploying from the
+ * catalogue, so both paths produce the same shape of assignments.
+ */
+export interface ResourceAddOption {
+  article: ResourceArticle;
+  articleNumber: string;
+  name: string;
+  /** Set for a serialised piece only. */
+  itemKey?: string;
+  serialNumber?: string;
+  state: ResourceAddOptionState;
+  /** How many pieces this option stands for: always 1 for a serialised piece. */
+  count: number;
+  /** The raw inventory status when it is not `an Lager` (e.g. "in Reparatur"). */
+  status?: string;
+}
+
+const STATE_ORDER: Record<ResourceAddOptionState, number> = { free: 0, notInStock: 1, deployed: 2 };
+
+/** Same fields the catalogue's free-text filter searches, restricted to this one option. */
+function matchesTerm(option: ResourceAddOption, term: string): boolean {
+  if (!term) {
+    return true;
+  }
+  return [option.articleNumber, option.name, option.article.manufacturer, option.serialNumber, option.status]
+    .filter((value): value is string => !!value)
+    .some((value) => value.toLowerCase().includes(term));
+}
+
+/** The inventory status, but only when it says something other than "ready for use". */
+function statusHint(status: string | undefined): string | undefined {
+  return status && status !== RESOURCE_STATUS_IN_STOCK ? status : undefined;
+}
+
+function stateOf(item: ResourceItem, index: ResourceAssignmentIndex): ResourceAddOptionState {
+  if (item.itemKey && index.byItemKey.has(item.itemKey)) {
+    return 'deployed';
+  }
+  return item.status === RESOURCE_STATUS_IN_STOCK ? 'free' : 'notInStock';
+}
+
+/**
+ * Turns the pieces of one article into pickable options: every serialised piece on its own,
+ * the pieces without a serial number pooled per state.
+ *
+ * The pool is what makes the numbers add up for fungible articles: the individual pieces are
+ * indistinguishable, so what is assigned is a *quantity* (`index.byArticle`), not specific
+ * items. That quantity is charged against the pooled in-stock pieces first, exactly like
+ * `computeResourceCatalogueRows` computes the catalogue's "Frei" column.
+ */
+function optionsForArticle(article: ResourceArticle, index: ResourceAssignmentIndex): ResourceAddOption[] {
+  const base = { article, articleNumber: article.articleNumber, name: article.name };
+  const options: ResourceAddOption[] = [];
+  const pooled = new Map<string, { state: ResourceAddOptionState; status?: string; count: number }>();
+
+  for (const item of article.items) {
+    const state = stateOf(item, index);
+    if (item.itemKey) {
+      options.push({
+        ...base,
+        itemKey: item.itemKey,
+        serialNumber: item.serialNumber,
+        state,
+        count: 1,
+        status: statusHint(item.status),
+      });
+      continue;
+    }
+    const key = `${state}|${item.status}`;
+    const entry = pooled.get(key) ?? { state, status: item.status, count: 0 };
+    entry.count++;
+    pooled.set(key, entry);
+  }
+
+  // Assigned quantity that no serialised piece accounts for: it belongs to the pool.
+  const assignedSerialised = article.items.filter((item) => item.itemKey && index.byItemKey.has(item.itemKey)).length;
+  let pooledAssigned = Math.max(0, (index.byArticle.get(article.articleNumber)?.quantity ?? 0) - assignedSerialised);
+
+  for (const entry of [...pooled.values()].sort((a, b) => STATE_ORDER[a.state] - STATE_ORDER[b.state])) {
+    const deployed = Math.min(entry.count, pooledAssigned);
+    pooledAssigned -= deployed;
+    if (deployed > 0) {
+      options.push({ ...base, state: 'deployed', count: deployed, status: statusHint(entry.status) });
+    }
+    if (entry.count > deployed) {
+      options.push({
+        ...base,
+        state: entry.state,
+        count: entry.count - deployed,
+        status: statusHint(entry.status),
+      });
+    }
+  }
+
+  return options;
+}
+
+/**
+ * Builds the resources offered by a marker's "add resource" search, best first: what is free,
+ * then what the inventory lists elsewhere (repair, on loan), then what is already on the map.
+ *
+ * Everything in the catalogue is reachable here - a piece is never hidden just because the
+ * export calls it unavailable; its state is spelled out on the option instead, and only
+ * `deployed` pieces cannot be picked. Assignments come from `ResourceService.assignmentIndex`,
+ * which is derived from the live map state, so a piece's state follows the map immediately -
+ * including changes made by another user in the same operation.
+ */
+export function buildResourceAddOptions(
+  articles: ResourceArticle[],
+  index: ResourceAssignmentIndex,
+  searchTerm: string,
+  limit = 25,
+): ResourceAddOption[] {
+  const term = searchTerm.trim().toLowerCase();
+
+  return articles
+    .flatMap((article) => optionsForArticle(article, index))
+    .filter((option) => matchesTerm(option, term))
+    .sort(
+      (a, b) =>
+        STATE_ORDER[a.state] - STATE_ORDER[b.state] ||
+        a.name.localeCompare(b.name) ||
+        a.articleNumber.localeCompare(b.articleNumber) ||
+        // within one article: the serialised pieces first, the pooled remainder last
+        Number(!a.serialNumber) - Number(!b.serialNumber) ||
+        (a.serialNumber ?? '').localeCompare(b.serialNumber ?? ''),
+    )
+    .slice(0, limit);
+}
+
+/** A piece already on the map cannot be assigned again - one physical piece, one place. */
+export function canAssignOption(option: ResourceAddOption): boolean {
+  return option.state !== 'deployed';
+}
+
+/**
+ * Returns `items` with `option` added - never mutating the array it is given, since it is part
+ * of the (immer-managed) draw element state.
+ *
+ * Adding a fungible piece bumps the quantity of the article's existing fungible record instead
+ * of appending a second one, so a marker never shows "1× Warnweste" twice. A serialised piece
+ * already on this marker is returned unchanged (it is one physical item).
+ */
+export function appendResourceAssignment(
+  items: readonly ResourceAssignment[],
+  option: ResourceAddOption,
+): ResourceAssignment[] {
+  if (option.itemKey) {
+    if (items.some((item) => item.itemKey === option.itemKey)) {
+      return [...items];
+    }
+    return [
+      ...items,
+      {
+        articleNumber: option.articleNumber,
+        name: option.name,
+        quantity: 1,
+        serialNumber: option.serialNumber,
+        itemKey: option.itemKey,
+      },
+    ];
+  }
+
+  const index = items.findIndex((item) => !item.itemKey && item.articleNumber === option.articleNumber);
+  if (index === -1) {
+    return [...items, { articleNumber: option.articleNumber, name: option.name, quantity: 1 }];
+  }
+  return items.map((item, i) => (i === index ? { ...item, quantity: item.quantity + 1 } : item));
+}

--- a/packages/app/src/app/resource/resource-assignments.spec.ts
+++ b/packages/app/src/app/resource/resource-assignments.spec.ts
@@ -1,0 +1,206 @@
+import { IZsMapBaseDrawElementState, ResourceArticle, ZsMapDrawElementStateType } from '@zskarte/types';
+import { describe, expect, it } from 'vitest';
+import { buildResourceAssignmentIndex, computeResourceCatalogueRows, findOrphanedAssignments } from './resource-assignments';
+
+function article(overrides: Partial<ResourceArticle> = {}): ResourceArticle {
+  return {
+    articleNumber: 'ZM-0001',
+    name: 'Stromaggregat',
+    articleGroup: 'Energie',
+    articleType: 'ZSO Material',
+    serialized: false,
+    totalCount: 10,
+    inStockCount: 10,
+    items: [],
+    ...overrides,
+  };
+}
+
+function element(overrides: Partial<IZsMapBaseDrawElementState> = {}): IZsMapBaseDrawElementState {
+  return {
+    id: 'el-1',
+    type: ZsMapDrawElementStateType.SYMBOL,
+    ...overrides,
+  };
+}
+
+describe('buildResourceAssignmentIndex', () => {
+  it('returns empty maps when no elements carry resourceItems', () => {
+    const index = buildResourceAssignmentIndex([element({ resourceItems: undefined }), element({ id: 'el-2' })]);
+    expect(index.byArticle.size).toBe(0);
+    expect(index.byItemKey.size).toBe(0);
+  });
+
+  it('ignores elements without an id even if they carry resourceItems', () => {
+    const index = buildResourceAssignmentIndex([
+      element({ id: undefined, resourceItems: [{ articleNumber: 'ZM-0001', name: 'Stromaggregat', quantity: 1 }] }),
+    ]);
+    expect(index.byArticle.size).toBe(0);
+  });
+
+  it('sums quantity across several markers assigning the same article', () => {
+    const index = buildResourceAssignmentIndex([
+      element({ id: 'el-1', resourceItems: [{ articleNumber: 'ZM-0001', name: 'Stromaggregat', quantity: 2 }] }),
+      element({ id: 'el-2', resourceItems: [{ articleNumber: 'ZM-0001', name: 'Stromaggregat', quantity: 3 }] }),
+    ]);
+    const entry = index.byArticle.get('ZM-0001');
+    expect(entry?.quantity).toBe(5);
+    expect(entry?.elementIds.sort()).toEqual(['el-1', 'el-2']);
+  });
+
+  it('does not duplicate an elementId when the same element assigns the article twice', () => {
+    const index = buildResourceAssignmentIndex([
+      element({
+        id: 'el-1',
+        resourceItems: [
+          { articleNumber: 'ZM-0001', name: 'Stromaggregat', quantity: 1, itemKey: 'ZM-0001|SN1' },
+          { articleNumber: 'ZM-0001', name: 'Stromaggregat', quantity: 1, itemKey: 'ZM-0001|SN2' },
+        ],
+      }),
+    ]);
+    const entry = index.byArticle.get('ZM-0001');
+    expect(entry?.quantity).toBe(2);
+    expect(entry?.elementIds).toEqual(['el-1']);
+  });
+
+  it('maps a serialised itemKey to its assigning element', () => {
+    const index = buildResourceAssignmentIndex([
+      element({
+        id: 'el-9',
+        resourceItems: [{ articleNumber: 'ZM-0002', name: 'Pumpe', quantity: 1, serialNumber: 'SN1', itemKey: 'ZM-0002|SN1' }],
+      }),
+    ]);
+    expect(index.byItemKey.get('ZM-0002|SN1')).toBe('el-9');
+  });
+
+  it('resolves a duplicate itemKey to the first assigning element without throwing', () => {
+    const index = buildResourceAssignmentIndex([
+      element({ id: 'el-1', resourceItems: [{ articleNumber: 'ZM-0002', name: 'Pumpe', quantity: 1, itemKey: 'ZM-0002|SN1' }] }),
+      element({ id: 'el-2', resourceItems: [{ articleNumber: 'ZM-0002', name: 'Pumpe', quantity: 1, itemKey: 'ZM-0002|SN1' }] }),
+    ]);
+    expect(index.byItemKey.get('ZM-0002|SN1')).toBe('el-1');
+  });
+
+  it('ignores empty itemKeys', () => {
+    const index = buildResourceAssignmentIndex([
+      element({ id: 'el-1', resourceItems: [{ articleNumber: 'ZM-0001', name: 'Stromaggregat', quantity: 1 }] }),
+    ]);
+    expect(index.byItemKey.size).toBe(0);
+  });
+});
+
+describe('computeResourceCatalogueRows', () => {
+  it('preserves input order and reports zero assignment when nothing is placed on the map', () => {
+    const articles = [article({ articleNumber: 'A' }), article({ articleNumber: 'B' })];
+    const index = buildResourceAssignmentIndex([]);
+    const rows = computeResourceCatalogueRows(articles, index);
+    expect(rows.map((r) => r.article.articleNumber)).toEqual(['A', 'B']);
+    expect(rows[0].assignedCount).toBe(0);
+    expect(rows[0].availableCount).toBe(10);
+    expect(rows[0].unavailableCount).toBe(0);
+    expect(rows[0].availability).toEqual(['available']);
+    expect(rows[0].elementIds).toEqual([]);
+  });
+
+  it('reports the unavailable bucket for pieces not an Lager', () => {
+    const articles = [article({ totalCount: 10, inStockCount: 7 })];
+    const rows = computeResourceCatalogueRows(articles, buildResourceAssignmentIndex([]));
+    expect(rows[0].unavailableCount).toBe(3);
+    expect(rows[0].availableCount).toBe(7);
+    expect(rows[0].availability.sort()).toEqual(['available', 'unavailable']);
+  });
+
+  it('marks a fully assigned article as assigned and not available', () => {
+    const articles = [article({ articleNumber: 'ZM-0001', totalCount: 5, inStockCount: 5 })];
+    const index = buildResourceAssignmentIndex([
+      element({ id: 'el-1', resourceItems: [{ articleNumber: 'ZM-0001', name: 'Stromaggregat', quantity: 5 }] }),
+    ]);
+    const rows = computeResourceCatalogueRows(articles, index);
+    expect(rows[0].assignedCount).toBe(5);
+    expect(rows[0].availableCount).toBe(0);
+    expect(rows[0].availability).toEqual(['assigned']);
+    expect(rows[0].elementIds).toEqual(['el-1']);
+  });
+
+  it('clamps availableCount at 0 when an article is over-assigned', () => {
+    const articles = [article({ articleNumber: 'ZM-0001', totalCount: 5, inStockCount: 5 })];
+    const index = buildResourceAssignmentIndex([
+      element({ id: 'el-1', resourceItems: [{ articleNumber: 'ZM-0001', name: 'Stromaggregat', quantity: 8 }] }),
+    ]);
+    const rows = computeResourceCatalogueRows(articles, index);
+    expect(rows[0].assignedCount).toBe(8);
+    expect(rows[0].availableCount).toBe(0);
+    expect(rows[0].availability).toEqual(['assigned']);
+  });
+
+  it('matches several availability buckets at once', () => {
+    const articles = [article({ articleNumber: 'ZM-0001', totalCount: 10, inStockCount: 6 })];
+    const index = buildResourceAssignmentIndex([
+      element({ id: 'el-1', resourceItems: [{ articleNumber: 'ZM-0001', name: 'Stromaggregat', quantity: 2 }] }),
+    ]);
+    const rows = computeResourceCatalogueRows(articles, index);
+    // inStock 6, assigned 2 -> available 4; totalCount 10 - inStock 6 -> unavailable 4
+    expect(rows[0].assignedCount).toBe(2);
+    expect(rows[0].availableCount).toBe(4);
+    expect(rows[0].unavailableCount).toBe(4);
+    expect([...rows[0].availability].sort()).toEqual(['assigned', 'available', 'unavailable']);
+  });
+});
+
+describe('findOrphanedAssignments', () => {
+  it('returns nothing when every assignment still matches the catalogue', () => {
+    const articles = [
+      article({
+        articleNumber: 'ZM-0001',
+        serialized: true,
+        items: [{ status: 'an Lager', serialNumber: 'SN1', itemKey: 'ZM-0001|SN1' }],
+      }),
+    ];
+    const elements = [
+      element({
+        id: 'el-1',
+        resourceItems: [{ articleNumber: 'ZM-0001', name: 'Stromaggregat', quantity: 1, itemKey: 'ZM-0001|SN1' }],
+      }),
+    ];
+    expect(findOrphanedAssignments(elements, articles)).toEqual([]);
+  });
+
+  it('flags an assignment whose article was removed from the catalogue', () => {
+    const elements = [
+      element({ id: 'el-1', resourceItems: [{ articleNumber: 'ZM-9999', name: 'Gone', quantity: 1 }] }),
+    ];
+    const orphans = findOrphanedAssignments(elements, []);
+    expect(orphans).toEqual([{ elementId: 'el-1', assignment: { articleNumber: 'ZM-9999', name: 'Gone', quantity: 1 } }]);
+  });
+
+  it('flags an assignment whose serial number was removed from its article', () => {
+    const articles = [
+      article({
+        articleNumber: 'ZM-0001',
+        serialized: true,
+        items: [{ status: 'an Lager', serialNumber: 'SN2', itemKey: 'ZM-0001|SN2' }],
+      }),
+    ];
+    const elements = [
+      element({
+        id: 'el-1',
+        resourceItems: [{ articleNumber: 'ZM-0001', name: 'Stromaggregat', quantity: 1, serialNumber: 'SN1', itemKey: 'ZM-0001|SN1' }],
+      }),
+    ];
+    const orphans = findOrphanedAssignments(elements, articles);
+    expect(orphans).toEqual([
+      {
+        elementId: 'el-1',
+        assignment: { articleNumber: 'ZM-0001', name: 'Stromaggregat', quantity: 1, serialNumber: 'SN1', itemKey: 'ZM-0001|SN1' },
+      },
+    ]);
+  });
+
+  it('ignores elements without an id or without resourceItems', () => {
+    const elements = [
+      element({ id: undefined, resourceItems: [{ articleNumber: 'ZM-9999', name: 'Gone', quantity: 1 }] }),
+      element({ id: 'el-2', resourceItems: undefined }),
+    ];
+    expect(findOrphanedAssignments(elements, [])).toEqual([]);
+  });
+});

--- a/packages/app/src/app/resource/resource-assignments.ts
+++ b/packages/app/src/app/resource/resource-assignments.ts
@@ -1,0 +1,129 @@
+import { IZsMapBaseDrawElementState, ResourceArticle, ResourceAssignment, ResourceAvailability } from '@zskarte/types';
+
+/**
+ * Index of resource assignments across all draw elements of a map.
+ * Pure, framework-free aggregation used by the resource catalogue and by
+ * orphan detection - no Angular DI, no side effects.
+ */
+export interface ResourceAssignmentIndex {
+  /** articleNumber -> summed quantity assigned + the (distinct) elements assigning it. */
+  byArticle: Map<string, { quantity: number; elementIds: string[] }>;
+  /** itemKey -> elementId (first wins on duplicates - a data anomaly, not an error). */
+  byItemKey: Map<string, string>;
+}
+
+/**
+ * Builds an aggregation index of all resource assignments currently placed on the map.
+ *
+ * Elements without an `id` or without `resourceItems` are ignored. Quantities are summed
+ * per `articleNumber`; each non-empty `itemKey` is mapped to the id of the element that
+ * first claims it - a duplicate itemKey (the same physical, serialised piece assigned to
+ * two markers) is a data anomaly, not something this function throws on.
+ */
+export function buildResourceAssignmentIndex(elements: IZsMapBaseDrawElementState[]): ResourceAssignmentIndex {
+  const byArticle = new Map<string, { quantity: number; elementIds: string[] }>();
+  const byItemKey = new Map<string, string>();
+
+  for (const element of elements) {
+    if (!element.id || !element.resourceItems?.length) continue;
+    const elementId = element.id;
+
+    for (const assignment of element.resourceItems) {
+      let entry = byArticle.get(assignment.articleNumber);
+      if (!entry) {
+        entry = { quantity: 0, elementIds: [] };
+        byArticle.set(assignment.articleNumber, entry);
+      }
+      entry.quantity += assignment.quantity;
+      if (!entry.elementIds.includes(elementId)) {
+        entry.elementIds.push(elementId);
+      }
+
+      if (assignment.itemKey && !byItemKey.has(assignment.itemKey)) {
+        byItemKey.set(assignment.itemKey, elementId);
+      }
+    }
+  }
+
+  return { byArticle, byItemKey };
+}
+
+/** One row of the resource catalogue view: an article plus its current deployment state. */
+export interface ResourceCatalogueRow {
+  article: ResourceArticle;
+  assignedCount: number;
+  availableCount: number;
+  unavailableCount: number;
+  /** Which filter buckets this row matches; a row can match several. */
+  availability: ResourceAvailability[];
+  elementIds: string[];
+}
+
+/**
+ * Computes one catalogue row per article, in the same order as `articles`.
+ *
+ * - `assignedCount` is the summed quantity currently placed on the map for that article.
+ * - `unavailableCount` is the piece count that is not `an Lager` (damaged, loaned out, ...).
+ * - `availableCount` is what's left in stock after subtracting what's assigned, floored at 0.
+ */
+export function computeResourceCatalogueRows(
+  articles: ResourceArticle[],
+  index: ResourceAssignmentIndex,
+): ResourceCatalogueRow[] {
+  return articles.map((article) => {
+    const entry = index.byArticle.get(article.articleNumber);
+    const assignedCount = entry?.quantity ?? 0;
+    const unavailableCount = article.totalCount - article.inStockCount;
+    const availableCount = Math.max(0, article.inStockCount - assignedCount);
+
+    const availability: ResourceAvailability[] = [];
+    if (availableCount > 0) availability.push('available');
+    if (assignedCount > 0) availability.push('assigned');
+    if (unavailableCount > 0) availability.push('unavailable');
+
+    return {
+      article,
+      assignedCount,
+      availableCount,
+      unavailableCount,
+      availability,
+      elementIds: entry?.elementIds ?? [],
+    };
+  });
+}
+
+/** One resource assignment on the map that no longer refers to something in the catalogue. */
+export interface OrphanedResourceAssignment {
+  elementId: string;
+  assignment: ResourceAssignment;
+}
+
+/**
+ * Finds resource assignments on the map whose article - or, for serialised pieces, whose
+ * specific item - is no longer part of the given catalogue (e.g. after a re-import that
+ * dropped or replaced articles).
+ */
+export function findOrphanedAssignments(
+  elements: IZsMapBaseDrawElementState[],
+  articles: ResourceArticle[],
+): OrphanedResourceAssignment[] {
+  const articleByNumber = new Map(articles.map((article) => [article.articleNumber, article]));
+  const orphaned: OrphanedResourceAssignment[] = [];
+
+  for (const element of elements) {
+    if (!element.id || !element.resourceItems?.length) continue;
+
+    for (const assignment of element.resourceItems) {
+      const article = articleByNumber.get(assignment.articleNumber);
+      if (!article) {
+        orphaned.push({ elementId: element.id, assignment });
+        continue;
+      }
+      if (assignment.itemKey && !article.items.some((item) => item.itemKey === assignment.itemKey)) {
+        orphaned.push({ elementId: element.id, assignment });
+      }
+    }
+  }
+
+  return orphaned;
+}

--- a/packages/app/src/app/resource/resource-signature.mapping.spec.ts
+++ b/packages/app/src/app/resource/resource-signature.mapping.spec.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { Signs } from '../map-renderer/signs';
+import {
+  RESOURCE_COLLECTION_SIGN_ID,
+  RESOURCE_SIGN_BY_ARTICLE_GROUP,
+  RESOURCE_SIGN_BY_ARTICLE_NUMBER,
+  resolveCollectionSignId,
+  resolveResourceSignId,
+} from './resource-signature.mapping';
+
+describe('resolveResourceSignId', () => {
+  it('resolves by articleNumber when a specific mapping exists', () => {
+    const [articleNumber, expectedId] = Object.entries(RESOURCE_SIGN_BY_ARTICLE_NUMBER)[0];
+    const id = resolveResourceSignId({ articleNumber, articleGroup: 'irrelevant-group' });
+    expect(id).toBe(expectedId);
+  });
+
+  it('prefers the articleNumber mapping over the articleGroup mapping', () => {
+    const [articleNumber] = Object.entries(RESOURCE_SIGN_BY_ARTICLE_NUMBER)[0];
+    const id = resolveResourceSignId({ articleNumber, articleGroup: 'Transport/Logistik' });
+    expect(id).toBe(RESOURCE_SIGN_BY_ARTICLE_NUMBER[articleNumber]);
+  });
+
+  it('falls back to the articleGroup mapping when no articleNumber mapping exists', () => {
+    const id = resolveResourceSignId({ articleNumber: 'ZM-UNKNOWN', articleGroup: 'Transport/Logistik' });
+    expect(id).toBe(RESOURCE_SIGN_BY_ARTICLE_GROUP['Transport/Logistik']);
+  });
+
+  it('falls back to the placeholder when neither articleNumber nor articleGroup match', () => {
+    const id = resolveResourceSignId({ articleNumber: 'ZM-UNKNOWN', articleGroup: 'Unknown Group' });
+    expect(id).toBe(Signs.RESOURCE_PLACEHOLDER_SIGN_ID);
+  });
+
+  it('every id in RESOURCE_SIGN_BY_ARTICLE_NUMBER exists in Signs.SIGNS', () => {
+    for (const id of Object.values(RESOURCE_SIGN_BY_ARTICLE_NUMBER)) {
+      expect(Signs.getSignById(id)).toBeDefined();
+    }
+  });
+
+  it('every id in RESOURCE_SIGN_BY_ARTICLE_GROUP exists in Signs.SIGNS', () => {
+    for (const id of Object.values(RESOURCE_SIGN_BY_ARTICLE_GROUP)) {
+      expect(Signs.getSignById(id)).toBeDefined();
+    }
+  });
+
+  it('RESOURCE_COLLECTION_SIGN_ID exists in Signs.SIGNS', () => {
+    expect(Signs.getSignById(RESOURCE_COLLECTION_SIGN_ID)).toBeDefined();
+  });
+
+  it('Signs.RESOURCE_PLACEHOLDER_SIGN_ID exists in Signs.SIGNS', () => {
+    expect(Signs.getSignById(Signs.RESOURCE_PLACEHOLDER_SIGN_ID)).toBeDefined();
+  });
+});
+
+describe('resolveCollectionSignId', () => {
+  it('uses the single sign id when every article unanimously resolves to it', () => {
+    const articles = [
+      { articleNumber: 'ZM-A', articleGroup: 'Transport/Logistik' },
+      { articleNumber: 'ZM-B', articleGroup: 'Transport/Logistik' },
+    ];
+    expect(resolveCollectionSignId(articles)).toBe(Signs.TRANSPORT_VEHICLE_SIGN_ID);
+  });
+
+  it('falls back to the Materialdepot collection sign for a mixed set of articles', () => {
+    const articles = [
+      { articleNumber: 'ZM-A', articleGroup: 'Transport/Logistik' },
+      { articleNumber: 'ZM-B', articleGroup: 'Sanitätsmaterial' },
+    ];
+    expect(resolveCollectionSignId(articles)).toBe(RESOURCE_COLLECTION_SIGN_ID);
+  });
+
+  it('falls back to the Materialdepot collection sign when every article resolves to the placeholder', () => {
+    const articles = [
+      { articleNumber: 'ZM-A', articleGroup: 'Unknown' },
+      { articleNumber: 'ZM-B', articleGroup: 'Unknown' },
+    ];
+    expect(resolveCollectionSignId(articles)).toBe(RESOURCE_COLLECTION_SIGN_ID);
+  });
+
+  it('returns the Materialdepot collection sign for an empty article list', () => {
+    expect(resolveCollectionSignId([])).toBe(RESOURCE_COLLECTION_SIGN_ID);
+  });
+});

--- a/packages/app/src/app/resource/resource-signature.mapping.spec.ts
+++ b/packages/app/src/app/resource/resource-signature.mapping.spec.ts
@@ -3,37 +3,52 @@ import { Signs } from '../map-renderer/signs';
 import {
   RESOURCE_COLLECTION_SIGN_ID,
   RESOURCE_SIGN_BY_ARTICLE_GROUP,
-  RESOURCE_SIGN_BY_ARTICLE_NUMBER,
+  RESOURCE_SIGN_BY_NAME_FRAGMENT,
   resolveCollectionSignId,
   resolveResourceSignId,
 } from './resource-signature.mapping';
 
 describe('resolveResourceSignId', () => {
-  it('resolves by articleNumber when a specific mapping exists', () => {
-    const [articleNumber, expectedId] = Object.entries(RESOURCE_SIGN_BY_ARTICLE_NUMBER)[0];
-    const id = resolveResourceSignId({ articleNumber, articleGroup: 'irrelevant-group' });
-    expect(id).toBe(expectedId);
+  it('resolves by a fragment of the article name, whatever the article number is', () => {
+    const { fragment, signId } = RESOURCE_SIGN_BY_NAME_FRAGMENT[0];
+    expect(resolveResourceSignId({ name: `Ein ${fragment}-Set`, articleGroup: 'irrelevant-group' })).toBe(signId);
   });
 
-  it('prefers the articleNumber mapping over the articleGroup mapping', () => {
-    const [articleNumber] = Object.entries(RESOURCE_SIGN_BY_ARTICLE_NUMBER)[0];
-    const id = resolveResourceSignId({ articleNumber, articleGroup: 'Transport/Logistik' });
-    expect(id).toBe(RESOURCE_SIGN_BY_ARTICLE_NUMBER[articleNumber]);
+  it('matches the name fragment case-insensitively', () => {
+    const { fragment, signId } = RESOURCE_SIGN_BY_NAME_FRAGMENT[0];
+    expect(resolveResourceSignId({ name: fragment.toUpperCase(), articleGroup: 'Unknown Group' })).toBe(signId);
   });
 
-  it('falls back to the articleGroup mapping when no articleNumber mapping exists', () => {
-    const id = resolveResourceSignId({ articleNumber: 'ZM-UNKNOWN', articleGroup: 'Transport/Logistik' });
+  it('prefers the name mapping over the articleGroup mapping', () => {
+    const { fragment, signId } = RESOURCE_SIGN_BY_NAME_FRAGMENT[0];
+    expect(resolveResourceSignId({ name: `${fragment}-Set`, articleGroup: 'Transport/Logistik' })).toBe(signId);
+  });
+
+  it('falls back to the articleGroup mapping when the name matches nothing', () => {
+    const id = resolveResourceSignId({ name: 'Anhänger ZS', articleGroup: 'Transport/Logistik' });
     expect(id).toBe(RESOURCE_SIGN_BY_ARTICLE_GROUP['Transport/Logistik']);
   });
 
-  it('falls back to the placeholder when neither articleNumber nor articleGroup match', () => {
-    const id = resolveResourceSignId({ articleNumber: 'ZM-UNKNOWN', articleGroup: 'Unknown Group' });
+  it('falls back to the placeholder when neither the name nor the articleGroup match', () => {
+    const id = resolveResourceSignId({ name: 'Stromaggregat', articleGroup: 'Unknown Group' });
     expect(id).toBe(Signs.RESOURCE_PLACEHOLDER_SIGN_ID);
   });
 
-  it('every id in RESOURCE_SIGN_BY_ARTICLE_NUMBER exists in Signs.SIGNS', () => {
-    for (const id of Object.values(RESOURCE_SIGN_BY_ARTICLE_NUMBER)) {
-      expect(Signs.getSignById(id)).toBeDefined();
+  it('does not claim a sign for articles that merely belong to an NTP set', () => {
+    for (const name of ['Blitzwarnlampe NTP', 'Faltsignal NTP', 'Polycom TPH 900 NTP Einerset']) {
+      expect(resolveResourceSignId({ name, articleGroup: 'Spezialartikel' })).toBe(Signs.RESOURCE_PLACEHOLDER_SIGN_ID);
+    }
+  });
+
+  it('every id in RESOURCE_SIGN_BY_NAME_FRAGMENT exists in Signs.SIGNS', () => {
+    for (const { signId } of RESOURCE_SIGN_BY_NAME_FRAGMENT) {
+      expect(Signs.getSignById(signId)).toBeDefined();
+    }
+  });
+
+  it('every fragment in RESOURCE_SIGN_BY_NAME_FRAGMENT is lowercase, as the matching expects', () => {
+    for (const { fragment } of RESOURCE_SIGN_BY_NAME_FRAGMENT) {
+      expect(fragment).toBe(fragment.toLowerCase());
     }
   });
 
@@ -55,24 +70,24 @@ describe('resolveResourceSignId', () => {
 describe('resolveCollectionSignId', () => {
   it('uses the single sign id when every article unanimously resolves to it', () => {
     const articles = [
-      { articleNumber: 'ZM-A', articleGroup: 'Transport/Logistik' },
-      { articleNumber: 'ZM-B', articleGroup: 'Transport/Logistik' },
+      { name: 'Anhänger ZS', articleGroup: 'Transport/Logistik' },
+      { name: 'Transportfahrzeug', articleGroup: 'Transport/Logistik' },
     ];
     expect(resolveCollectionSignId(articles)).toBe(Signs.TRANSPORT_VEHICLE_SIGN_ID);
   });
 
   it('falls back to the Materialdepot collection sign for a mixed set of articles', () => {
     const articles = [
-      { articleNumber: 'ZM-A', articleGroup: 'Transport/Logistik' },
-      { articleNumber: 'ZM-B', articleGroup: 'Sanitätsmaterial' },
+      { name: 'Anhänger ZS', articleGroup: 'Transport/Logistik' },
+      { name: 'Sanitätsrucksack', articleGroup: 'Sanitätsmaterial' },
     ];
     expect(resolveCollectionSignId(articles)).toBe(RESOURCE_COLLECTION_SIGN_ID);
   });
 
   it('falls back to the Materialdepot collection sign when every article resolves to the placeholder', () => {
     const articles = [
-      { articleNumber: 'ZM-A', articleGroup: 'Unknown' },
-      { articleNumber: 'ZM-B', articleGroup: 'Unknown' },
+      { name: 'Stromaggregat', articleGroup: 'Unknown' },
+      { name: 'Leuchtballon', articleGroup: 'Unknown' },
     ];
     expect(resolveCollectionSignId(articles)).toBe(RESOURCE_COLLECTION_SIGN_ID);
   });

--- a/packages/app/src/app/resource/resource-signature.mapping.ts
+++ b/packages/app/src/app/resource/resource-signature.mapping.ts
@@ -1,0 +1,71 @@
+import { ResourceArticle } from '@zskarte/types';
+import { Signs } from '../map-renderer/signs';
+
+/**
+ * Maps a specific `articleNumber` to a BABS pictogram id.
+ *
+ * Deliberately sparse: the BABS catalogue has no pictograms for generators, lighting,
+ * pumps, sirens or extinguishers, and the near-matches that exist ('Energieausfall',
+ * 'Stromausfall', 'Wasserversorgungsausfall') are red/orange damage-or-hazard signs that
+ * would be factually wrong for a resource marker. Only articles that genuinely are the
+ * thing a real sign depicts are listed here - everything else falls through to the group
+ * mapping, and then to the placeholder.
+ *
+ * The two entries below are the NTP-specific articles found in the sample export
+ * ("Grid-Export (63)(Tabelle1).csv"), both under the 'Spezialartikel' article group and
+ * both literally naming themselves as the NTP set/signal:
+ * - ZM-001665 'Notfalltreffpunkt-Set NTP'
+ * - ZM-001834 'Faltsignal NTP'
+ * They map to sign id 158 ('Notfalltreffpunkt' / 'Emergency meeting point').
+ * (Two further NTP-adjacent articles exist in the export - ZM-001835 'Blitzwarnlampe NTP'
+ * and ZM-001693 'Polycom TPH 900 NTP Einerset' - but neither one *is* the NTP marker
+ * itself (a warning lamp and a radio set respectively), so they are intentionally left
+ * unmapped and fall back to the placeholder.)
+ */
+export const RESOURCE_SIGN_BY_ARTICLE_NUMBER: Record<string, number> = {
+  'ZM-001665': 158, // Notfalltreffpunkt-Set NTP -> Notfalltreffpunkt
+  'ZM-001834': 158, // Faltsignal NTP -> Notfalltreffpunkt
+};
+
+/**
+ * Maps an `articleGroup` to a BABS pictogram id. Used when no per-article mapping exists.
+ */
+export const RESOURCE_SIGN_BY_ARTICLE_GROUP: Record<string, number> = {
+  'Transport/Logistik': Signs.TRANSPORT_VEHICLE_SIGN_ID, // 201 - Transportfahrzeug
+  'Sanitätsmaterial': 94, // Sanitätshilfsstelle
+};
+
+/** Materialdepot - the default pictogram for a marker collecting several distinct resources. */
+export const RESOURCE_COLLECTION_SIGN_ID = 80;
+
+/**
+ * Resolves the pictogram id for a single resource article: by `articleNumber`, then by
+ * `articleGroup`, and finally the resource placeholder when nothing matches.
+ */
+export function resolveResourceSignId(article: Pick<ResourceArticle, 'articleNumber' | 'articleGroup'>): number {
+  return (
+    RESOURCE_SIGN_BY_ARTICLE_NUMBER[article.articleNumber] ??
+    RESOURCE_SIGN_BY_ARTICLE_GROUP[article.articleGroup] ??
+    Signs.RESOURCE_PLACEHOLDER_SIGN_ID
+  );
+}
+
+/**
+ * Resolves the pictogram id for a marker that collects several resource articles: if every
+ * article resolves to the same specific (non-placeholder) sign, that sign is used; otherwise
+ * the generic Materialdepot collection sign is used.
+ */
+export function resolveCollectionSignId(articles: Pick<ResourceArticle, 'articleNumber' | 'articleGroup'>[]): number {
+  if (articles.length === 0) {
+    return RESOURCE_COLLECTION_SIGN_ID;
+  }
+
+  const resolvedIds = articles.map((article) => resolveResourceSignId(article));
+  const [first, ...rest] = resolvedIds;
+  const allSame = rest.every((id) => id === first);
+
+  if (allSame && first !== Signs.RESOURCE_PLACEHOLDER_SIGN_ID) {
+    return first;
+  }
+  return RESOURCE_COLLECTION_SIGN_ID;
+}

--- a/packages/app/src/app/resource/resource-signature.mapping.ts
+++ b/packages/app/src/app/resource/resource-signature.mapping.ts
@@ -2,30 +2,27 @@ import { ResourceArticle } from '@zskarte/types';
 import { Signs } from '../map-renderer/signs';
 
 /**
- * Maps a specific `articleNumber` to a BABS pictogram id.
+ * Name fragments that identify what an article *is*, matched case-insensitively against the
+ * `Artikel` column of the imported CSV.
  *
- * Deliberately sparse: the BABS catalogue has no pictograms for generators, lighting,
- * pumps, sirens or extinguishers, and the near-matches that exist ('Energieausfall',
- * 'Stromausfall', 'Wasserversorgungsausfall') are red/orange damage-or-hazard signs that
- * would be factually wrong for a resource marker. Only articles that genuinely are the
- * thing a real sign depicts are listed here - everything else falls through to the group
- * mapping, and then to the placeholder.
+ * Deliberately sparse, and deliberately keyed on the article name rather than on article
+ * numbers: numbers are assigned per organisation, so a hardcoded list of them only ever fits
+ * the one export it was read from. The names in the export are the shared vocabulary.
  *
- * The two entries below are the NTP-specific articles found in the sample export
- * ("Grid-Export (63)(Tabelle1).csv"), both under the 'Spezialartikel' article group and
- * both literally naming themselves as the NTP set/signal:
- * - ZM-001665 'Notfalltreffpunkt-Set NTP'
- * - ZM-001834 'Faltsignal NTP'
- * They map to sign id 158 ('Notfalltreffpunkt' / 'Emergency meeting point').
- * (Two further NTP-adjacent articles exist in the export - ZM-001835 'Blitzwarnlampe NTP'
- * and ZM-001693 'Polycom TPH 900 NTP Einerset' - but neither one *is* the NTP marker
- * itself (a warning lamp and a radio set respectively), so they are intentionally left
- * unmapped and fall back to the placeholder.)
+ * Only fragments that name the very thing a BABS sign depicts belong here. 'Notfalltreffpunkt'
+ * is such a case (sign 158). The bare abbreviation 'NTP' is not: it also appears on articles
+ * that merely belong to an NTP set - a warning lamp, a radio set, a folding sign - none of
+ * which *are* the meeting point. Those fall through to the group mapping and then to the
+ * placeholder, which is the honest answer.
+ *
+ * The BABS catalogue has no pictograms for generators, lighting, pumps, sirens or
+ * extinguishers either, and the near-matches that exist ('Energieausfall', 'Stromausfall',
+ * 'Wasserversorgungsausfall') are red/orange damage-or-hazard signs that would be factually
+ * wrong on a resource marker - so those keep the neutral placeholder too.
  */
-export const RESOURCE_SIGN_BY_ARTICLE_NUMBER: Record<string, number> = {
-  'ZM-001665': 158, // Notfalltreffpunkt-Set NTP -> Notfalltreffpunkt
-  'ZM-001834': 158, // Faltsignal NTP -> Notfalltreffpunkt
-};
+export const RESOURCE_SIGN_BY_NAME_FRAGMENT: { fragment: string; signId: number }[] = [
+  { fragment: 'notfalltreffpunkt', signId: 158 }, // Notfalltreffpunkt
+];
 
 /**
  * Maps an `articleGroup` to a BABS pictogram id. Used when no per-article mapping exists.
@@ -39,15 +36,13 @@ export const RESOURCE_SIGN_BY_ARTICLE_GROUP: Record<string, number> = {
 export const RESOURCE_COLLECTION_SIGN_ID = 80;
 
 /**
- * Resolves the pictogram id for a single resource article: by `articleNumber`, then by
+ * Resolves the pictogram id for a single resource article: by a fragment of its name, then by
  * `articleGroup`, and finally the resource placeholder when nothing matches.
  */
-export function resolveResourceSignId(article: Pick<ResourceArticle, 'articleNumber' | 'articleGroup'>): number {
-  return (
-    RESOURCE_SIGN_BY_ARTICLE_NUMBER[article.articleNumber] ??
-    RESOURCE_SIGN_BY_ARTICLE_GROUP[article.articleGroup] ??
-    Signs.RESOURCE_PLACEHOLDER_SIGN_ID
-  );
+export function resolveResourceSignId(article: Pick<ResourceArticle, 'name' | 'articleGroup'>): number {
+  const name = article.name?.toLowerCase() ?? '';
+  const byName = RESOURCE_SIGN_BY_NAME_FRAGMENT.find((entry) => name.includes(entry.fragment));
+  return byName?.signId ?? RESOURCE_SIGN_BY_ARTICLE_GROUP[article.articleGroup] ?? Signs.RESOURCE_PLACEHOLDER_SIGN_ID;
 }
 
 /**
@@ -55,7 +50,7 @@ export function resolveResourceSignId(article: Pick<ResourceArticle, 'articleNum
  * article resolves to the same specific (non-placeholder) sign, that sign is used; otherwise
  * the generic Materialdepot collection sign is used.
  */
-export function resolveCollectionSignId(articles: Pick<ResourceArticle, 'articleNumber' | 'articleGroup'>[]): number {
+export function resolveCollectionSignId(articles: Pick<ResourceArticle, 'name' | 'articleGroup'>[]): number {
   if (articles.length === 0) {
     return RESOURCE_COLLECTION_SIGN_ID;
   }

--- a/packages/app/src/app/resource/resource.service.ts
+++ b/packages/app/src/app/resource/resource.service.ts
@@ -1,0 +1,289 @@
+import { Injectable, Signal, computed, effect, inject, resource, signal } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { tap } from 'rxjs';
+import {
+  IZsMapBaseDrawElementState,
+  ResourceArticle,
+  ResourceArticleApi,
+  ResourceImportMeta,
+  ResourceImportRequestApi,
+  ResourceImportResponseApi,
+} from '@zskarte/types';
+import { ApiService } from '../api/api.service';
+import { SessionService } from '../session/session.service';
+import { StrapiApiResponseList } from '../helper/strapi-utils';
+import { db } from '../db/db';
+import { ZsMapStateService } from '../state/state.service';
+import {
+  ResourceAssignmentIndex,
+  ResourceCatalogueRow,
+  OrphanedResourceAssignment,
+  buildResourceAssignmentIndex,
+  computeResourceCatalogueRows,
+  findOrphanedAssignments,
+} from './resource-assignments';
+
+/** Sorted, de-duplicated, non-empty string values - used for the catalogue filter dropdowns. */
+function distinctSorted(values: (string | undefined)[]): string[] {
+  const distinct = new Set(values.filter((value): value is string => Boolean(value?.trim())));
+  return [...distinct].sort((a, b) => a.localeCompare(b));
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ResourceService {
+  private _api = inject(ApiService);
+  private _session = inject(SessionService);
+  //late-bound (see setStateService) to avoid a DI cycle:
+  //ZsMapStateService -> SyncService -> ResourceService -> ZsMapStateService
+  private _state!: ZsMapStateService;
+  private _connectionId!: string;
+
+  private operationId = signal<string | null>(null);
+  private organizationId = signal<string | null>(null);
+  private resourceResource = resource({
+    params: () => ({
+      operationId: this.operationId(),
+      organizationId: this.organizationId(),
+    }),
+    loader: async (request) => {
+      return await this.loadCatalogue(request.params.operationId, request.params.organizationId);
+    },
+  });
+  readonly backendData = this.resourceResource.value;
+  readonly loading = this.resourceResource.isLoading;
+  readonly backendError = this.resourceResource.error;
+  readonly error = signal(false);
+  readonly cachedOnly = signal(false);
+  readonly reload = () => this.resourceResource.reload();
+
+  readonly articles = signal<ResourceArticle[]>([]);
+  readonly importMeta = signal<ResourceImportMeta | undefined>(undefined);
+
+  /** All draw elements currently on the map, kept up to date once `setStateService` is wired. */
+  private readonly drawElements = signal<IZsMapBaseDrawElementState[]>([]);
+
+  readonly assignmentIndex: Signal<ResourceAssignmentIndex> = computed(() =>
+    buildResourceAssignmentIndex(this.drawElements()),
+  );
+  readonly catalogueRows: Signal<ResourceCatalogueRow[]> = computed(() =>
+    computeResourceCatalogueRows(this.articles(), this.assignmentIndex()),
+  );
+  readonly orphanedAssignments: Signal<OrphanedResourceAssignment[]> = computed(() =>
+    findOrphanedAssignments(this.drawElements(), this.articles()),
+  );
+
+  readonly articleGroups: Signal<string[]> = computed(() =>
+    distinctSorted(this.articles().map((article) => article.articleGroup)),
+  );
+  readonly articleTypes: Signal<string[]> = computed(() =>
+    distinctSorted(this.articles().map((article) => article.articleType)),
+  );
+  readonly storageSites: Signal<string[]> = computed(() =>
+    distinctSorted(this.articles().flatMap((article) => article.items.map((item) => item.storageLocation))),
+  );
+
+  constructor() {
+    effect(() => {
+      this._session
+        .observeOperationId()
+        .pipe(
+          tap((operationId) => this.operationId.set(operationId as string)),
+          tap(() => this.resourceResource.reload()),
+        )
+        .subscribe();
+    });
+    effect(() => {
+      this._session
+        .observeOrganizationId()
+        .pipe(
+          tap((organizationId) => this.organizationId.set(organizationId as string)),
+          tap(() => this.resourceResource.reload()),
+        )
+        .subscribe();
+    });
+
+    effect(async () => {
+      if (this._session.isWorkLocal()) {
+        this.applyArticles((this.backendData() as ResourceArticleApi[]) || []);
+        return;
+      }
+      const operationId = this.operationId();
+      const organizationId = this.organizationId();
+      if (!operationId || !organizationId) {
+        this.applyArticles([]);
+        return;
+      }
+
+      if (this.backendError()) {
+        try {
+          const cached = await db.localResourceArticles.where({ operationId, organizationId }).toArray();
+          if (cached.length > 0) {
+            this.applyArticles(cached);
+            this.error.set(false);
+            this.cachedOnly.set(true);
+            return;
+          }
+        } catch (e) {
+          console.error(`Error retrieving cached resource articles for ${operationId}:`, e);
+        }
+        this.error.set(true);
+        this.applyArticles([]);
+      } else {
+        this.error.set(false);
+        this.cachedOnly.set(false);
+        const current = this.backendData() as ResourceArticleApi[] | undefined;
+        if (current && current.length > 0) {
+          this.applyArticles(current);
+          try {
+            await db.transaction('rw', db.localResourceArticles, async () => {
+              await db.localResourceArticles.where({ operationId, organizationId }).delete();
+              await db.localResourceArticles.bulkPut(
+                current.map((article) => ({
+                  ...article,
+                  operationId,
+                  organizationId,
+                  fromCache: true,
+                })),
+              );
+            });
+          } catch (e) {
+            console.error(`Error updating resource cache for ${operationId}:`, e);
+          }
+        } else {
+          this.applyArticles([]);
+          //delete from cache if backend explicitly sends an empty list
+          if (Array.isArray(current)) {
+            try {
+              await db.localResourceArticles.where({ operationId, organizationId }).delete();
+            } catch (e) {
+              console.error(`Error clearing resource cache for ${operationId}:`, e);
+            }
+          }
+        }
+      }
+    });
+  }
+
+  private applyArticles(list: ResourceArticleApi[]): void {
+    this.articles.set(list);
+    const first = list[0];
+    this.importMeta.set(
+      first
+        ? {
+            importId: first.importId,
+            importedAt: first.importedAt,
+            sourceExportedAt: first.sourceExportedAt,
+            sourceOrganisation: first.sourceOrganisation,
+          }
+        : undefined,
+    );
+  }
+
+  public setStateService(state: ZsMapStateService): void {
+    this._state = state;
+    state.observeMapState().subscribe((mapState) => {
+      this.drawElements.set(Object.values(mapState?.drawElements ?? {}));
+    });
+  }
+
+  public setConnectionId(connectionId: string): void {
+    this._connectionId = connectionId;
+  }
+
+  public async loadCatalogue(operationId: string | null, organizationId: string | null): Promise<ResourceArticleApi[]> {
+    if (!operationId || !organizationId) {
+      return [];
+    }
+    if (this._session.isWorkLocal() || operationId.startsWith('local-')) {
+      return await db.localResourceArticles.where({ operationId, organizationId }).toArray();
+    }
+
+    const articles: ResourceArticleApi[] = [];
+    let page = 0;
+    const pageSize = 1000;
+    let error: HttpErrorResponse | undefined;
+    let result: StrapiApiResponseList<ResourceArticleApi> | undefined;
+    do {
+      page++;
+      //organization is implicit by session
+      ({ error, result } = await this._api.get<StrapiApiResponseList<ResourceArticleApi>>(
+        `/api/resource-articles?operationId=${operationId}&pagination[pageSize]=${pageSize}&pagination[page]=${page}&sort=articleNumber`,
+        { keepMeta: true },
+      ));
+      if (error || !result) {
+        throw 'error on fetch resource articles';
+      }
+      articles.push(...result.data);
+    } while (page < result.meta.pagination.pageCount);
+    return articles;
+  }
+
+  public findArticle(articleNumber: string): ResourceArticle | undefined {
+    return this.articles().find((article) => article.articleNumber === articleNumber);
+  }
+
+  /**
+   * Local operations (guest mode, `local-…`) have no server behind them, so the catalogue is
+   * written straight to IndexedDB instead of being POSTed. Mirrors what the import endpoint
+   * does server-side: the operation's whole catalogue is replaced in one transaction.
+   */
+  private async commitImportLocally(
+    request: ResourceImportRequestApi,
+    operationId: string,
+    organizationId: string,
+  ): Promise<{ error?: unknown; result?: ResourceImportResponseApi }> {
+    const importedAt = new Date();
+    const rows = request.articles.map((article) => ({
+      ...article,
+      importId: request.importId,
+      importedAt,
+      sourceExportedAt: request.sourceExportedAt,
+      sourceOrganisation: request.sourceOrganisation,
+      operationId,
+      organizationId,
+      fromCache: true,
+    }));
+    try {
+      await db.transaction('rw', db.localResourceArticles, async () => {
+        await db.localResourceArticles.where({ operationId, organizationId }).delete();
+        await db.localResourceArticles.bulkPut(rows);
+      });
+    } catch (error) {
+      return { error };
+    }
+    this.applyArticles(rows);
+    this.error.set(false);
+    this.cachedOnly.set(false);
+    return {
+      result: {
+        importId: request.importId,
+        articleCount: request.articles.length,
+        itemCount: request.articles.reduce((sum, article) => sum + article.items.length, 0),
+        alreadyImported: false,
+      },
+    };
+  }
+
+  public async commitImport(
+    request: ResourceImportRequestApi,
+  ): Promise<{ error?: unknown; result?: ResourceImportResponseApi }> {
+    const operationId = this.operationId();
+    const organizationId = this.organizationId();
+    if ((this._session.isWorkLocal() || operationId?.startsWith('local-')) && operationId && organizationId) {
+      return await this.commitImportLocally(request, operationId, organizationId);
+    }
+
+    const response = await this._api.post<ResourceImportResponseApi>(
+      '/api/resource-articles/import',
+      { data: request },
+      { headers: { identifier: this._connectionId } },
+    );
+    const { error, result } = response;
+    if (!error && result) {
+      this.reload();
+    }
+    return response;
+  }
+}

--- a/packages/app/src/app/resource/testing/resource-fixture.csv
+++ b/packages/app/src/app/resource/testing/resource-fixture.csv
@@ -1,0 +1,25 @@
+Organisation;ZSO Unteres Fricktal;;;67;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+Material - Übersicht Bestand;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+Bestand ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+Exportiert am;07.09.2026;;14:15:45;;Benutzer;max.muster;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+Organisation;Status;aktuelle Verwendung;Artikelnummer;Artikel;Artikelgruppe;Artikeltyp;Sirenentyp;Kommentar;Seriennummer;Serien-Nr. intern;Charge;Hersteller;Plombiert;Konserviert;Betriebsart;Inhalt;Einheit;Kapazität;Aktueller Inhalt;Einkaufspreis;Kaufpreis;Kaufdatum;Garantieende;Zulassungs-Nr.;Lagerort-Code;Lagerort;Verrechnung;Verrechnung am;Verrechnung durch;Verrechnung Detail;SAP Exportdatum;SAP Zuweisungs-Nr.;SAP Zahlungsdatum;SAP Mahnung 1;SAP Beleg-Nr.;Lagerort 2;Koordinaten
+ZSO Unteres Fricktal;an Lager;;ZM-000680;"Stromaggregat ""Kirsch""";Erzeugen von Energie;Stand. ZS Material Kat. B;;;SN-1;12;;Kirsch;Nein;Nein;;;;;;;;;;;2.2.01;Augarten\Halle;Nein;;;;;;;;;BSA Augarten Rheinfelden;
+ZSO Unteres Fricktal;an Lager;;ZM-000680;"Stromaggregat ""Kirsch""";Erzeugen von Energie;Stand. ZS Material Kat. B;;;SN-2;13;;Kirsch;Nein;Nein;;;;;;;;;;;2.2.01;Augarten\Halle;Nein;;;;;;;;;BSA Augarten Rheinfelden;
+ZSO Unteres Fricktal;an Lager;;ZM-000680;"Stromaggregat ""Kirsch""";Erzeugen von Energie;Stand. ZS Material Kat. B;;;SN-2;14;;Kirsch;Nein;Nein;;;;;;;;;;;2.2.02;Augarten\Halle;Nein;;;;;;;;;BSA Augarten Rheinfelden;
+ZSO Unteres Fricktal;an Lager;;ZM-000057;Anhänger ZS;Transport/Logistik;Stand. ZS Material Kat. B;;"AG 719 186
+Weisse Nummer";AG-1;;;;Nein;Nein;;;;;;;;;;;2.1.1;Rüteli\Aussenplatz;Nein;;;;;;;;;Materiallager Rüteli;
+ZSO Unteres Fricktal;in Reparatur;;ZM-000057;Anhänger ZS;Transport/Logistik;Stand. ZS Material Kat. B;;;AG-2;;;;Nein;Nein;;;;;;;;;;;2.1.1;Rüteli\Aussenplatz;Nein;;;;;;;;;Materiallager Rüteli;
+ZSO Unteres Fricktal;an Lager;;ZM-001577;"Klett ""Soldat""";Ausrüstung AdZS;Stand. ZS Material Kat. C;;;;;;;Nein;Nein;;;;;;;;;;;1.1;Persönlich;Nein;;;;;;;;;Persönliche Ausrüstung;
+ZSO Unteres Fricktal;an Lager;;ZM-001577;"Klett ""Soldat""";Ausrüstung AdZS;Stand. ZS Material Kat. C;;;;;;;Nein;Nein;;;;;;;;;;;1.1;Persönlich;Nein;;;;;;;;;Persönliche Ausrüstung;
+ZSO Unteres Fricktal;an Lager;;ZM-001577;"Klett ""Soldat""";Ausrüstung AdZS;Stand. ZS Material Kat. C;;;;;;;Nein;Nein;;;;;;;;;;;1.1;Persönlich;Nein;;;;;;;;;Persönliche Ausrüstung;
+ZSO Unteres Fricktal;an Lager;;;Beingummi pro Stück;Ausrüstung AdZS;Stand. ZS Material Kat. C;;;;;;;Nein;Nein;;;;;;;;;;;1.2;Persönlich;Nein;;;;;;;;;Persönliche Ausrüstung;
+ZSO Unteres Fricktal;an Lager;;;Beingummi pro Stück;Ausrüstung AdZS;Stand. ZS Material Kat. C;;;;;;;Nein;Nein;;;;;;;;;;;1.2;Persönlich;Nein;;;;;;;;;Persönliche Ausrüstung;
+ZSO Unteres Fricktal;an Lager;;ZM-000552;Regenjacke 52/56;Ausrüstung AdZS;Stand. ZS Material Kat. C;;;;;;;Nein;Nein;;;;;;;;;;;1.3;Persönlich;Nein;;;;;;;;;Persönliche Ausrüstung;
+ZSO Unteres Fricktal;an Lager;;ZM-000552;Regenjacke 52/56;Ausrüstung AdZS;Stand. ZS Material Kat. C;;;;;;;Nein;Nein;;;;;;;;;;;1.3;Persönlich;Nein;;;;;;;;;Persönliche Ausrüstung;
+ZSO Unteres Fricktal;an Lager;;ZM-000552;Regenjacke52/56;Ausrüstung AdZS;Stand. ZS Material Kat. C;;;;;;;Nein;Nein;;;;;;;;;;;1.3;Persönlich;Nein;;;;;;;;;Persönliche Ausrüstung;
+ZSO Unteres Fricktal;an Lager;;ZM-000582;Schadenplatzbeleuchtung (el);Beleuchtung;Stand. ZS Material Kat. C;;;;;;;Nein;Nein;;;;;;;;;;;2.3;Werkhof\Lager;Nein;;;;;;;;;#VALUE!;
+ZSO Unteres Fricktal;an Lager;;ZM-000015;Abwasser Tauchpumpe Mast ATP20, inkl. Zubehör;Wassermaterial;Stand. ZS Material Kat. C;;;TP-9;;;;Ja;Nein;;;Liter;;;;;09.12.2024;;;2.4;Werkhof\Lager;Nein;;;;;;;;;BSA Werkhof Stein;47.547959470582526, 7.767585683309598
+ZSO Unteres Fricktal;an Lager;;ZM-999999;;Keine Zuordnung;ZSO Material;;;;;;;Nein;Nein;;;;;;;;;;;9.9;Unbekannt;Nein;;;;;;;;;;

--- a/packages/app/src/app/selected-feature/selected-feature.component.html
+++ b/packages/app/src/app/selected-feature/selected-feature.component.html
@@ -246,6 +246,103 @@
                   />
                 </mat-form-field>
               }
+              @if (canAssignResources(drawElement)) {
+                <div class="resource-assignments">
+                  <div class="resource-assignments-header" style="font-weight: bold; margin-bottom: 0.5rem">
+                    {{ i18n.get('resourceAssignedItems') }} ({{ (drawElement.resourceItems ?? []).length }})
+                  </div>
+                  @for (assignment of drawElement.resourceItems ?? []; track $index) {
+                    <div
+                      class="resource-assignment-row"
+                      style="display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.25rem"
+                    >
+                      @let sign = resourceAssignmentSignature(assignment);
+                      @if (sign) {
+                        <img
+                          [src]="getImageUrl(sign)"
+                          alt=""
+                          class="resource-assignment-icon"
+                          style="width: 22px; height: 22px; object-fit: contain; flex-shrink: 0"
+                        />
+                      }
+                      <span class="resource-assignment-label" style="flex: 1; min-width: 0">
+                        {{ assignment.quantity }}× {{ assignment.name }}
+                        @if (assignment.serialNumber) {
+                          <span
+                            class="resource-assignment-serial"
+                            style="display: block; color: #787878; font-size: 0.8rem"
+                          >
+                            {{ i18n.get('resourceSerialNumber') }}: {{ assignment.serialNumber }}
+                          </span>
+                        }
+                      </span>
+                      <button
+                        mat-icon-button
+                        type="button"
+                        [attr.aria-label]="i18n.get('resourceRemoveAssignment')"
+                        [matTooltip]="i18n.get('resourceRemoveAssignment')"
+                        (click)="removeResourceAssignment($index, drawElement)"
+                      >
+                        <mat-icon>close</mat-icon>
+                      </button>
+                    </div>
+                  }
+                  <mat-form-field appearance="outline" subscriptSizing="dynamic" class="resource-add-field">
+                    <mat-label>{{ i18n.get('resourceAddAssignment') }}</mat-label>
+                    <input
+                      matInput
+                      type="text"
+                      [placeholder]="i18n.get('resourceAddAssignmentSearch')"
+                      [matAutocomplete]="resourceAddAutocomplete"
+                      [ngModel]="resourceSearch()"
+                      (ngModelChange)="updateResourceSearch($event)"
+                    />
+                    <mat-icon matSuffix>search</mat-icon>
+                  </mat-form-field>
+                  <mat-autocomplete
+                    #resourceAddAutocomplete="matAutocomplete"
+                    [displayWith]="displayNoResourceOption"
+                    (optionSelected)="addResourceAssignment($event.option.value, drawElement)"
+                  >
+                    @for (option of resourceAddOptions(); track option.itemKey ?? option.articleNumber + option.state) {
+                      <mat-option
+                        [value]="option"
+                        [disabled]="!canAssignResourceOption(option)"
+                        class="resource-add-option"
+                      >
+                        @let optionSign = resourceOptionSignature(option);
+                        @if (optionSign) {
+                          <img [src]="getImageUrl(optionSign)" alt="" class="resource-add-option-icon" />
+                        }
+                        <span class="resource-add-option-label">
+                          <span class="resource-add-option-name">{{ option.name }}</span>
+                          <span class="resource-add-option-meta">
+                            {{ option.articleNumber }}
+                            @if (option.serialNumber) {
+                              · {{ i18n.get('resourceSerialNumber') }}: {{ option.serialNumber }}
+                            } @else {
+                              · {{ option.count }} {{ i18n.get('resourceAddAssignmentPieces') }}
+                            }
+                            @switch (option.state) {
+                              @case ('free') {
+                                · {{ i18n.get('resourceAddAssignmentAvailable') }}
+                              }
+                              @case ('deployed') {
+                                · {{ i18n.get('resourceAddAssignmentDeployed') }}
+                              }
+                              @case ('notInStock') {
+                                · {{ option.status }}
+                              }
+                            }
+                          </span>
+                        </span>
+                      </mat-option>
+                    } @empty {
+                      <mat-option disabled>{{ i18n.get('resourceAddAssignmentNoResults') }}</mat-option>
+                    }
+                  </mat-autocomplete>
+                </div>
+              }
             }
           </div>
           <mat-divider></mat-divider>

--- a/packages/app/src/app/selected-feature/selected-feature.component.scss
+++ b/packages/app/src/app/selected-feature/selected-feature.component.scss
@@ -233,3 +233,54 @@ div.flex {
 .report-number-chip mat-icon::after {
   margin-left: -2px;
 }
+
+.resource-add-field {
+  width: 100%;
+  margin-top: 0.5rem;
+}
+
+// The option holds two lines, so it must be allowed to grow; its inner text wrapper is part of
+// mat-option's own view, hence ::ng-deep to lay the icon and the label out side by side.
+.resource-add-option {
+  height: auto;
+  min-height: 48px;
+
+  ::ng-deep .mdc-list-item__primary-text {
+    display: flex;
+    align-items: center;
+    width: 100%;
+  }
+}
+
+.resource-add-option-icon {
+  width: 22px;
+  height: 22px;
+  object-fit: contain;
+  flex-shrink: 0;
+  margin-right: 0.5rem;
+}
+
+.resource-add-option-label {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  line-height: 1.25;
+  padding: 0.25rem 0;
+}
+
+.resource-add-option-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+// The meta line carries the state ("verfügbar", "in Reparatur", ...) - it must stay readable in
+// the narrow panel, so it wraps instead of being cut off.
+.resource-add-option-meta {
+  white-space: normal;
+}
+
+.resource-add-option-meta {
+  color: #787878;
+  font-size: 0.8rem;
+}

--- a/packages/app/src/app/selected-feature/selected-feature.component.ts
+++ b/packages/app/src/app/selected-feature/selected-feature.component.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { Component, computed, inject, OnDestroy } from '@angular/core';
+import { Component, computed, inject, OnDestroy, signal } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ConfirmationDialogComponent } from '../confirmation-dialog/confirmation-dialog.component';
 import { DetailImageViewComponent } from '../detail-image-view/detail-image-view.component';
@@ -27,11 +27,14 @@ import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatChipInputEvent, MatChipsModule } from '@angular/material/chips';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import {
   defineDefaultValuesForSignature,
   FillStyle,
   getColorForCategory,
   IconsOffset,
+  ResourceAssignment,
   Sign,
   signatureDefaultValues,
   ZsMapDrawElementState,
@@ -41,6 +44,10 @@ import { MatDividerModule } from '@angular/material/divider';
 import { Router } from '@angular/router';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { Signs } from '../map-renderer/signs';
+import { ResourceService } from '../resource/resource.service';
+import { RESOURCE_LAYER_NAME, ResourcePlacementService } from '../resource/placement/resource-placement.service';
+import { resolveResourceSignId } from '../resource/resource-signature.mapping';
+import { ResourceAddOption, buildResourceAddOptions, canAssignOption } from '../resource/resource-assignment-picker';
 
 @Component({
   selector: 'app-selected-feature',
@@ -62,12 +69,16 @@ import { Signs } from '../map-renderer/signs';
     MatCheckboxModule,
     MatDividerModule,
     MatChipsModule,
+    MatTooltipModule,
+    MatAutocompleteModule,
   ],
 })
 export class SelectedFeatureComponent implements OnDestroy {
   dialog = inject(MatDialog);
   i18n = inject(I18NService);
   zsMapStateService = inject(ZsMapStateService);
+  private resourceService = inject(ResourceService);
+  private resourcePlacement = inject(ResourcePlacementService);
   private router = inject(Router);
 
   groupedFeatures = null;
@@ -263,6 +274,97 @@ export class SelectedFeatureComponent implements OnDestroy {
         draft[field as T] = value;
       });
     }
+  }
+
+  /**
+   * Resolves the small pictogram shown next to one assigned resource: looked up via the
+   * article's own group (not the marker's `symbolId`, which the user can freely change), or
+   * the resource placeholder when the article is no longer in the catalogue.
+   */
+  resourceAssignmentSignature(assignment: ResourceAssignment): Sign | undefined {
+    const article = this.resourceService.findArticle(assignment.articleNumber);
+    const signId = article ? resolveResourceSignId(article) : Signs.RESOURCE_PLACEHOLDER_SIGN_ID;
+    return Signs.getSignById(signId);
+  }
+
+  /** Free-text term of the "add resource" search below the assigned-resources list. */
+  readonly resourceSearch = signal('');
+
+  /**
+   * The catalogue entries matching `resourceSearch()`, free ones first. Nothing is hidden: a
+   * piece the inventory export lists as unavailable (in Reparatur, ausgeliehen, ...) is offered
+   * too, with its status shown, since the export is a snapshot and the person on the map knows
+   * what is actually on site. Only pieces already carried by a marker cannot be picked.
+   */
+  readonly resourceAddOptions = computed(() =>
+    buildResourceAddOptions(
+      this.resourceService.articles(),
+      this.resourceService.assignmentIndex(),
+      this.resourceSearch(),
+    ),
+  );
+
+  // skipcq: JS-0105
+  canAssignResourceOption(option: ResourceAddOption): boolean {
+    return canAssignOption(option);
+  }
+
+  /**
+   * Whether the resource section (list + search) is offered for this element: for markers that
+   * already carry resources, and for anything on the shared "Mittel im Einsatz" layer - the
+   * markers `ResourcePlacementService` deploys to. Keeping it to those preserves the invariant
+   * that a marker carrying resources *is* a resource marker, which is what lets `takeBack`
+   * delete it once its last piece is returned to stock.
+   */
+  canAssignResources(element: ZsMapDrawElementState): boolean {
+    if (this.resourceService.articles().length === 0) {
+      return false;
+    }
+    return !!element.resourceItems?.length || this.selectedElementLayerName() === RESOURCE_LAYER_NAME;
+  }
+
+  /** Pictogram of one search result, resolved from its article exactly like an assigned row. */
+  resourceOptionSignature(option: ResourceAddOption): Sign | undefined {
+    return Signs.getSignById(resolveResourceSignId(option.article));
+  }
+
+  /** Adds the picked piece to this marker and resets the search so the next one can be typed. */
+  addResourceAssignment(option: ResourceAddOption, element: ZsMapDrawElementState) {
+    this.resourceSearch.set('');
+    if (!element.id || !canAssignOption(option)) {
+      return;
+    }
+    this.resourcePlacement.assign(element.id, option);
+  }
+
+  /**
+   * The autocomplete writes the picked option (an object) back through `ngModel` before
+   * `optionSelected` fires; only real typing carries a string.
+   */
+  updateResourceSearch(value: unknown) {
+    this.resourceSearch.set(typeof value === 'string' ? value : '');
+  }
+
+  /** Keeps the input empty when an option is picked - the picked resource shows up in the list above. */
+  // skipcq: JS-0105
+  displayNoResourceOption(): string {
+    return '';
+  }
+
+  /**
+   * Removes one assigned resource from this marker via `ResourcePlacementService.takeBack`, the
+   * same path `resource-deployed.component` uses - so both places behave identically, including
+   * deleting the marker once its last resource item is taken back. The piece becomes available
+   * again in the catalogue automatically: `ResourceService.assignmentIndex` is a computed signal
+   * derived from `state.observeMapState()`, which `takeBack` writes through, so this recomputes
+   * as soon as the map state changes - no separate "free the item" step needed.
+   */
+  removeResourceAssignment(index: number, element: ZsMapDrawElementState) {
+    const assignment = (element.resourceItems ?? [])[index];
+    if (!element.id || !assignment) {
+      return;
+    }
+    this.resourcePlacement.takeBack(element.id, assignment);
   }
 
   updateFillStyle<T extends keyof FillStyle>(element: ZsMapDrawElementState, field: T, value: FillStyle[T]) {

--- a/packages/app/src/app/sidebar/sidebar-menu/sidebar-menu.component.ts
+++ b/packages/app/src/app/sidebar/sidebar-menu/sidebar-menu.component.ts
@@ -119,7 +119,7 @@ export class SidebarMenuComponent {
   }
 
   openResourceOverviewWindow(): void {
-    this.dialog.open(ResourceOverviewComponent);
+    this.dialog.open(ResourceOverviewComponent, { width: '90vw', maxWidth: '1400px', height: '85vh' });
   }
 
   organisationSettings(): void {

--- a/packages/app/src/app/state/i18n.service.ts
+++ b/packages/app/src/app/state/i18n.service.ts
@@ -6,6 +6,7 @@ import { MAP_TRANSLATIONS } from './translations/map.translations';
 import { LAYER_TRANSLATIONS } from './translations/layer.translations';
 import { JOURNAL_TRANSLATIONS } from './translations/journal.translations';
 import { DOCUMENTATION_TRANSLATIONS } from './translations/documentation.translations';
+import { RESOURCE_TRANSLATIONS } from './translations/resource.translations';
 
 /**
  * Translation Management Guide - ZSKarte Application
@@ -335,6 +336,7 @@ export class I18NService {
     ...LAYER_TRANSLATIONS,
     ...JOURNAL_TRANSLATIONS,
     ...DOCUMENTATION_TRANSLATIONS,
+    ...RESOURCE_TRANSLATIONS,
   };
 
   public get(key: string): string {

--- a/packages/app/src/app/state/translations/resource.translations.ts
+++ b/packages/app/src/app/state/translations/resource.translations.ts
@@ -1,0 +1,553 @@
+//resource catalogue (Mittelübersicht) texts
+export const RESOURCE_TRANSLATIONS = {
+  resourceCatalogue: {
+    de: 'Katalog',
+    en: 'Catalogue',
+    fr: 'Catalogue',
+  },
+  resourceTabCatalogue: {
+    de: 'Katalog',
+    en: 'Catalogue',
+    fr: 'Catalogue',
+  },
+  resourceTabDeployed: {
+    de: 'Im Einsatz',
+    en: 'Deployed',
+    fr: 'En engagement',
+  },
+  resourceTabFormations: {
+    de: 'Formationen',
+    en: 'Formations',
+    fr: 'Formations',
+  },
+  resourceImportCsv: {
+    de: 'CSV importieren',
+    en: 'Import CSV',
+    fr: 'Importer CSV',
+  },
+  resourceImportTitle: {
+    de: 'Bestand importieren',
+    en: 'Import stock',
+    fr: 'Importer le stock',
+  },
+  resourceImportPreviewTitle: {
+    de: 'Bestand importieren — Vorschau',
+    en: 'Import stock — preview',
+    fr: 'Importer le stock — aperçu',
+  },
+  resourceImportSelectFile: {
+    de: 'Datei auswählen',
+    en: 'Select file',
+    fr: 'Sélectionner un fichier',
+  },
+  resourceImportRead: {
+    de: 'Einlesen',
+    en: 'Read file',
+    fr: 'Lire le fichier',
+  },
+  resourceImportReadSummary: {
+    de: 'Gelesen',
+    en: 'Read',
+    fr: 'Lu',
+  },
+  resourceImportCommit: {
+    de: 'Import ausführen',
+    en: 'Run import',
+    fr: "Exécuter l'import",
+  },
+  resourceImportHint: {
+    de: 'Erwartete Spalten: Artikelnummer, Bezeichnung, Artikelgruppe, Artikeltyp, Status, Seriennummer, Lagerort u.a. gemäss Export des Inventarsystems.',
+    en: 'Expected columns: article number, name, article group, article type, status, serial number, storage location, etc. as exported by the inventory system.',
+    fr: "Colonnes attendues : numéro d'article, désignation, groupe d'articles, type d'article, statut, numéro de série, emplacement de stockage, etc. selon l'export du système d'inventaire.",
+  },
+  resourceImportAdded: {
+    de: 'Artikel neu',
+    en: 'New articles',
+    fr: 'Nouveaux articles',
+  },
+  resourceImportRemoved: {
+    de: 'Artikel nicht mehr im Export',
+    en: 'Articles no longer in export',
+    fr: "Articles absents de l'export",
+  },
+  resourceImportChanged: {
+    de: 'Artikel mit geänderter Stückzahl',
+    en: 'Articles with changed quantity',
+    fr: 'Articles avec quantité modifiée',
+  },
+  resourceImportUnchanged: {
+    de: 'unverändert',
+    en: 'unchanged',
+    fr: 'inchangé',
+  },
+  resourceImportAffected: {
+    de: 'zugewiesene Mittel entfallen',
+    en: 'assigned resources affected',
+    fr: 'ressources attribuées concernées',
+  },
+  resourceImportAffectedHint: {
+    de: 'Diese Mittel bleiben auf der Karte, werden aber als nicht mehr an Lager markiert.',
+    en: 'These resources stay on the map but are marked as no longer in stock.',
+    fr: "Ces ressources restent sur la carte mais sont marquées comme n'étant plus en stock.",
+  },
+  resourceImportOrgMismatch: {
+    de: 'Die Organisation im Export stimmt nicht mit Ihrer Organisation überein',
+    en: 'The organisation in the export does not match your organisation',
+    fr: "L'organisation figurant dans l'export ne correspond pas à votre organisation",
+  },
+  resourceImportNotices: {
+    de: 'Hinweise',
+    en: 'Notices',
+    fr: 'Remarques',
+  },
+  resourceImportErrors: {
+    de: 'Fehler beim Einlesen',
+    en: 'Errors while reading',
+    fr: 'Erreurs lors de la lecture',
+  },
+  resourceImportSuccess: {
+    de: 'Bestand importiert',
+    en: 'Stock imported',
+    fr: 'Stock importé',
+  },
+  resourceClear: {
+    de: 'Bestand entfernen',
+    en: 'Remove stock',
+    fr: "Supprimer l'inventaire",
+  },
+  resourceClearTitle: {
+    de: 'Gesamten Bestand entfernen?',
+    en: 'Remove the entire stock?',
+    fr: "Supprimer tout l'inventaire ?",
+  },
+  resourceClearConfirm: {
+    de: 'Der gesamte Bestand dieses Ereignisses wird entfernt. Bereits auf der Karte platzierte Mittel bleiben bestehen und werden als "Nicht im Katalog" gekennzeichnet.',
+    en: 'The entire stock of this event will be removed. Resources already placed on the map are kept and will be marked as "not in catalogue".',
+    fr: "L'ensemble de l'inventaire de cet événement sera supprimé. Les moyens déjà placés sur la carte sont conservés et seront marqués « hors catalogue ».",
+  },
+  resourceImportOnlineOnly: {
+    de: 'Der Import ist nur mit Verbindung zum Server möglich',
+    en: 'The import is only possible with a connection to the server',
+    fr: "L'import n'est possible qu'avec une connexion au serveur",
+  },
+  resourceImportRows: {
+    de: 'Zeilen',
+    en: 'Rows',
+    fr: 'Lignes',
+  },
+  resourceImportArticles: {
+    de: 'Artikel',
+    en: 'Articles',
+    fr: 'Articles',
+  },
+  resourceImportItems: {
+    de: 'Stück',
+    en: 'Pieces',
+    fr: 'Pièces',
+  },
+  resourceExportedAt: {
+    de: 'Export vom',
+    en: 'Exported on',
+    fr: 'Exporté le',
+  },
+  resourceOverviewIntro: {
+    de: 'Bestand als CSV importieren: eine Zeile pro Stück, Spalten mit Semikolon getrennt. Stücke mit Seriennummer sind einzeln zuweisbar, alle übrigen zählen als Menge. Danach lassen sich Mittel auf der Karte platzieren und einzelnen Markierungen zuweisen.',
+    en: 'Import your stock as CSV: one row per piece, columns separated by semicolons. Pieces with a serial number can be assigned individually, all others count as a quantity. Resources can then be placed on the map and assigned to individual markers.',
+    fr: "Importez votre stock au format CSV : une ligne par pièce, colonnes séparées par des points-virgules. Les pièces avec numéro de série s'attribuent individuellement, les autres comptent comme quantité. Les moyens peuvent ensuite être placés sur la carte et attribués à des marqueurs.",
+  },
+  resourceExampleCsv: {
+    de: 'Beispiel-CSV herunterladen',
+    en: 'Download example CSV',
+    fr: "Télécharger le CSV d'exemple",
+  },
+  resourceExampleCsvHint: {
+    de: 'Die Vorlage enthält alle Pflichtspalten, erklärt sie in den Kopfzeilen und zeigt Beispielzeilen - Beispielzeilen ersetzen, fertig.',
+    en: 'The template contains every required column, explains them in its header rows and shows example rows - replace the example rows and you are done.',
+    fr: "Le modèle contient toutes les colonnes obligatoires, les explique dans ses en-têtes et montre des lignes d'exemple - remplacez-les et c'est prêt.",
+  },
+  resourceMarkerGroup: {
+    de: 'Markierung',
+    en: 'Marker',
+    fr: 'Marqueur',
+  },
+  resourceMarkerGroupCount: {
+    de: 'Mittel auf dieser Markierung',
+    en: 'resources on this marker',
+    fr: 'moyens sur ce marqueur',
+  },
+  resourceLastImport: {
+    de: 'Stand',
+    en: 'As of',
+    fr: 'État au',
+  },
+  resourceCachedOnly: {
+    de: 'Offline — lokal gespeicherter Stand',
+    en: 'Offline — locally cached state',
+    fr: 'Hors ligne — état enregistré localement',
+  },
+  resourceSearch: {
+    de: 'Suchen',
+    en: 'Search',
+    fr: 'Rechercher',
+  },
+  resourceSearchHint: {
+    de: 'Artikel, Artikelnummer, Seriennummer',
+    en: 'Article, article number, serial number',
+    fr: "Article, numéro d'article, numéro de série",
+  },
+  resourceFilterClear: {
+    de: 'Filter leeren',
+    en: 'Clear filter',
+    fr: 'Réinitialiser le filtre',
+  },
+  resourceFilterAvailability: {
+    de: 'Verfügbarkeit',
+    en: 'Availability',
+    fr: 'Disponibilité',
+  },
+  resourceAvailable: {
+    de: 'verfügbar',
+    en: 'available',
+    fr: 'disponible',
+  },
+  resourceAssigned: {
+    de: 'zugewiesen',
+    en: 'assigned',
+    fr: 'attribué',
+  },
+  resourceUnavailable: {
+    de: 'nicht einsatzbereit',
+    en: 'not ready for use',
+    fr: 'non disponible',
+  },
+  resourceCountOf: {
+    de: 'von',
+    en: 'of',
+    fr: 'sur',
+  },
+  resourceNoFilterResults: {
+    de: 'Keine Artikel entsprechen den Filtern',
+    en: 'No articles match the filters',
+    fr: 'Aucun article ne correspond aux filtres',
+  },
+  resourceLoadError: {
+    de: 'Fehler beim Laden des Bestands',
+    en: 'Error loading stock',
+    fr: 'Erreur lors du chargement du stock',
+  },
+  resourceSerialNumberInternal: {
+    de: 'Interne Seriennummer',
+    en: 'Internal serial number',
+    fr: 'Numéro de série interne',
+  },
+  resourceItemsToggle: {
+    de: 'Einzelstücke anzeigen/ausblenden',
+    en: 'Show/hide individual pieces',
+    fr: 'Afficher/masquer les pièces individuelles',
+  },
+  resourceSelectArticle: {
+    de: 'Artikel auswählen',
+    en: 'Select article',
+    fr: "Sélectionner l'article",
+  },
+  resourceSelectAllArticles: {
+    de: 'Alle angezeigten Artikel auswählen',
+    en: 'Select all shown articles',
+    fr: 'Sélectionner tous les articles affichés',
+  },
+  resourceSelectItem: {
+    de: 'Stück auswählen',
+    en: 'Select piece',
+    fr: 'Sélectionner la pièce',
+  },
+  resourceQuantityDecrease: {
+    de: 'Menge verringern',
+    en: 'Decrease quantity',
+    fr: 'Diminuer la quantité',
+  },
+  resourceQuantityIncrease: {
+    de: 'Menge erhöhen',
+    en: 'Increase quantity',
+    fr: 'Augmenter la quantité',
+  },
+  resourceArticleNumber: {
+    de: 'Artikelnummer',
+    en: 'Article number',
+    fr: "Numéro d'article",
+  },
+  resourceArticleName: {
+    de: 'Artikel',
+    en: 'Article',
+    fr: 'Article',
+  },
+  resourceArticleGroup: {
+    de: 'Artikelgruppe',
+    en: 'Article group',
+    fr: "Groupe d'articles",
+  },
+  resourceArticleType: {
+    de: 'Artikeltyp',
+    en: 'Article type',
+    fr: "Type d'article",
+  },
+  resourceStorageLocation: {
+    de: 'Lagerort',
+    en: 'Storage location',
+    fr: 'Emplacement de stockage',
+  },
+  resourceSerialNumber: {
+    de: 'Seriennummer',
+    en: 'Serial number',
+    fr: 'Numéro de série',
+  },
+  resourceQuantity: {
+    de: 'Menge',
+    en: 'Quantity',
+    fr: 'Quantité',
+  },
+  resourceTotalCount: {
+    de: 'Bestand',
+    en: 'Stock',
+    fr: 'Stock',
+  },
+  resourceFreeCount: {
+    de: 'Frei',
+    en: 'Free',
+    fr: 'Libre',
+  },
+  resourceSelected: {
+    de: 'Mittel ausgewählt',
+    en: 'Resources selected',
+    fr: 'Ressources sélectionnées',
+  },
+  resourceSelectionClear: {
+    de: 'Auswahl leeren',
+    en: 'Clear selection',
+    fr: 'Effacer la sélection',
+  },
+  resourceDeploy: {
+    de: 'Auf Karte platzieren',
+    en: 'Place on map',
+    fr: 'Placer sur la carte',
+  },
+  resourceDeployTitle: {
+    de: 'Mittel platzieren',
+    en: 'Place resources',
+    fr: 'Placer les ressources',
+  },
+  resourceDeployMode: {
+    de: 'Darstellung auf der Karte',
+    en: 'Display on the map',
+    fr: 'Affichage sur la carte',
+  },
+  resourceDeployCollection: {
+    de: 'Sammel-Standort',
+    en: 'Collection location',
+    fr: 'Emplacement groupé',
+  },
+  resourceDeployCollectionHint: {
+    de: 'ein Marker für alle Mittel',
+    en: 'one marker for all resources',
+    fr: 'un marqueur pour toutes les ressources',
+  },
+  resourceDeploySingle: {
+    de: 'Einzeln',
+    en: 'Individual',
+    fr: 'Individuel',
+  },
+  resourceDeploySingleHint: {
+    de: 'ein Marker pro Mittel',
+    en: 'one marker per resource',
+    fr: 'un marqueur par ressource',
+  },
+  resourceDeployName: {
+    de: 'Bezeichnung',
+    en: 'Label',
+    fr: 'Désignation',
+  },
+  resourceDeploySignature: {
+    de: 'Signatur',
+    en: 'Signature',
+    fr: 'Signature',
+  },
+  resourceDeployChangeSignature: {
+    de: 'Signatur ändern',
+    en: 'Change signature',
+    fr: 'Modifier la signature',
+  },
+  resourceDeployMessage: {
+    de: 'Meldung',
+    en: 'Message',
+    fr: 'Message',
+  },
+  resourceDeployFromJournal: {
+    de: 'aus dem Journal übernommen',
+    en: 'taken from the journal',
+    fr: 'repris du journal',
+  },
+  resourceDeployOnMap: {
+    de: 'Klicken Sie auf die Karte, um die Mittel zu platzieren',
+    en: 'Click on the map to place the resources',
+    fr: 'Cliquez sur la carte pour placer les ressources',
+  },
+  resourceDeployAtCenter: {
+    de: 'Am Kartenzentrum platzieren',
+    en: 'Place at map center',
+    fr: 'Placer au centre de la carte',
+  },
+  resourceDeployLocation: {
+    de: 'Ort',
+    en: 'Location',
+    fr: 'Emplacement',
+  },
+  resourceDeployLocationSearch: {
+    de: 'Adresse oder Koordinaten suchen',
+    en: 'Search address or coordinates',
+    fr: 'Rechercher une adresse ou des coordonnées',
+  },
+  resourceDeployLocationChosen: {
+    de: 'Gewählter Ort',
+    en: 'Chosen location',
+    fr: 'Emplacement choisi',
+  },
+  resourceDeployLocationChange: {
+    de: 'Ändern',
+    en: 'Change',
+    fr: 'Modifier',
+  },
+  resourceDeployLocationRequired: {
+    de: 'Wählen Sie eine Adresse oder Koordinate, oder verwenden Sie eine der Alternativen unten.',
+    en: 'Choose an address or coordinate, or use one of the alternatives below.',
+    fr: "Choisissez une adresse ou des coordonnées, ou utilisez l'une des alternatives ci-dessous.",
+  },
+  resourceDeployLocationAlternatives: {
+    de: 'Alternativ',
+    en: 'Alternatively',
+    fr: 'Alternativement',
+  },
+  resourceDeployAtLocation: {
+    de: 'An gewähltem Ort platzieren',
+    en: 'Place at chosen location',
+    fr: "Placer à l'emplacement choisi",
+  },
+  resourceNoCatalogue: {
+    de: 'Noch kein Bestand geladen',
+    en: 'No stock loaded yet',
+    fr: "Aucun stock chargé pour l'instant",
+  },
+  resourceNoCatalogueHint: {
+    de: 'Importieren Sie den Materialexport Ihrer Organisation als CSV, um die Mittelübersicht zu nutzen.',
+    en: "Import your organisation's material export as CSV to use the resource catalogue.",
+    fr: "Importez l'export du matériel de votre organisation au format CSV pour utiliser le catalogue des ressources.",
+  },
+  resourceAssignedItems: {
+    de: 'Zugewiesene Mittel',
+    en: 'Assigned resources',
+    fr: 'Ressources attribuées',
+  },
+  resourceAddAssignment: {
+    de: 'Mittel hinzufügen',
+    en: 'Add resource',
+    fr: 'Ajouter une ressource',
+  },
+  resourceAddAssignmentSearch: {
+    de: 'Suchen: Bezeichnung, Artikelnummer, Seriennummer',
+    en: 'Search: name, article number, serial number',
+    fr: 'Rechercher : désignation, numéro d’article, numéro de série',
+  },
+  resourceAddAssignmentNoResults: {
+    de: 'Keine Mittel gefunden',
+    en: 'No resources found',
+    fr: 'Aucune ressource trouvée',
+  },
+  resourceAddAssignmentAvailable: {
+    de: 'verfügbar',
+    en: 'available',
+    fr: 'disponible',
+  },
+  resourceAddAssignmentDeployed: {
+    de: 'bereits im Einsatz',
+    en: 'already deployed',
+    fr: 'déjà engagée',
+  },
+  resourceAddAssignmentPieces: {
+    de: 'Stück',
+    en: 'pcs',
+    fr: 'pièces',
+  },
+  resourceRemoveAssignment: {
+    de: 'Mittel entfernen',
+    en: 'Remove resource',
+    fr: 'Retirer la ressource',
+  },
+  resourceNoDeployedFilterResults: {
+    de: 'Keine Mittel entsprechen den Filtern',
+    en: 'No resources match the filters',
+    fr: 'Aucun moyen ne correspond aux filtres',
+  },
+  resourceNoDeployed: {
+    de: 'Keine Mittel im Einsatz',
+    en: 'No resources deployed',
+    fr: 'Aucun moyen engagé',
+  },
+  resourceNoDeployedHint: {
+    de: 'Wählen Sie im Katalog Mittel aus und platzieren Sie sie auf der Karte.',
+    en: 'Select resources in the catalogue and place them on the map.',
+    fr: 'Sélectionnez des moyens dans le catalogue et placez-les sur la carte.',
+  },
+  resourceNoFormations: {
+    de: 'Keine Formationen vorhanden',
+    en: 'No formations available',
+    fr: 'Aucune formation disponible',
+  },
+  resourceNoFormationsHint: {
+    de: 'Formationen erscheinen hier, sobald eine Formations-Signatur auf der Karte gesetzt wird.',
+    en: 'Formations appear here as soon as a formation signature is placed on the map.',
+    fr: 'Les formations apparaissent ici dès quʼune signature de formation est placée sur la carte.',
+  },
+  resourceOrphanAssignments: {
+    de: 'Nicht im Katalog',
+    en: 'Not in catalogue',
+    fr: 'Absent du catalogue',
+  },
+  resourceOpenOverview: {
+    de: 'Mittelübersicht öffnen',
+    en: 'Open resource overview',
+    fr: "Ouvrir l'aperçu des ressources",
+  },
+  resourcePlaceholderSign: {
+    de: 'Mittel (aus Mittelübersicht)',
+    en: 'Resource (from resource overview)',
+    fr: "Ressource (depuis l'aperçu des ressources)",
+  },
+  resourceDeploySelection: {
+    de: 'Auswahl',
+    en: 'Selection',
+    fr: 'Sélection',
+  },
+  resourceDeployMessageNone: {
+    de: 'Keine',
+    en: 'None',
+    fr: 'Aucun',
+  },
+  resourceDeployManyMarkersWarning: {
+    de: 'Diese Auswahl erzeugt mehr als 50 einzelne Marker auf der Karte.',
+    en: 'This selection creates more than 50 individual markers on the map.',
+    fr: 'Cette sélection crée plus de 50 marqueurs individuels sur la carte.',
+  },
+  resourceTakeBack: {
+    de: 'Zurücknehmen',
+    en: 'Take back',
+    fr: 'Reprendre',
+  },
+  resourceTakeBackAll: {
+    de: 'Alle zurücknehmen',
+    en: 'Take all back',
+    fr: 'Tout reprendre',
+  },
+  resourceTakeBackConfirm: {
+    de: 'Alle Mittel dieses Markers ins Lager zurücknehmen?',
+    en: 'Take all resources of this marker back to stock?',
+    fr: 'Reprendre toutes les ressources de ce marqueur en stock ?',
+  },
+};

--- a/packages/app/src/app/state/translations/resource.translations.ts
+++ b/packages/app/src/app/state/translations/resource.translations.ts
@@ -165,15 +165,15 @@ export const RESOURCE_TRANSLATIONS = {
     en: 'The template contains every required column, explains them in its header rows and shows example rows - replace the example rows and you are done.',
     fr: "Le modèle contient toutes les colonnes obligatoires, les explique dans ses en-têtes et montre des lignes d'exemple - remplacez-les et c'est prêt.",
   },
-  resourceMarkerGroup: {
-    de: 'Markierung',
-    en: 'Marker',
-    fr: 'Marqueur',
+  resourceMarkerResourceCount: {
+    de: 'Mittel',
+    en: 'Resources',
+    fr: 'Moyens',
   },
-  resourceMarkerGroupCount: {
-    de: 'Mittel auf dieser Markierung',
-    en: 'resources on this marker',
-    fr: 'moyens sur ce marqueur',
+  resourceMarkerResourcesToggle: {
+    de: 'Mittel dieser Markierung anzeigen/ausblenden',
+    en: 'Show/hide the resources of this marker',
+    fr: 'Afficher/masquer les moyens de ce marqueur',
   },
   resourceLastImport: {
     de: 'Stand',

--- a/packages/app/src/app/sync/sync.service.ts
+++ b/packages/app/src/app/sync/sync.service.ts
@@ -14,6 +14,7 @@ import { toObservable } from '@angular/core/rxjs-interop';
 import { deserialize, SuperJSONResult } from 'superjson';
 import { ChangesetInconsistentError, IZsChangeset } from '@zskarte/types';
 import { ChangesetService } from '../changeset/changeset.service';
+import { ResourceService } from '../resource/resource.service';
 
 export interface User {
   username: string;
@@ -40,6 +41,7 @@ export class SyncService {
   private _session = inject(SessionService);
   private _journal = inject(JournalService);
   private _changeset = inject(ChangesetService);
+  private _resource = inject(ResourceService);
 
   private _connectionId = uuidv4();
   private _socket: Socket | undefined;
@@ -121,6 +123,7 @@ export class SyncService {
 
     this._journal.setConnectionId(this._connectionId);
     this._changeset.setConnectionId(this._connectionId);
+    this._resource.setConnectionId(this._connectionId);
   }
 
   public setStateService(state: ZsMapStateService): void {
@@ -174,6 +177,9 @@ export class SyncService {
       this._socket.on('state:journal', (json: SuperJSONResult) => {
         const entry = deserialize(json) as Partial<JournalEntry>;
         this._journal.patchEntry(entry);
+      });
+      this._socket.on('state:resources', () => {
+        this._resource.reload();
       });
       this._socket.on('state:connections', (connections: Connection[]) => {
         this._connections.next(connections);

--- a/packages/app/src/assets/doc/resource/mittel-beispiel.csv
+++ b/packages/app/src/assets/doc/resource/mittel-beispiel.csv
@@ -1,0 +1,20 @@
+Organisation;ZSO Musterstadt
+Hinweis;Vorlage für die Mittelübersicht der Zivilschutz-Karte. Ersetzen Sie die Beispielzeilen unten durch Ihren eigenen Bestand.
+Hinweis;Trennzeichen ist das Semikolon; als Zeichensatz eignen sich UTF-8 und Windows-1252. Alle Zeilen oberhalb der Kopfzeile "Organisation;Status;..." werden beim Import ignoriert.
+Hinweis;Eine Zeile = ein physisches Stück. Mehrere Zeilen mit derselben Artikelnummer werden zu einem Artikel zusammengefasst (Bestand = Anzahl Zeilen).
+Hinweis;Pflichtspalten: Status, Artikelnummer, Artikel, Artikelgruppe, Artikeltyp, Seriennummer, Lagerort. Seriennummer und Lagerort dürfen leer bleiben.
+Hinweis;Mit Seriennummer wird jedes Stück einzeln zuweisbar; ohne Seriennummer zählt nur die Menge.
+Hinweis;Status "an Lager" heisst einsatzbereit. Jeder andere Wert (z.B. "in Reparatur", "ausgeliehen") gilt als nicht verfügbar - das Mittel bleibt aber auffindbar und zuweisbar.
+Hinweis;Artikelgruppe "Transport/Logistik" und "Sanitätsmaterial" erhalten eine eigene Signatur, alle übrigen ein neutrales Mittel-Symbol.
+Hinweis;Optional: Kaufdatum als TT.MM.JJJJ, Koordinaten als "Breitengrad, Längengrad" (WGS84), Plombiert als Ja/Nein.
+Exportiert am;01.09.2026;;08:00:00
+Organisation;Status;Artikelnummer;Artikel;Artikelgruppe;Artikeltyp;Hersteller;Einheit;Seriennummer;Charge;Kommentar;Plombiert;Kaufdatum;Lagerort-Code;Lagerort;Lagerort 2;Koordinaten
+ZSO Musterstadt;an Lager;ZM-000001;Stromaggregat 2 kVA;Erzeugen von Energie;Stand. ZS Material Kat. C;Honda;Stk;SN-1001;;;Nein;14.03.2022;1.1;Werkhof\Lager;Werkhof Musterstadt;
+ZSO Musterstadt;an Lager;ZM-000001;Stromaggregat 2 kVA;Erzeugen von Energie;Stand. ZS Material Kat. C;Honda;Stk;SN-1002;;;Nein;14.03.2022;1.1;Werkhof\Lager;Werkhof Musterstadt;
+ZSO Musterstadt;in Reparatur;ZM-000001;Stromaggregat 2 kVA;Erzeugen von Energie;Stand. ZS Material Kat. C;Honda;Stk;SN-1003;;Generator defekt, in Revision;Nein;14.03.2022;1.1;Werkhof\Lager;Werkhof Musterstadt;
+ZSO Musterstadt;an Lager;ZM-000002;Warnweste Zivilschutz L;Ausrüstung AdZS;Stand. ZS Material Kat. C;;Stk;;CH-2024-07;;Nein;;1.2;Werkhof\Lager;Werkhof Musterstadt;
+ZSO Musterstadt;an Lager;ZM-000002;Warnweste Zivilschutz L;Ausrüstung AdZS;Stand. ZS Material Kat. C;;Stk;;CH-2024-07;;Nein;;1.2;Werkhof\Lager;Werkhof Musterstadt;
+ZSO Musterstadt;an Lager;ZM-000002;Warnweste Zivilschutz L;Ausrüstung AdZS;Stand. ZS Material Kat. C;;Stk;;CH-2024-07;;Nein;;1.2;Werkhof\Lager;Werkhof Musterstadt;
+ZSO Musterstadt;an Lager;ZM-000003;Anhänger 2 t;Transport/Logistik;Stand. ZS Material Kat. B;Humbaur;Stk;AG-7;;Weisse Nummer;Nein;02.05.2019;2.1;Einstellhalle;Werkhof Musterstadt;47.0502, 8.3093
+ZSO Musterstadt;an Lager;ZM-000004;Sanitätsrucksack;Sanitätsmaterial;Stand. ZS Material Kat. A;;Stk;SR-21;;Verfalldaten prüfen;Ja;10.11.2023;3.4;Sanitätsposten;Zivilschutzanlage Musterstadt;
+ZSO Musterstadt;ausgeliehen;ZM-000004;Sanitätsrucksack;Sanitätsmaterial;Stand. ZS Material Kat. A;;Stk;SR-22;;Ausgeliehen an Feuerwehr;Ja;10.11.2023;3.4;Sanitätsposten;Zivilschutzanlage Musterstadt;

--- a/packages/app/src/assets/img/signs/resource-placeholder.svg
+++ b/packages/app/src/assets/img/signs/resource-placeholder.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="156px" height="156px" viewBox="0 0 156 156" version="1.1" xmlns="http://www.w3.org/2000/svg" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+	.st1{fill:none;stroke:#0000FF;stroke-width:4;}
+	.st2{fill:none;stroke:#0000FF;stroke-width:5;stroke-linejoin:round;stroke-linecap:round;}
+</style>
+<circle class="st0" cx="78" cy="78" r="78"/>
+<circle class="st1" cx="78" cy="78" r="76"/>
+<rect class="st2" x="45" y="51" width="66" height="54" rx="3"/>
+<line class="st2" x1="45" y1="71" x2="111" y2="71"/>
+<line class="st2" x1="78" y1="51" x2="78" y2="71"/>
+</svg>

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -57,6 +57,7 @@ import { SearchService } from './app/search/search.service';
 import { OperationService } from './app/session/operations/operation.service';
 import { ChangesetService } from './app/changeset/changeset.service';
 import { SidebarService } from './app/sidebar/sidebar.service';
+import { ResourceService } from './app/resource/resource.service';
 
 // enable immerjs patches
 enablePatches();
@@ -120,6 +121,7 @@ bootstrapApplication(AppComponent, {
         inject(OperationService),
         inject(ChangesetService),
         inject(SidebarService),
+        inject(ResourceService),
       );
       return initializerFn();
     }),

--- a/packages/app/tests/fixtures/resource-small.csv
+++ b/packages/app/tests/fixtures/resource-small.csv
@@ -1,0 +1,14 @@
+Organisation;ZSO Unteres Fricktal;;;67;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+Material - Übersicht Bestand;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+Bestand ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+Exportiert am;07.09.2026;;14:15:45;;Benutzer;max.muster;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+Organisation;Status;aktuelle Verwendung;Artikelnummer;Artikel;Artikelgruppe;Artikeltyp;Sirenentyp;Kommentar;Seriennummer;Serien-Nr. intern;Charge;Hersteller;Plombiert;Konserviert;Betriebsart;Inhalt;Einheit;Kapazität;Aktueller Inhalt;Einkaufspreis;Kaufpreis;Kaufdatum;Garantieende;Zulassungs-Nr.;Lagerort-Code;Lagerort;Verrechnung;Verrechnung am;Verrechnung durch;Verrechnung Detail;SAP Exportdatum;SAP Zuweisungs-Nr.;SAP Zahlungsdatum;SAP Mahnung 1;SAP Beleg-Nr.;Lagerort 2;Koordinaten
+ZSO Unteres Fricktal;an Lager;;ZM-000001;Stromaggregat Honda EU20i, 2kVA;Erzeugen von Energie;Stand. ZS Material Kat. C;;;SN-1;;;;Nein;Nein;;;;;;;;;;;1.1;Werkhof\Lager;Nein;;;;;;;;;BSA Werkhof Stein;
+ZSO Unteres Fricktal;an Lager;;ZM-000001;Stromaggregat Honda EU20i, 2kVA;Erzeugen von Energie;Stand. ZS Material Kat. C;;;SN-2;;;;Nein;Nein;;;;;;;;;;;1.1;Werkhof\Lager;Nein;;;;;;;;;BSA Werkhof Stein;
+ZSO Unteres Fricktal;an Lager;;ZM-000002;Warnweste Zivilschutz L;Ausrüstung AdZS;Stand. ZS Material Kat. C;;;;;;;Nein;Nein;;;;;;;;;;;1.1;Werkhof\Lager;Nein;;;;;;;;;BSA Werkhof Stein;
+ZSO Unteres Fricktal;an Lager;;ZM-000002;Warnweste Zivilschutz L;Ausrüstung AdZS;Stand. ZS Material Kat. C;;;;;;;Nein;Nein;;;;;;;;;;;1.1;Werkhof\Lager;Nein;;;;;;;;;BSA Werkhof Stein;
+ZSO Unteres Fricktal;an Lager;;ZM-000002;Warnweste Zivilschutz L;Ausrüstung AdZS;Stand. ZS Material Kat. C;;;;;;;Nein;Nein;;;;;;;;;;;1.1;Werkhof\Lager;Nein;;;;;;;;;BSA Werkhof Stein;
+ZSO Unteres Fricktal;in Reparatur;;ZM-000003;Anhänger ZS;Transport/Logistik;Stand. ZS Material Kat. B;;;AG-7;;;;Nein;Nein;;;;;;;;;;;1.1;Werkhof\Lager;Nein;;;;;;;;;BSA Werkhof Stein;

--- a/packages/app/tests/resource.spec.ts
+++ b/packages/app/tests/resource.spec.ts
@@ -1,0 +1,133 @@
+import { test, expect, Locator, Page } from '@playwright/test';
+import path from 'path';
+import { login } from './util';
+
+const FIXTURE_PATH = path.join(__dirname, 'fixtures', 'resource-small.csv');
+
+function overviewDialog(page: Page): Locator {
+  return page.locator('mat-dialog-container').filter({ has: page.getByRole('heading', { name: 'Mittelübersicht' }) });
+}
+
+function importDialog(page: Page): Locator {
+  return page.locator('mat-dialog-container').filter({ has: page.getByRole('heading', { name: /Bestand importieren/ }) });
+}
+
+function deployDialog(page: Page): Locator {
+  return page.locator('mat-dialog-container').filter({ has: page.getByRole('heading', { name: 'Mittel platzieren' }) });
+}
+
+async function openResourceOverview(page: Page) {
+  await page.getByRole('button', { name: 'Kartenmenü' }).click();
+  await page.getByRole('menuitem', { name: 'Mittelübersicht' }).click();
+  await expect(overviewDialog(page)).toBeVisible();
+}
+
+/** Article-number cell followed by the Bestand and Frei cells, in that order. */
+function catalogueRow(page: Page, articleNumber: string): Locator {
+  return overviewDialog(page).locator('tr', { hasText: articleNumber });
+}
+
+/**
+ * Serial with one shared page: the catalogue of a local (guest) operation lives in
+ * IndexedDB, which is per browser context. A fresh context per test would start from an
+ * empty catalogue, so the import in the second test would not be visible to the later ones.
+ */
+test.describe.configure({ mode: 'serial' });
+
+test.describe('Mittelübersicht', () => {
+  let page: Page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    await login(page);
+    await page.locator('mat-list-item', { hasText: 'e2e test' }).first().click();
+    const nameDialog = page.getByRole('dialog');
+    await nameDialog.getByRole('textbox').fill('Guest');
+    await nameDialog.getByRole('button', { name: 'OK' }).click();
+    await page.waitForSelector('#map', { state: 'visible' });
+    await page.waitForTimeout(500);
+    await openResourceOverview(page);
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test('shows the three tabs and the empty state before any import', async () => {
+    const dialog = overviewDialog(page);
+    await expect(dialog.getByRole('tab', { name: 'Katalog' })).toBeVisible();
+    await expect(dialog.getByRole('tab', { name: 'Im Einsatz' })).toBeVisible();
+    await expect(dialog.getByRole('tab', { name: 'Formationen' })).toBeVisible();
+    await expect(dialog.getByText('Noch kein Bestand geladen')).toBeVisible();
+  });
+
+  test('imports the CSV fixture and lists the three articles', async () => {
+    const dialog = overviewDialog(page);
+    await dialog.getByRole('button', { name: 'CSV importieren' }).click();
+
+    const importD = importDialog(page);
+    await expect(importD).toBeVisible();
+    await importD.locator('input[type="file"]').setInputFiles(FIXTURE_PATH);
+    await importD.getByRole('button', { name: 'Einlesen' }).click();
+
+    // Preview step: 6 rows / 3 articles, as parsed from the fixture.
+    await expect(importD.getByText(/Gelesen:\s*6\s*Zeilen\s*·\s*3\s*Artikel/)).toBeVisible();
+
+    await importD.getByRole('button', { name: 'Import ausführen' }).click();
+    await expect(importD).not.toBeVisible();
+
+    // Back in the catalogue: count line and the three imported articles.
+    await expect(dialog.getByText(/^3 von 3 Artikel · 6 Stück$/)).toBeVisible();
+    await expect(dialog.getByRole('cell', { name: 'ZM-000001', exact: true })).toBeVisible();
+    await expect(dialog.getByRole('cell', { name: 'ZM-000002', exact: true })).toBeVisible();
+    await expect(dialog.getByRole('cell', { name: 'ZM-000003', exact: true })).toBeVisible();
+  });
+
+  test('filters the catalogue by article name', async () => {
+    const dialog = overviewDialog(page);
+    await dialog.getByLabel('Suchen').fill('Stromaggregat');
+
+    await expect(dialog.getByText(/^1 von 3 Artikel · 2 Stück$/)).toBeVisible();
+    await expect(dialog.getByRole('cell', { name: 'ZM-000001', exact: true })).toBeVisible();
+    await expect(dialog.getByRole('cell', { name: 'ZM-000002', exact: true })).not.toBeVisible();
+    await expect(dialog.getByRole('cell', { name: 'ZM-000003', exact: true })).not.toBeVisible();
+
+    await dialog.getByRole('button', { name: 'Filter leeren' }).click();
+    await expect(dialog.getByText(/^3 von 3 Artikel · 6 Stück$/)).toBeVisible();
+  });
+
+  test('shows reduced availability for an article under repair', async () => {
+    const row = catalogueRow(page, 'ZM-000003');
+    // Bestand (total stock) is 1, Frei (available) is 0 - the one piece is "in Reparatur".
+    await expect(row.getByRole('cell').nth(5)).toHaveText('1');
+    await expect(row.getByRole('cell').nth(6)).toHaveText('0');
+  });
+
+  test('places a resource on the map and reflects it in Im Einsatz', async () => {
+    const dialog = overviewDialog(page);
+    const row002 = catalogueRow(page, 'ZM-000002');
+
+    await expect(row002.getByRole('cell').nth(6)).toHaveText('3');
+    await row002.getByRole('checkbox').click();
+    await expect(dialog.getByText('3 Mittel ausgewählt')).toBeVisible();
+
+    await dialog.getByRole('button', { name: 'Auf Karte platzieren' }).click();
+
+    const deployD = deployDialog(page);
+    await expect(deployD).toBeVisible();
+    await deployD.getByRole('radio', { name: /Sammel-Standort/ }).check();
+    await deployD.getByLabel('Bezeichnung').fill('Sammelplatz Warnwesten');
+    await deployD.getByRole('button', { name: 'Am Kartenzentrum platzieren' }).click();
+    await expect(deployD).not.toBeVisible();
+
+    // Placed pieces show up under "Im Einsatz" ...
+    await dialog.getByRole('tab', { name: 'Im Einsatz' }).click();
+    const deployedRow = dialog.locator('tr', { hasText: 'Sammelplatz Warnwesten' });
+    await expect(deployedRow).toBeVisible();
+    await expect(deployedRow).toContainText('Warnweste Zivilschutz L');
+
+    // ... and the catalogue now shows the article as fully assigned.
+    await dialog.getByRole('tab', { name: 'Katalog' }).click();
+    await expect(row002.getByRole('cell').nth(6)).toHaveText('0');
+  });
+});

--- a/packages/server/config/sync/user-role.guest.json
+++ b/packages/server/config/sync/user-role.guest.json
@@ -126,6 +126,21 @@
       "locale": null
     },
     {
+      "action": "api::resource-article.resource-article.find",
+      "documentId": "qt73siywhyrcqozytvb2p5l7",
+      "locale": null
+    },
+    {
+      "action": "api::resource-article.resource-article.findOne",
+      "documentId": "rg6obxbds32pldqbkkwzckw5",
+      "locale": null
+    },
+    {
+      "action": "api::resource-article.resource-article.import",
+      "documentId": "ra3imprtguest000000000001",
+      "locale": null
+    },
+    {
       "action": "api::wms-source.wms-source.find",
       "documentId": "bm55vo5otup253d0awakyosh",
       "locale": null

--- a/packages/server/config/sync/user-role.operationread.json
+++ b/packages/server/config/sync/user-role.operationread.json
@@ -71,6 +71,16 @@
       "locale": null
     },
     {
+      "action": "api::resource-article.resource-article.find",
+      "documentId": "lui8nyyk8kr8b2ihhu2ydhjv",
+      "locale": null
+    },
+    {
+      "action": "api::resource-article.resource-article.findOne",
+      "documentId": "rn4x4efu1o4p2pcj13jctfql",
+      "locale": null
+    },
+    {
       "action": "api::wms-source.wms-source.find",
       "documentId": "r1kuk1iq2925r1xyvuui5318",
       "locale": null

--- a/packages/server/config/sync/user-role.operationwrite.json
+++ b/packages/server/config/sync/user-role.operationwrite.json
@@ -106,6 +106,21 @@
       "locale": null
     },
     {
+      "action": "api::resource-article.resource-article.find",
+      "documentId": "m4wb21ylad5v7oonlb3fhknl",
+      "locale": null
+    },
+    {
+      "action": "api::resource-article.resource-article.findOne",
+      "documentId": "yzb5q25a57wy1t9hwded6jts",
+      "locale": null
+    },
+    {
+      "action": "api::resource-article.resource-article.import",
+      "documentId": "iqfmq1ou10aeles9ufc9ejd6",
+      "locale": null
+    },
+    {
       "action": "api::wms-source.wms-source.create",
       "documentId": "soijby1t7f7dpk81xgx9q03k",
       "locale": null

--- a/packages/server/config/sync/user-role.organization.json
+++ b/packages/server/config/sync/user-role.organization.json
@@ -186,6 +186,21 @@
       "locale": null
     },
     {
+      "action": "api::resource-article.resource-article.find",
+      "documentId": "lp4dvuz3ziibm2nowklo14kf",
+      "locale": null
+    },
+    {
+      "action": "api::resource-article.resource-article.findOne",
+      "documentId": "mhdyrt5gz8to4kg6v8go2gv8",
+      "locale": null
+    },
+    {
+      "action": "api::resource-article.resource-article.import",
+      "documentId": "iavybgvpmoy9xsvgwmjdxg36",
+      "locale": null
+    },
+    {
       "action": "api::wms-source.wms-source.create",
       "documentId": "aygbzsq5oyjllfql9ltx6lg2",
       "locale": null

--- a/packages/server/src/api/resource-article/content-types/resource-article/schema.json
+++ b/packages/server/src/api/resource-article/content-types/resource-article/schema.json
@@ -1,0 +1,85 @@
+{
+  "kind": "collectionType",
+  "collectionName": "resource_articles",
+  "info": {
+    "singularName": "resource-article",
+    "pluralName": "resource-articles",
+    "displayName": "Resource Article",
+    "description": "One inventory article (Artikelnummer) of an operation's resource catalogue; the individual pieces are stored in items[]"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "articleNumber": {
+      "type": "string",
+      "required": true
+    },
+    "syntheticNumber": {
+      "type": "boolean",
+      "default": false
+    },
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "nameVariants": {
+      "type": "json"
+    },
+    "articleGroup": {
+      "type": "string"
+    },
+    "articleType": {
+      "type": "string"
+    },
+    "manufacturer": {
+      "type": "string"
+    },
+    "unit": {
+      "type": "string"
+    },
+    "sirenType": {
+      "type": "string"
+    },
+    "serialized": {
+      "type": "boolean",
+      "default": false
+    },
+    "totalCount": {
+      "type": "integer",
+      "required": true
+    },
+    "inStockCount": {
+      "type": "integer",
+      "required": true
+    },
+    "items": {
+      "type": "json",
+      "required": true
+    },
+    "importId": {
+      "type": "string",
+      "required": true
+    },
+    "importedAt": {
+      "type": "datetime"
+    },
+    "sourceExportedAt": {
+      "type": "datetime"
+    },
+    "sourceOrganisation": {
+      "type": "string"
+    },
+    "operation": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::operation.operation"
+    },
+    "organization": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::organization.organization"
+    }
+  }
+}

--- a/packages/server/src/api/resource-article/controllers/resource-article.ts
+++ b/packages/server/src/api/resource-article/controllers/resource-article.ts
@@ -1,0 +1,246 @@
+/**
+ * resource-article controller
+ */
+
+import { factories } from '@strapi/strapi';
+import { errors } from '@strapi/utils';
+import fp from 'lodash/fp';
+import { broadcastResourcesUpdate } from '../../../state/resources';
+
+const MAX_ARTICLES = 5000;
+const MAX_ITEMS_PER_ARTICLE = 5000;
+const MAX_TOTAL_ITEMS = 60000;
+const MAX_ARTICLE_NUMBER_LENGTH = 64;
+const MAX_NAME_LENGTH = 255;
+const MAX_STRING_LENGTH = 255;
+const MAX_ITEM_STRING_LENGTH = 512;
+const MAX_NAME_VARIANTS = 20;
+/** Optional string fields of ResourceItem; `status` is handled separately because it is required. */
+const ITEM_STRING_FIELDS = [
+  'serialNumber',
+  'itemKey',
+  'serialNumberInternal',
+  'batch',
+  'storageCode',
+  'storageLocation',
+  'storageLocation2',
+  'comment',
+  'purchaseDate',
+] as const;
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const RESOURCE_ARTICLE_POPULATE = {
+  operation: { fields: ['documentId' as any] },
+  organization: { fields: ['documentId' as any] },
+};
+
+/** Trims a string and caps its length, returns undefined for non-strings/empty results. */
+const optionalString = (value: unknown, maxLength: number = MAX_STRING_LENGTH): string | undefined => {
+  if (!fp.isString(value)) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed.slice(0, maxLength);
+};
+
+/** Trims a required string, throws a ValidationError if it is missing/empty. */
+const requiredString = (value: unknown, maxLength: number, fieldLabel: string): string => {
+  const trimmed = optionalString(value, maxLength);
+  if (!trimmed) {
+    throw new errors.ValidationError(`"${fieldLabel}" is required and must be a non-empty string`);
+  }
+  return trimmed;
+};
+
+/** Validates a required finite number (used for totalCount/inStockCount). */
+const requiredNumber = (value: unknown, fieldLabel: string): number => {
+  if (!fp.isFinite(value)) {
+    throw new errors.ValidationError(`"${fieldLabel}" is required and must be a number`);
+  }
+  return value as number;
+};
+
+const optionalBoolean = (value: unknown, defaultValue: boolean): boolean => {
+  return fp.isBoolean(value) ? value : defaultValue;
+};
+
+const optionalDate = (value: unknown): Date | undefined => {
+  if (!value) return undefined;
+  const date = new Date(value as any);
+  if (Number.isNaN(date.getTime())) return undefined;
+  return date;
+};
+
+/** WGS84 [lat, lon] or undefined. */
+const optionalCoordinates = (value: unknown): [number, number] | undefined => {
+  if (!fp.isArray(value) || value.length !== 2) return undefined;
+  const [lat, lon] = value;
+  if (!fp.isFinite(lat) || !fp.isFinite(lon)) return undefined;
+  if (lat < -90 || lat > 90 || lon < -180 || lon > 180) return undefined;
+  return [lat as number, lon as number];
+};
+
+/**
+ * Rebuilds a single piece from the schema allow-list.
+ * The client payload must never reach the json column unfiltered - it is stored verbatim
+ * and handed back to every client of the operation.
+ */
+const sanitizeItem = (value: unknown, itemLabel: string): Record<string, unknown> => {
+  if (!fp.isObject(value)) {
+    throw new errors.ValidationError(`"${itemLabel}" must be an object`);
+  }
+  const item = value as any;
+  const sanitized: Record<string, unknown> = {
+    status: optionalString(item.status, MAX_ITEM_STRING_LENGTH) ?? '',
+  };
+  for (const field of ITEM_STRING_FIELDS) {
+    const parsed = optionalString(item[field], MAX_ITEM_STRING_LENGTH);
+    if (parsed !== undefined) sanitized[field] = parsed;
+  }
+  if (fp.isBoolean(item.sealed)) sanitized.sealed = item.sealed;
+  const coordinates = optionalCoordinates(item.coordinates);
+  if (coordinates) sanitized.coordinates = coordinates;
+  return sanitized;
+};
+
+/** Distinct, trimmed, capped list of alternative article spellings. */
+const sanitizeNameVariants = (value: unknown): string[] | undefined => {
+  if (!fp.isArray(value)) return undefined;
+  const variants = [
+    ...new Set(
+      value
+        .slice(0, MAX_NAME_VARIANTS)
+        .map((entry) => optionalString(entry, MAX_NAME_LENGTH))
+        .filter((entry): entry is string => entry !== undefined),
+    ),
+  ];
+  return variants.length > 0 ? variants : undefined;
+};
+
+export default factories.createCoreController('api::resource-article.resource-article', ({ strapi }) => ({
+  async find(ctx) {
+    ctx.query.populate = RESOURCE_ARTICLE_POPULATE;
+    return await super.find(ctx);
+  },
+  async findOne(ctx) {
+    ctx.query.populate = RESOURCE_ARTICLE_POPULATE;
+    return await super.findOne(ctx);
+  },
+  async import(ctx) {
+    const { identifier }: { identifier: string } = ctx.request.headers as any;
+    if (!identifier) {
+      ctx.status = 400;
+      return { message: 'Missing headers: identifier' };
+    }
+
+    await this.validateQuery(ctx);
+    await this.sanitizeQuery(ctx);
+
+    const { data: rawData } = ctx.request.body as any;
+    if (!fp.isObject(rawData)) {
+      throw new errors.ValidationError('Missing "data" payload in the request body');
+    }
+    const data = rawData as any;
+
+    //validate & normalise defensively - never spread the client object into the DB row
+    const operationDocumentId = requiredString(data.operation, MAX_STRING_LENGTH, 'data.operation');
+    const organizationDocumentId = requiredString(data.organization, MAX_STRING_LENGTH, 'data.organization');
+    const importId = requiredString(data.importId, MAX_STRING_LENGTH, 'data.importId');
+    if (!UUID_REGEX.test(importId)) {
+      throw new errors.ValidationError('"data.importId" must be a valid uuid');
+    }
+    const sourceExportedAt = optionalDate(data.sourceExportedAt);
+    const sourceOrganisation = optionalString(data.sourceOrganisation);
+
+    if (!fp.isArray(data.articles)) {
+      throw new errors.ValidationError('"data.articles" is required and must be an array');
+    }
+    if (data.articles.length > MAX_ARTICLES) {
+      throw new errors.ValidationError(`"data.articles" must not contain more than ${MAX_ARTICLES} entries`);
+    }
+
+    let itemCount = 0;
+    const rows = data.articles.map((rawArticle: any, index: number) => {
+      if (!fp.isObject(rawArticle)) {
+        throw new errors.ValidationError(`"data.articles[${index}]" must be an object`);
+      }
+      const article = rawArticle as any;
+      if (!fp.isArray(article.items)) {
+        throw new errors.ValidationError(`"data.articles[${index}].items" is required and must be an array`);
+      }
+      if (article.items.length > MAX_ITEMS_PER_ARTICLE) {
+        throw new errors.ValidationError(
+          `"data.articles[${index}].items" must not contain more than ${MAX_ITEMS_PER_ARTICLE} entries`,
+        );
+      }
+      itemCount += article.items.length;
+      if (itemCount > MAX_TOTAL_ITEMS) {
+        throw new errors.ValidationError(`"data.articles" must not contain more than ${MAX_TOTAL_ITEMS} items in total`);
+      }
+
+      //build the DB row explicitly, field by field, from the schema allow-list
+      return {
+        articleNumber: requiredString(article.articleNumber, MAX_ARTICLE_NUMBER_LENGTH, `data.articles[${index}].articleNumber`),
+        syntheticNumber: optionalBoolean(article.syntheticNumber, false),
+        name: requiredString(article.name, MAX_NAME_LENGTH, `data.articles[${index}].name`),
+        nameVariants: sanitizeNameVariants(article.nameVariants),
+        articleGroup: optionalString(article.articleGroup),
+        articleType: optionalString(article.articleType),
+        manufacturer: optionalString(article.manufacturer),
+        unit: optionalString(article.unit),
+        sirenType: optionalString(article.sirenType),
+        serialized: optionalBoolean(article.serialized, false),
+        totalCount: requiredNumber(article.totalCount, `data.articles[${index}].totalCount`),
+        inStockCount: requiredNumber(article.inStockCount, `data.articles[${index}].inStockCount`),
+        items: article.items.map((item: unknown, itemIndex: number) =>
+          sanitizeItem(item, `data.articles[${index}].items[${itemIndex}]`),
+        ),
+        importId,
+        importedAt: new Date(),
+        sourceExportedAt,
+        sourceOrganisation,
+        operation: operationDocumentId,
+        organization: organizationDocumentId,
+      };
+    });
+    const articleCount = rows.length;
+
+    //load the operation, it must exist and be active
+    const operation = await strapi.documents('api::operation.operation').findOne({
+      documentId: operationDocumentId,
+      fields: ['phase'],
+    });
+    if (!operation) {
+      return ctx.notFound(`operation ${operationDocumentId} not found`);
+    }
+    if (operation.phase !== 'active') {
+      return ctx.forbidden('The operation is archived, no update allowed.');
+    }
+
+    //idempotency: if this import was already applied, don't re-apply it
+    const alreadyImportedCount = await strapi.documents('api::resource-article.resource-article').count({
+      filters: {
+        operation: { documentId: { $eq: operationDocumentId } },
+        importId: { $eq: importId },
+      },
+    });
+    if (alreadyImportedCount > 0) {
+      return this.transformResponse({ importId, articleCount, itemCount, alreadyImported: true });
+    }
+
+    await strapi.db.transaction(async () => {
+      //replace the operation's whole resource catalogue with the newly imported one
+      await strapi.db
+        .query('api::resource-article.resource-article')
+        .deleteMany({ filters: { operation: { documentId: operationDocumentId } } });
+
+      for (const row of rows) {
+        await strapi.documents('api::resource-article.resource-article').create({ data: row });
+      }
+    });
+
+    broadcastResourcesUpdate(identifier, operationDocumentId, { importId, articleCount, itemCount });
+
+    ctx.status = 201;
+    return this.transformResponse({ importId, articleCount, itemCount, alreadyImported: false });
+  },
+}));

--- a/packages/server/src/api/resource-article/routes/import.ts
+++ b/packages/server/src/api/resource-article/routes/import.ts
@@ -1,0 +1,17 @@
+import { CreateAccessControlMiddlewareConfig } from '../../../middlewares/AccessControlMiddlewareConfig';
+import { AccessControlTypes } from '../../../definitions';
+
+export default {
+  routes: [
+    {
+      method: 'POST',
+      path: '/resource-articles/import',
+      handler: 'resource-article.import',
+      config: {
+        middlewares: [
+          CreateAccessControlMiddlewareConfig({ type: 'api::resource-article.resource-article', check: AccessControlTypes.CREATE }),
+        ],
+      },
+    },
+  ],
+};

--- a/packages/server/src/api/resource-article/routes/resource-article.ts
+++ b/packages/server/src/api/resource-article/routes/resource-article.ts
@@ -1,0 +1,11 @@
+/**
+ * resource-article router
+ */
+
+import { factories } from '@strapi/strapi';
+import { AccessControlMiddlewareRoutesConfig } from '../../../middlewares/AccessControlMiddlewareConfig';
+
+export default factories.createCoreRouter(
+  'api::resource-article.resource-article',
+  AccessControlMiddlewareRoutesConfig({ type: 'api::resource-article.resource-article' }),
+);

--- a/packages/server/src/api/resource-article/services/resource-article.ts
+++ b/packages/server/src/api/resource-article/services/resource-article.ts
@@ -1,0 +1,7 @@
+/**
+ * resource-article service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::resource-article.resource-article');

--- a/packages/server/src/definitions/TypeGuards.ts
+++ b/packages/server/src/definitions/TypeGuards.ts
@@ -53,6 +53,7 @@ const HasOperationTypes: HasOperationType[] = [
   'api::access.access',
   'api::map-snapshot.map-snapshot',
   'api::journal-entry.journal-entry',
+  'api::resource-article.resource-article',
 ];
 const HasOrganizationTypes: HasOrganizationType[] = [
   'plugin::users-permissions.user',
@@ -60,6 +61,7 @@ const HasOrganizationTypes: HasOrganizationType[] = [
   'api::wms-source.wms-source',
   'api::map-layer.map-layer',
   'api::journal-entry.journal-entry',
+  'api::resource-article.resource-article',
 ];
 const AccessCheckableTypes: AccessCheckableType[] = [
   ...IsOperationTypes,

--- a/packages/server/src/definitions/constants/WebsocketEvent.ts
+++ b/packages/server/src/definitions/constants/WebsocketEvent.ts
@@ -1,6 +1,7 @@
 export const WebsocketEvent = {
   STATE_CHANGESET: 'state:changeset',
   STATE_JOURNAL: 'state:journal',
+  STATE_RESOURCES: 'state:resources',
   CONNECTIONS: 'state:connections',
 } as const;
 export type WebsocketEvent = (typeof WebsocketEvent)[keyof typeof WebsocketEvent];

--- a/packages/server/src/state/operation.ts
+++ b/packages/server/src/state/operation.ts
@@ -191,14 +191,26 @@ const addChangeset = async (
         return { error, result: undefined };
       }
       const oldMapState = mapState;
-      mapState = applyPatches(mapState, changeset.patches);
+      let revertedMapState: typeof mapState;
+      try {
+        mapState = applyPatches(mapState, changeset.patches);
 
-      if (task.aborted || task.clientAborted) {
-        return { error: { message: 'aborted' }, result: undefined };
+        if (task.aborted || task.clientAborted) {
+          return { error: { message: 'aborted' }, result: undefined };
+        }
+
+        //verify clean reverse possible
+        revertedMapState = applyPatches(mapState, changeset.inversePatches);
+      } catch (e) {
+        // A patch whose path cannot be resolved (e.g. it targets a draw element this server
+        // never received) is not a server fault: throwing here turned into a 500, which the
+        // client treats as "retry later", so the very same broken changeset was resubmitted
+        // forever. Report it as invalid instead - the client already has a path for that and
+        // drops the changeset.
+        const message = e instanceof Error ? e.message : String(e);
+        strapi.log.error(`changeset ${changeset.id} cannot be applied: ${message}`);
+        return { error: { message, isInvalid: true }, result: undefined };
       }
-
-      //verify clean reverse possible
-      const revertedMapState = applyPatches(mapState, changeset.inversePatches);
       if (!_.isEqual(oldMapState, revertedMapState)) {
         const elemId = changeset.patches[0].path[1];
         console.error(

--- a/packages/server/src/state/resources.ts
+++ b/packages/server/src/state/resources.ts
@@ -1,0 +1,12 @@
+import { OperationCache } from '../definitions';
+import { operationCaches } from './operation';
+import { broadcastResources } from './socketio';
+
+const broadcastResourcesUpdate = (identifier: string, operationId: string, data: any) => {
+  const operationCache: OperationCache = operationCaches[operationId];
+  if (!operationCache) return;
+
+  broadcastResources(operationCache, identifier, data);
+};
+
+export { broadcastResourcesUpdate };

--- a/packages/server/src/state/socketio.ts
+++ b/packages/server/src/state/socketio.ts
@@ -132,4 +132,18 @@ const broadcastJournal = (operationCache: OperationCache, identifier: string, da
   }
 };
 
-export { connectSocketIo, socketConnection, broadcastConnections, broadcastChangeset, broadcastJournal };
+/** Broadcast received resource catalogue change to all currently connected sockets of an operation */
+const broadcastResources = (operationCache: OperationCache, identifier: string, data: any) => {
+  data = superjsonSerialize(data);
+  const connections = _.filter(operationCache.connections, (c) => c.identifier !== identifier);
+  for (const connection of connections) {
+    try {
+      connection.socket.emit(WebsocketEvent.STATE_RESOURCES, data);
+    } catch (error) {
+      connection.socket.disconnect();
+      strapi.log.error(error);
+    }
+  }
+};
+
+export { connectSocketIo, socketConnection, broadcastConnections, broadcastChangeset, broadcastJournal, broadcastResources };

--- a/packages/server/types/generated/contentTypes.d.ts
+++ b/packages/server/types/generated/contentTypes.d.ts
@@ -644,6 +644,48 @@ export interface ApiOrganizationOrganization extends Struct.CollectionTypeSchema
   };
 }
 
+export interface ApiResourceArticleResourceArticle extends Struct.CollectionTypeSchema {
+  collectionName: 'resource_articles';
+  info: {
+    description: "One inventory article (Artikelnummer) of an operation's resource catalogue; the individual pieces are stored in items[]";
+    displayName: 'Resource Article';
+    pluralName: 'resource-articles';
+    singularName: 'resource-article';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    articleGroup: Schema.Attribute.String;
+    articleNumber: Schema.Attribute.String & Schema.Attribute.Required;
+    articleType: Schema.Attribute.String;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> & Schema.Attribute.Private;
+    importedAt: Schema.Attribute.DateTime;
+    importId: Schema.Attribute.String & Schema.Attribute.Required;
+    inStockCount: Schema.Attribute.Integer & Schema.Attribute.Required;
+    items: Schema.Attribute.JSON & Schema.Attribute.Required;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<'oneToMany', 'api::resource-article.resource-article'> &
+      Schema.Attribute.Private;
+    manufacturer: Schema.Attribute.String;
+    name: Schema.Attribute.String & Schema.Attribute.Required;
+    nameVariants: Schema.Attribute.JSON;
+    operation: Schema.Attribute.Relation<'manyToOne', 'api::operation.operation'>;
+    organization: Schema.Attribute.Relation<'manyToOne', 'api::organization.organization'>;
+    publishedAt: Schema.Attribute.DateTime;
+    serialized: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
+    sirenType: Schema.Attribute.String;
+    sourceExportedAt: Schema.Attribute.DateTime;
+    sourceOrganisation: Schema.Attribute.String;
+    syntheticNumber: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
+    totalCount: Schema.Attribute.Integer & Schema.Attribute.Required;
+    unit: Schema.Attribute.String;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> & Schema.Attribute.Private;
+  };
+}
+
 export interface ApiSigningKeySigningKey extends Struct.CollectionTypeSchema {
   collectionName: 'signing_keys';
   info: {
@@ -1121,6 +1163,7 @@ declare module '@strapi/strapi' {
       'api::map-snapshot.map-snapshot': ApiMapSnapshotMapSnapshot;
       'api::operation.operation': ApiOperationOperation;
       'api::organization.organization': ApiOrganizationOrganization;
+      'api::resource-article.resource-article': ApiResourceArticleResourceArticle;
       'api::signing-key.signing-key': ApiSigningKeySigningKey;
       'api::wms-source.wms-source': ApiWmsSourceWmsSource;
       'plugin::content-releases.release': PluginContentReleasesRelease;

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -5,3 +5,4 @@ export * from "./session/interfaces";
 export * from "./sign/interfaces";
 export * from "./state/interfaces";
 export * from './general/interfaces';
+export * from './resource/interfaces';

--- a/packages/types/resource/interfaces.ts
+++ b/packages/types/resource/interfaces.ts
@@ -1,0 +1,86 @@
+import { DocumentApi } from '../map-layer/interfaces';
+
+/** Status as exported by the inventory system; 'an Lager' is the only ready-for-use value. */
+export const RESOURCE_STATUS_IN_STOCK = 'an Lager';
+
+/** One physical piece = one CSV row. Empty CSV cells are omitted, never stored as ''. */
+export interface ResourceItem {
+  status: string;
+  serialNumber?: string;
+  /** `${articleNumber}|${serialNumber}` (+ '#2', '#3' … for duplicates); only when serialNumber is set. */
+  itemKey?: string;
+  serialNumberInternal?: string;
+  batch?: string;
+  storageCode?: string;
+  storageLocation?: string;
+  storageLocation2?: string;
+  comment?: string;
+  sealed?: boolean;
+  /** ISO yyyy-mm-dd, parsed from the CSV's dd.mm.yyyy. */
+  purchaseDate?: string;
+  /** WGS84 [lat, lon]. */
+  coordinates?: [number, number];
+}
+
+/** One article = one Artikelnummer, grouped over all its pieces. */
+export interface ResourceArticle {
+  articleNumber: string;
+  /** true when the CSV row had no Artikelnummer and a '~slug' key was synthesised. */
+  syntheticNumber?: boolean;
+  name: string;
+  nameVariants?: string[];
+  articleGroup: string;
+  articleType: string;
+  manufacturer?: string;
+  unit?: string;
+  sirenType?: string;
+  /** true when at least one piece has a serialNumber. */
+  serialized: boolean;
+  totalCount: number;
+  inStockCount: number;
+  items: ResourceItem[];
+}
+
+export interface ResourceImportMeta {
+  /** Client-generated uuid, used as the idempotency key. */
+  importId: string;
+  importedAt?: Date;
+  sourceExportedAt?: Date;
+  sourceOrganisation?: string;
+}
+
+export interface ResourceArticleApi extends ResourceArticle, ResourceImportMeta, Partial<DocumentApi> {
+  operation?: DocumentApi;
+  organization?: DocumentApi;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+/** Body of POST /api/resource-articles/import, wrapped as { data: ResourceImportRequestApi }. */
+export interface ResourceImportRequestApi extends ResourceImportMeta {
+  operation: string;
+  organization: string;
+  /** An empty array clears the catalogue. */
+  articles: ResourceArticle[];
+}
+
+export interface ResourceImportResponseApi {
+  importId: string;
+  articleCount: number;
+  itemCount: number;
+  /** true when this importId had already been applied (idempotent replay). */
+  alreadyImported: boolean;
+}
+
+/** Reference from a map draw element to deployed resources. */
+export interface ResourceAssignment {
+  articleNumber: string;
+  /** Snapshot of the article name so the map stays readable without the catalogue. */
+  name: string;
+  /** Always 1 for a serialised piece. */
+  quantity: number;
+  serialNumber?: string;
+  itemKey?: string;
+}
+
+export type ResourceAvailability = 'available' | 'assigned' | 'unavailable';

--- a/packages/types/sign/interfaces.ts
+++ b/packages/types/sign/interfaces.ts
@@ -1,5 +1,6 @@
 import { FeatureLike } from "ol/Feature";
 import { Circle, LineString, MultiPolygon, Point, Polygon } from "ol/geom";
+import { ResourceAssignment } from "../resource/interfaces";
 
 export enum HierarchyLevel {
   TRUPP = 'trupp',
@@ -70,6 +71,9 @@ export interface Sign {
   additionalInfo?: string; // Right text (2 Z, 3 Gr, etc.)
   formationNumber?: string; // Bottom number
   formationLocation?: string; // Bottom location name
+
+  // Resource catalogue (Mittelübersicht)
+  resourceItems?: ResourceAssignment[];
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/types/state/interfaces.ts
+++ b/packages/types/state/interfaces.ts
@@ -1,6 +1,7 @@
 import { Coordinate } from 'ol/coordinate';
 import { MapLayer, WmsSource } from '../map-layer/interfaces';
 import { FillStyle, HierarchyLevel, IconsOffset } from '../sign/interfaces';
+import { ResourceAssignment } from '../resource/interfaces';
 import { Feature } from 'ol';
 import { PermissionType } from '../session/interfaces';
 import { Extent } from 'ol/extent';
@@ -390,6 +391,10 @@ export interface IZsMapBaseDrawElementState extends IZsMapBaseElementState {
   additionalInfo?: string;
   formationNumber?: string;
   formationLocation?: string;
+
+  // Resource catalogue (Mittelübersicht)
+  resourceItems?: ResourceAssignment[];
+  resourceImportId?: string;
 }
 
 export interface ZsMapTextDrawElementState extends IZsMapBaseDrawElementState {


### PR DESCRIPTION
Closes https://github.com/zskarte/zskarte/issues/922

## What this adds

Mittelübersicht — a resource (Mittel) catalogue for an operation, from CSV import through to
tracking what is deployed where on the map.

The workflow it enables:

1. **Import** the material export of your organisation as CSV (`Mittelübersicht → CSV importieren`).
   A downloadable, self-documenting example template is linked right next to the button, so an
   organisation without an inventory export can fill one in by hand.
2. **Browse** the catalogue: filter by article group, type, storage location and availability,
   expand an article to its individual pieces, and select across pages and filters.
3. **Place** the selection on the map — as one collection marker or one marker per piece — at a
   searched address, at the map centre, or by clicking the map.
4. **Adjust** a marker afterwards: search the catalogue from the marker panel to assign more
   resources, or take single ones back. Availability is derived from the live map state, so the
   catalogue's "Frei" column follows immediately — including changes made by other users in the
   same operation.
5. **Review** what is out there in the "Im Einsatz" and "Formationen" tabs.

## Backend

A `resource-article` content type: one row per Artikelnummer, its physical pieces in an `items`
json column, scoped to operation + organization.

- `POST /resource-articles/import` replaces an operation's whole catalogue in one transaction.
  The payload is never spread into the row — every field is rebuilt from a schema allow-list with
  trimming, length caps and range checks, because `items` is stored verbatim and handed back to
  every client of the operation. Size limits guard against oversized imports.
- Idempotent on a client-generated `importId`, so a retried request cannot duplicate or clear a
  catalogue. Imports into an archived operation are rejected.
- A successful import broadcasts `state:resources` over the existing socket.io channel; clients
  reload the catalogue rather than receiving it inline.
- Follows the DEVELOPER_GUIDE checklist for new types: access-control middleware on both routers,
  `HasOperationTypes`/`HasOrganizationTypes` registration, exported role permissions.

Guest/local operations have no server behind them, so their catalogue is written to IndexedDB
instead; the app also caches the catalogue there for offline use.

## Notes for review

- **`fix(changeset)` is unrelated to the feature.** `applyPatches` threw on a patch path it could
  not resolve, which surfaced as a 500; the client treats that as transient and retried the same
  broken changeset indefinitely. It now returns `isInvalid: true`, which the client already
  handles by dropping the changeset. Found while working on this, but independent — happy to
  split it into its own PR.
- **Role configs and `types/generated/contentTypes.d.ts` are touched** as a consequence of adding
  the content type, not by hand-editing generated output.
- **Signatures resolve from the CSV, not from hardcoded article numbers.** An earlier revision
  mapped two specific Artikelnummern to a pictogram; those are assigned per organisation, so the
  mapping now matches a fragment of the article *name* (`notfalltreffpunkt` → sign 158) plus the
  article group (`Transport/Logistik`, `Sanitätsmaterial`). Everything else keeps a neutral
  placeholder rather than borrowing a red damage/hazard sign that would be factually wrong on a
  resource marker. Consequence worth knowing: articles that merely belong to an NTP set
  (`Faltsignal NTP`, `Blitzwarnlampe NTP`) get the placeholder; there is a test asserting this.
- **CSV decoding tries UTF-8 before windows-1252.** The export is windows-1252, but UTF-8 umlaut
  bytes are valid windows-1252 characters, so a hand-filled template or a spreadsheet re-save was
  silently imported as mojibake ("Ausrüstung"). Strict UTF-8 first is decisive because a real
  export's single-byte umlauts are not valid UTF-8. Both encodings are covered by tests.
- **`.gitignore` gained one exemption.** The repo-wide `*.csv` rule (meant for data dumps) would
  have swallowed the downloadable template, leaving the download link 404ing. Exempted the same
  way the CSV test fixtures already are.
- **The parser handles the export's quirks**: metadata rows above the header, `;` separators,
  doubled-quote escaping, and bare `\n` inside quoted `Kommentar` cells while rows otherwise end
  in `\r\n`.

## Testing

- 86 unit tests across 6 spec files: CSV parsing (including the encoding cases and the embedded
  newline regression), aggregation, import diffing, the assignment index and availability
  computation, the marker-side resource picker, and the signature mapping. The specs parse and
  aggregate the shipped example template itself, so it cannot drift out of sync with the parser.
- 5 Playwright cases covering import → catalogue → filtering → placement → "Im Einsatz".
- Manually verified against a running instance: import, placement, assigning and taking back
  resources on a marker, the grouped "Im Einsatz" view, and the template download.

Known, pre-existing on `dev` and not introduced here: `npm test` collects the Playwright specs
into vitest and `changeset.service.spec.ts` fails with "window is not defined" — on `dev` that
means zero tests actually run. This branch adds `tests/resource.spec.ts` to that collection
problem. Happy to add the Playwright directory to `testPathIgnorePatterns` in this PR if you want
`npm test` green.

Not covered by e2e yet: assigning resources from the marker panel, the grouped deployed view, and
the template download. Can follow.

